### PR TITLE
feat: Team management overhaul — invitations, deactivate, resend & branded emails

### DIFF
--- a/components/AuthScreen.tsx
+++ b/components/AuthScreen.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from "react";
-import { Layout, Mail, Lock, Loader2, AlertCircle, Info } from "lucide-react";
+import { Layout, Mail, Lock, Loader2, AlertCircle, Info, Send } from "lucide-react";
 import { useAuth } from "../hooks/useAuth";
 
 const AuthScreen: React.FC = () => {
@@ -12,6 +12,12 @@ const AuthScreen: React.FC = () => {
   const [error, setError] = useState<string | null>(null);
   const [info, setInfo] = useState<string | null>(null);
 
+  // Expired invite link state
+  const [showResendForm, setShowResendForm] = useState(false);
+  const [resendEmail, setResendEmail] = useState("");
+  const [resendLoading, setResendLoading] = useState(false);
+  const [resendDone, setResendDone] = useState(false);
+
   // Detect Supabase OTP errors returned as URL hash fragments
   // e.g. #error=access_denied&error_code=otp_expired
   useEffect(() => {
@@ -20,14 +26,24 @@ const AuthScreen: React.FC = () => {
     const params = new URLSearchParams(hash.slice(1));
     const errorCode = params.get("error_code");
     if (errorCode === "otp_expired" || errorCode === "otp_disabled") {
-      setInfo(
-        "Your invitation link has expired. Sign in below, then paste the invite token " +
-        "(the UUID from your invitation email) to join your team."
-      );
-      // Clean up the hash so it doesn't persist on refresh
+      setShowResendForm(true);
       window.history.replaceState({}, "", window.location.pathname + window.location.search);
     }
   }, []);
+
+  const handleResendRequest = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setResendLoading(true);
+    try {
+      await fetch("/.netlify/functions/invite", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ action: "request_resend", email: resendEmail.trim() }),
+      });
+    } catch {}
+    setResendLoading(false);
+    setResendDone(true);
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -91,6 +107,45 @@ const AuthScreen: React.FC = () => {
                 : "Start managing your ESG reporting today."}
             </p>
           </div>
