### PR TITLE
copy: reframe landing tagline to be inclusive of consultants and ESG teams

### DIFF
--- a/components/AuthScreen.tsx
+++ b/components/AuthScreen.tsx
@@ -50,11 +50,10 @@ const AuthScreen: React.FC = () => {
         </div>
         <div className="my-12">
           <h1 className="text-3xl lg:text-5xl font-serif font-bold mb-6 leading-tight">
-            Sustainability reporting,<br />without the consultant fees.
+            Sustainability reporting,<br />powered by your expertise.
           </h1>
           <p className="text-lg opacity-90 max-w-lg">
-            AI-assisted ESRS &amp; CSRD compliance for SMEs. Build your sustainability
-            statement from your business model — no ESG team required.
+            AI-assisted ESRS &amp; CSRD compliance for SMEs. Built for consultants and ESG teams to deliver structured sustainability statements — faster, and grounded in the business model.
           </p>
         </div>
         <div className="text-sm opacity-70">


### PR DESCRIPTION
## What changed

Updated the hero copy on the `AuthScreen` login/signup panel.

**Before:**
> Sustainability reporting, without the consultant fees.
> AI-assisted ESRS & CSRD compliance for SMEs. Build your sustainability statement from your business model — no ESG team required.

**After:**
> Sustainability reporting, powered by your expertise.
> AI-assisted ESRS & CSRD compliance for SMEs. Built for consultants and ESG teams to deliver structured sustainability statements — faster, and grounded in the business model.

## Why

The original copy framed the tool as a replacement for consultants and ESG professionals ("no consultant fees", "no ESG team required"). In practice, these are exactly the people most likely to use the product. The new copy positions Aeternum Ally as a productivity multiplier for experts rather than a substitute for them.

## Files changed

- `components/AuthScreen.tsx` — headline and sub-copy only; no logic changes