+
+          {/* Expired invite link — self-service resend */}
+          {showResendForm && (
+            <div className="mb-6 p-4 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl text-sm text-amber-800 dark:text-amber-200">
+              <div className="flex items-start gap-2 mb-3">
+                <Info className="w-4 h-4 flex-shrink-0 mt-0.5 text-amber-500" />
+                <p className="font-semibold">Your invite link has expired.</p>
+              </div>
+              {resendDone ? (
+                <p className="text-emerald-700 dark:text-emerald-300 font-medium">
+                  ✓ If a pending invitation exists for that email, a new link has been sent. Check your inbox.
+                </p>
+              ) : (
+                <>
+                  <p className="mb-3 text-amber-700 dark:text-amber-300">
+                    Enter your email below to receive a fresh invite link.
+                  </p>
+                  <form onSubmit={handleResendRequest} className="flex gap-2">
+                    <input
+                      type="email"
+                      required
+                      value={resendEmail}
+                      onChange={(e) => setResendEmail(e.target.value)}
+                      placeholder="you@company.com"
+                      className="flex-1 px-3 py-2 rounded-lg border border-amber-300 dark:border-amber-700 bg-white dark:bg-slate-900 text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-amber-400"
+                    />
+                    <button
+                      type="submit"
+                      disabled={resendLoading}
+                      className="flex items-center gap-1.5 px-3 py-2 bg-amber-500 hover:bg-amber-600 text-white text-sm font-medium rounded-lg transition-colors disabled:opacity-50"
+                    >
+                      {resendLoading ? <Loader2 className="w-3.5 h-3.5 animate-spin" /> : <Send className="w-3.5 h-3.5" />}
+                      Send
+                    </button>
+                  </form>
+                </>
+              )}
+            </div>
+          )}
 
           {error && (
             <div className="mb-4 flex items-start gap-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-700 dark:text-red-300">

--- a/components/CompanyProfileForm.tsx
+++ b/components/CompanyProfileForm.tsx
@@ -284,8 +284,11 @@ const TeamPanel: React.FC<TeamPanelProps> = ({
   };
 
   const [resendingId, setResendingId] = useState<string | null>(null);
+  const [fallbackLink, setFallbackLink] = useState<{ inviteId: string; link: string } | null>(null);
+
   const handleResendInvite = async (inviteId: string, email: string) => {
     setResendingId(inviteId);
+    setFallbackLink(null);
     try {
       const sessionResp = await supabase.auth.getSession();
       const accessToken = sessionResp.data.session?.access_token;
@@ -298,7 +301,13 @@ const TeamPanel: React.FC<TeamPanelProps> = ({
       });
       const body = await resp.json().catch(() => ({}));
       if (!resp.ok) throw new Error(body.error ?? 'Failed to resend invitation.');
-      alert(`Invitation resent to ${email}. The new link is valid for 24 hours.`);
+
+      if (body.fallback_link) {
+        // Email delivery unavailable for existing users — surface the link directly
+        setFallbackLink({ inviteId, link: body.fallback_link });
+      } else {
+        alert(`Invitation resent to ${email}. The new link is valid for 1 hour.`);
+      }
     } catch (err: any) {
       alert(err?.message ?? 'Failed to resend invitation.');
     } finally {
@@ -464,6 +473,30 @@ const TeamPanel: React.FC<TeamPanelProps> = ({
                 })}
               </tbody>
             </table>
+          </div>
+        </div>
+      )}
+
+      {/* Fallback link banner (shown when Supabase can't email an existing user) */}
+      {fallbackLink && (
+        <div className="p-4 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl text-sm">
+          <p className="font-semibold text-amber-800 dark:text-amber-200 mb-1">
+            Email delivery unavailable — share this link directly:
+          </p>
+          <p className="text-amber-700 dark:text-amber-300 text-xs mb-2">
+            Copy and send this link to the invitee. It expires in 1 hour.
+          </p>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 text-xs font-mono bg-white dark:bg-slate-950 p-2 rounded border border-amber-200 dark:border-amber-700 text-slate-700 dark:text-slate-300 break-all">
+              {fallbackLink.link}
+            </code>
+            <button
+              onClick={() => { navigator.clipboard.writeText(fallbackLink.link); copyToken(fallbackLink.link); }}
+              className="p-2 hover:bg-amber-100 dark:hover:bg-amber-900/40 rounded text-amber-700 dark:text-amber-300"
+              title="Copy link"
+            >
+              {copied ? <CheckCircle2 className="w-4 h-4" /> : <Copy className="w-4 h-4" />}
+            </button>
           </div>
         </div>
       )}

--- a/netlify/functions/invite.ts
+++ b/netlify/functions/invite.ts
@@ -10,6 +10,46 @@ const json = (statusCode: number, body: unknown) => ({
   body: JSON.stringify(body),
 });
 
+/**
+ * Send (or resend) an invite email for an existing invite record.
+ * - New users  → inviteUserByEmail creates their account + sends the email.
+ * - Existing users → inviteUserByEmail may throw; fall back to generateLink
+ *   (magic-link type) which works for any user and returns a direct URL we
+ *   surface to the admin as a copy-able fallback link.
+ * Returns { link } when email delivery is uncertain so the caller can display it.
+ */
+async function sendInviteEmail(
+  admin: any,
+  email: string,
+  inviteToken: string
+): Promise<{ link: string | null }> {
+  const redirectTo = `${appUrl}?invite_token=${inviteToken}`;
+
+  // First attempt: works for new users and usually for existing ones too.
+  try {
+    await admin.auth.admin.inviteUserByEmail(email, { redirectTo });
+    return { link: null }; // email sent via Supabase template
+  } catch (e) {
+    console.warn("inviteUserByEmail failed, falling back to generateLink:", e);
+  }
+
+  // Fallback: generate a magic-link for existing users.
+  try {
+    const { data, error } = await admin.auth.admin.generateLink({
+      type: "magiclink",
+      email,
+      options: { redirectTo },
+    });
+    if (error) throw error;
+    // generateLink does NOT send an email itself — return the link so the admin
+    // can copy-paste it and share directly with the invitee.
+    return { link: (data as any)?.properties?.action_link ?? null };
+  } catch (e) {
+    console.warn("generateLink also failed:", e);
+    return { link: null };
+  }
+}
+
 const handler = async (event: any) => {
   if (event.httpMethod !== "POST") {
     return { statusCode: 405, body: "Method Not Allowed" };
@@ -22,20 +62,7 @@ const handler = async (event: any) => {
     });
   }
 
-  const authHeader = event.headers.authorization || event.headers.Authorization;
-  if (!authHeader || !authHeader.startsWith("Bearer ")) {
-    return json(401, { error: "You must be signed in to invite team members." });
-  }
-  const accessToken = authHeader.slice("Bearer ".length);
-
   const admin = createClient(supabaseUrl, serviceKey);
-
-  // Verify the inviter
-  const { data: userResp, error: userErr } = await admin.auth.getUser(accessToken);
-  if (userErr || !userResp?.user) {
-    return json(401, { error: "Your session has expired. Please sign in again." });
-  }
-  const inviter = userResp.user;
 
   let body: any;
   try {
@@ -44,7 +71,51 @@ const handler = async (event: any) => {
     return json(400, { error: "Invalid request body." });
   }
 
-  const { email, role, organization_id, action, invite_id } = body || {};
+  const { action, email, role, organization_id, invite_id } = body || {};
+
+  // ── REQUEST_RESEND (unauthenticated) ──────────────────────────────────────
+  // Called from the sign-in page when a user's invite link has expired.
+  // Looks up any pending invite for the email and fires a fresh link.
+  // Always returns 200 (no email enumeration).
+  if (action === "request_resend") {
+    if (!email) return json(400, { error: "Missing email." });
+
+    const { data: invite } = await admin
+      .from("organization_invites")
+      .select("id, email")
+      .eq("email", email.trim().toLowerCase())
+      .gt("expires_at", new Date().toISOString())
+      .order("created_at", { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (invite) {
+      const { link } = await sendInviteEmail(admin, invite.email, invite.id);
+      // link is non-null only when email delivery isn't available — we don't
+      // surface it here because the user is unauthenticated.
+      void link;
+    }
+
+    // Always return the same message to prevent email enumeration.
+    return json(200, {
+      success: true,
+      message: "If a pending invitation exists for this email, a new link has been sent. Check your inbox.",
+    });
+  }
+
+  // All other actions require authentication.
+  const authHeader = event.headers.authorization || event.headers.Authorization;
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return json(401, { error: "You must be signed in to invite team members." });
+  }
+  const accessToken = authHeader.slice("Bearer ".length);
+
+  const { data: userResp, error: userErr } = await admin.auth.getUser(accessToken);
+  if (userErr || !userResp?.user) {
+    return json(401, { error: "Your session has expired. Please sign in again." });
+  }
+  const inviter = userResp.user;
+
   if (!email || !organization_id) {
     return json(400, { error: "Missing required fields: email, organization_id." });
   }
@@ -61,7 +132,7 @@ const handler = async (event: any) => {
     return json(403, { error: "Only Owners and Admins can invite team members." });
   }
 
-  // ── RESEND: re-fire the email for an existing invite record ──────────────
+  // ── RESEND (authenticated, Owner/Admin only) ──────────────────────────────
   if (action === "resend") {
     if (!invite_id) return json(400, { error: "Missing invite_id for resend." });
 
@@ -72,19 +143,17 @@ const handler = async (event: any) => {
       .eq("organization_id", organization_id)
       .maybeSingle();
 
-    if (!existingInvite) {
-      return json(404, { error: "Invitation not found." });
-    }
+    if (!existingInvite) return json(404, { error: "Invitation not found." });
 
-    try {
-      await admin.auth.admin.inviteUserByEmail(existingInvite.email, {
-        redirectTo: `${appUrl}?invite_token=${existingInvite.id}`,
-      });
-    } catch (e) {
-      console.warn("inviteUserByEmail (resend) failed:", e);
-    }
+    const { link } = await sendInviteEmail(admin, existingInvite.email, existingInvite.id);
 
-    return json(200, { success: true, invite_token: existingInvite.id });
+    return json(200, {
+      success: true,
+      invite_token: existingInvite.id,
+      // link is non-null only when Supabase couldn't send the email itself
+      // (existing-user fallback). Show it in the UI so the admin can copy it.
+      fallback_link: link,
+    });
   }
 
   // ── NEW INVITE ────────────────────────────────────────────────────────────
@@ -93,7 +162,6 @@ const handler = async (event: any) => {
     return json(400, { error: "Invalid role. Must be Admin, Manager, or Consultant." });
   }
 
-  // Block re-invites if the email already belongs to a member of this org
   const { data: existingMember } = await admin
     .from("organization_members")
     .select("id")
@@ -104,7 +172,6 @@ const handler = async (event: any) => {
     return json(409, { error: "This person is already a member of your team." });
   }
 
-  // Block duplicate pending invites
   const { data: existingInvite } = await admin
     .from("organization_invites")
     .select("id")
@@ -115,7 +182,6 @@ const handler = async (event: any) => {
     return json(409, { error: "An invitation has already been sent to this email. Use Resend to send a new link." });
   }
 
-  // Insert invite row (its UUID is the token)
   const { data: invite, error: insertErr } = await admin
     .from("organization_invites")
     .insert({ organization_id, email, role, invited_by: inviter.id })
@@ -125,20 +191,13 @@ const handler = async (event: any) => {
     return json(500, { error: insertErr?.message ?? "Failed to create invitation." });
   }
 
-  // Send the email via Supabase Auth admin API.
-  try {
-    await admin.auth.admin.inviteUserByEmail(email, {
-      redirectTo: `${appUrl}?invite_token=${invite.id}`,
-    });
-  } catch (e) {
-    // Don't fail — admin can copy the token manually.
-    console.warn("inviteUserByEmail failed:", e);
-  }
+  const { link } = await sendInviteEmail(admin, email, invite.id);
 
   return json(200, {
     success: true,
     invite_token: invite.id,
     expires_at: invite.expires_at,
+    fallback_link: link,
   });
 };
 

--- a/netlify/functions/invite.ts
+++ b/netlify/functions/invite.ts
@@ -21,13 +21,15 @@ const json = (statusCode: number, body: unknown) => ({
 async function sendInviteEmail(
   admin: any,
   email: string,
-  inviteToken: string
+  inviteToken: string,
+  companyName: string
 ): Promise<{ link: string | null }> {
   const redirectTo = `${appUrl}?invite_token=${inviteToken}`;
+  const data = { company_name: companyName, app_name: "Aeternum Ally" };
 
   // First attempt: works for new users and usually for existing ones too.
   try {
-    await admin.auth.admin.inviteUserByEmail(email, { redirectTo });
+    await admin.auth.admin.inviteUserByEmail(email, { redirectTo, data });
     return { link: null }; // email sent via Supabase template
   } catch (e) {
     console.warn("inviteUserByEmail failed, falling back to generateLink:", e);
@@ -35,15 +37,15 @@ async function sendInviteEmail(
 
   // Fallback: generate a magic-link for existing users.
   try {
-    const { data, error } = await admin.auth.admin.generateLink({
+    const { data: linkData, error } = await admin.auth.admin.generateLink({
       type: "magiclink",
       email,
-      options: { redirectTo },
+      options: { redirectTo, data },
     });
     if (error) throw error;
     // generateLink does NOT send an email itself — return the link so the admin
     // can copy-paste it and share directly with the invitee.
-    return { link: (data as any)?.properties?.action_link ?? null };
+    return { link: linkData?.properties?.action_link ?? null };
   } catch (e) {
     console.warn("generateLink also failed:", e);
     return { link: null };
@@ -82,7 +84,7 @@ const handler = async (event: any) => {
 
     const { data: invite } = await admin
       .from("organization_invites")
-      .select("id, email")
+      .select("id, email, organization_id")
       .eq("email", email.trim().toLowerCase())
       .gt("expires_at", new Date().toISOString())
       .order("created_at", { ascending: false })
@@ -90,9 +92,13 @@ const handler = async (event: any) => {
       .maybeSingle();
 
     if (invite) {
-      const { link } = await sendInviteEmail(admin, invite.email, invite.id);
-      // link is non-null only when email delivery isn't available — we don't
-      // surface it here because the user is unauthenticated.
+      const { data: profile } = await admin
+        .from("company_profiles")
+        .select("name")
+        .eq("organization_id", invite.organization_id)
+        .maybeSingle();
+      const companyName = profile?.name ?? "your team";
+      const { link } = await sendInviteEmail(admin, invite.email, invite.id, companyName);
       void link;
     }
 
@@ -145,7 +151,14 @@ const handler = async (event: any) => {
 
     if (!existingInvite) return json(404, { error: "Invitation not found." });
 
-    const { link } = await sendInviteEmail(admin, existingInvite.email, existingInvite.id);
+    const { data: profile } = await admin
+      .from("company_profiles")
+      .select("name")
+      .eq("organization_id", organization_id)
+      .maybeSingle();
+    const companyName = profile?.name ?? "your team";
+
+    const { link } = await sendInviteEmail(admin, existingInvite.email, existingInvite.id, companyName);
 
     return json(200, {
       success: true,
@@ -191,7 +204,14 @@ const handler = async (event: any) => {
     return json(500, { error: insertErr?.message ?? "Failed to create invitation." });
   }
 
-  const { link } = await sendInviteEmail(admin, email, invite.id);
+  const { data: profile } = await admin
+    .from("company_profiles")
+    .select("name")
+    .eq("organization_id", organization_id)
+    .maybeSingle();
+  const companyName = profile?.name ?? "your team";
+
+  const { link } = await sendInviteEmail(admin, email, invite.id, companyName);
 
   return json(200, {
     success: true,


### PR DESCRIPTION
## Summary

A full overhaul of the Team tab and invitation flow covering UX, reliability, and branding.

### Team Tab (Company Profile → Team)
- **Pending invitations list** — shows all sent-but-unaccepted invites with email, role, and expiry. Expired rows are dimmed with a red label.
- **Resend** — Owner can resend a fresh email link for any pending invite without cancelling/recreating it. Blocks duplicate invites with a clear error directing to Resend.
- **Deactivate access** — renamed from "Remove", restricted to Owner only. Admins can still invite and change roles.
- **Cancel invitation** — Owner can delete a pending invite before it's accepted.
- **Fallback link** — if Supabase can't email an existing user, a copy-able direct link is shown in the panel.

### Invite email reliability
- `inviteUserByEmail` silently fails for users already in Supabase Auth. New `sendInviteEmail` helper tries it first, then falls back to `generateLink` (works for all users).

### Expired link UX (AuthScreen)
- Replaces confusing "paste your UUID" message with a self-service email form.
- User enters their email → backend finds their pending invite → sends a fresh link.
- Always returns a generic success message to prevent email enumeration.

### Branded invite email
- Company name fetched from `company_profiles` and passed as `data` to Supabase's invite API.
- Template can now use `{{ .Data.company_name }}` and `{{ .Data.app_name }}`.

## Supabase dashboard action required

Update the invite email template at **Authentication → Email Templates → Invite User**:

```html
<h2>You've been invited to join {{ .Data.company_name }} on Aeternum Ally</h2>
<p><strong>{{ .Data.company_name }}</strong> has invited you to join their workspace on <strong>Aeternum Ally</strong> — an AI-assisted sustainability reporting platform for ESRS & CSRD compliance.</p>
<p style="text-align:center;margin:24px 0;">
  <a href="{{ .ConfirmationURL }}" style="background:#2d7d5a;color:#fff;padding:12px 28px;border-radius:8px;text-decoration:none;font-weight:bold;display:inline-block;">Accept Invitation</a>
</p>
<p style="font-size:12px;color:#666;">This link expires in 1 hour. If you weren't expecting this, you can safely ignore this email.</p>
```

## Test plan

- [ ] Send invitation → verify branded email arrives with correct company name
- [ ] Click **Resend** → verify new email sent; if user already exists, fallback link shown in panel
- [ ] Click expired invite link → amber banner with email input appears on sign-in page
- [ ] Submit email in expired-link form → "check your inbox" confirmation shown
- [ ] Owner: Cancel pending invite → row removed from table
- [ ] Owner: Deactivate active member → member loses access immediately
- [ ] Admin: confirm Deactivate/Cancel/Resend buttons are not visible
- [ ] Invite already-invited email → "use Resend" error shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)