### PR TITLE
fix: auto-join workspace on invite + fix resend email for existing users

### DIFF
--- a/components/OrgSetupScreen.tsx
+++ b/components/OrgSetupScreen.tsx
@@ -9,47 +9,112 @@ interface Props {
 }
 
 const OrgSetupScreen: React.FC<Props> = ({ userEmail, onComplete, onSignOut }) => {
-  const [mode, setMode] = useState<"choice" | "create" | "join">("choice");
+  const [mode, setMode] = useState<"checking" | "choice" | "create" | "join">("checking");
   const [companyName, setCompanyName] = useState("");
   const [inviteToken, setInviteToken] = useState("");
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [joiningCompany, setJoiningCompany] = useState<string | null>(null);
 
-  // Auto-detect invite token in URL (?invite_token=...)
-  // Also detect Supabase OTP expiry errors in the URL hash (#error_code=otp_expired)
+  // On mount:
+  // 1. Check URL for an explicit invite_token (token-based invite link)
+  // 2. Otherwise, look up any pending invite for this email and auto-join
+  // 3. Check for expired OTP error in URL hash
   useEffect(() => {
-    const params = new URLSearchParams(window.location.search);
-    const token = params.get("invite_token");
-    if (token) {
-      setInviteToken(token);
-      setMode("join");
-    }
-
-    const hash = window.location.hash;
-    if (hash) {
-      const hashParams = new URLSearchParams(hash.slice(1));
-      const errorCode = hashParams.get("error_code");
-      if (errorCode === "otp_expired" || errorCode === "otp_disabled") {
-        setError(
-          "Your invitation link has expired. Paste the invite token (the UUID from your invitation email) below to join your team."
-        );
-        setMode("join");
-        window.history.replaceState({}, "", window.location.pathname + window.location.search);
+    const run = async () => {
+      // Handle Supabase OTP expiry error in hash
+      const hash = window.location.hash;
+      if (hash) {
+        const hashParams = new URLSearchParams(hash.slice(1));
+        const errorCode = hashParams.get("error_code");
+        if (errorCode === "otp_expired" || errorCode === "otp_disabled") {
+          window.history.replaceState({}, "", window.location.pathname + window.location.search);
+          setError("Your invitation link has expired. You can still join by entering your invite token below.");
+          setMode("join");
+          return;
+        }
       }
-    }
+
+      // Check for explicit token in URL
+      const params = new URLSearchParams(window.location.search);
+      const urlToken = params.get("invite_token");
+      if (urlToken) {
+        await autoAccept(urlToken);
+        return;
+      }
+
+      // Auto-lookup: find a pending invite matching this email
+      const { data: invite } = await supabase
+        .from("organization_invites")
+        .select("id, organization_id")
+        .eq("email", userEmail.toLowerCase())
+        .gt("expires_at", new Date().toISOString())
+        .order("created_at", { ascending: false })
+        .limit(1)
+        .maybeSingle();
+
+      if (invite) {
+        // Fetch company name for the friendly "Joining X..." message
+        const { data: profile } = await supabase
+          .from("company_profiles")
+          .select("name")
+          .eq("organization_id", invite.organization_id)
+          .maybeSingle();
+        setJoiningCompany(profile?.name ?? "your team");
+        await autoAccept(invite.id);
+        return;
+      }
+
+      // No invite found — show the normal choice screen
+      setMode("choice");
+    };
+
+    run();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
+
+  const autoAccept = async (token: string) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const sessionResp = await supabase.auth.getSession();
+      const accessToken = sessionResp.data.session?.access_token;
+      if (!accessToken) throw new Error("Not signed in.");
+
+      const response = await fetch("/.netlify/functions/accept-invite", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ invite_token: token }),
+      });
+
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(body.error ?? "Could not accept invite.");
+      }
+
+      // Clean URL
+      const url = new URL(window.location.href);
+      url.searchParams.delete("invite_token");
+      window.history.replaceState({}, "", url.toString());
+
+      onComplete();
+    } catch (e: any) {
+      setError(e?.message ?? "Failed to accept invitation.");
+      setMode("join");
+    } finally {
+      setIsLoading(false);
+    }
+  };
 
   const handleCreateOrg = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!companyName.trim()) {
-      setError("Please enter your company name.");
-      return;
-    }
+    if (!companyName.trim()) { setError("Please enter your company name."); return; }
     setIsLoading(true);
     setError(null);
-
     try {
-      // Atomic create-org-with-owner via SQL function (bypasses RLS chicken-and-egg).
       const { error: rpcErr } = await supabase.rpc("create_organization_with_owner", {
         p_company_name: companyName.trim(),
       });
@@ -64,49 +129,29 @@ const OrgSetupScreen: React.FC<Props> = ({ userEmail, onComplete, onSignOut }) =
 
   const handleJoinOrg = async (e: React.FormEvent) => {
     e.preventDefault();
-    if (!inviteToken.trim()) {
-      setError("Please enter your invite token.");
-      return;
-    }
-    setIsLoading(true);
-    setError(null);
-
-    try {
-      const sessionResp = await supabase.auth.getSession();
-      const accessToken = sessionResp.data.session?.access_token;
-      if (!accessToken) throw new Error("Not signed in.");
-
-      const response = await fetch("/.netlify/functions/accept-invite", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${accessToken}`,
-        },
-        body: JSON.stringify({ invite_token: inviteToken.trim() }),
-      });
-
-      if (!response.ok) {
-        const body = await response.json().catch(() => ({}));
-        throw new Error(body.error ?? "Could not accept invite. The token may be invalid or expired.");
-      }
-
-      // Strip the token from the URL so refresh doesn't re-trigger
-      const url = new URL(window.location.href);
-      url.searchParams.delete("invite_token");
-      window.history.replaceState({}, "", url.toString());
-
-      onComplete();
-    } catch (e: any) {
-      setError(e?.message ?? "Failed to accept invitation.");
-    } finally {
-      setIsLoading(false);
-    }
+    if (!inviteToken.trim()) { setError("Please enter your invite token."); return; }
+    await autoAccept(inviteToken.trim());
   };
 
+  // ── Auto-joining splash ─────────────────────────────────────────────────────
+  if (mode === "checking" || (isLoading && joiningCompany)) {
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-900 dark:to-slate-950 flex items-center justify-center p-6">
+        <div className="text-center">
+          <Loader2 className="w-10 h-10 animate-spin text-esg-500 mx-auto mb-4" />
+          <p className="text-lg font-semibold text-slate-700 dark:text-slate-200">
+            {joiningCompany ? `Joining ${joiningCompany}…` : "Checking your invitation…"}
+          </p>
+          <p className="text-sm text-slate-400 mt-1">This will only take a moment.</p>
+        </div>
+      </div>
+    );
+  }
+
+  // ── Normal setup screen ─────────────────────────────────────────────────────
   return (
     <div className="min-h-screen bg-gradient-to-br from-slate-50 to-slate-100 dark:from-slate-900 dark:to-slate-950 flex items-center justify-center p-6">
       <div className="w-full max-w-2xl">
-        {/* Header */}
         <div className="text-center mb-8">
           <div className="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-esg-100 dark:bg-esg-900/30 text-esg-700 dark:text-esg-300 text-xs font-bold uppercase tracking-wider mb-4">
             <CheckCircle2 className="w-3 h-3" /> Signed in as {userEmail}
@@ -117,7 +162,7 @@ const OrgSetupScreen: React.FC<Props> = ({ userEmail, onComplete, onSignOut }) =
           <p className="text-slate-500 dark:text-slate-400">
             {mode === "choice" && "Set up your company workspace or join an existing team."}
             {mode === "create" && "Tell us about your company."}
-            {mode === "join" && "Paste the invite token your team admin shared with you."}
+            {mode === "join"   && "Enter your invite token to join your team's workspace."}
           </p>
         </div>
 
@@ -132,11 +177,8 @@ const OrgSetupScreen: React.FC<Props> = ({ userEmail, onComplete, onSignOut }) =
           {mode === "choice" && (
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <button
-                onClick={() => {
-                  setMode("create");
-                  setError(null);
-                }}
-                className="p-6 text-left rounded-xl border-2 border-slate-200 dark:border-slate-700 hover:border-esg-500 hover:bg-esg-50 dark:hover:bg-esg-900/20 transition-all group"
+                onClick={() => { setMode("create"); setError(null); }}
+                className="p-6 text-left rounded-xl border-2 border-slate-200 dark:border-slate-700 hover:border-esg-500 hover:bg-esg-50 dark:hover:bg-esg-900/20 transition-all"
               >
                 <Building2 className="w-8 h-8 text-esg-600 mb-4" />
                 <h3 className="font-bold text-slate-800 dark:text-white mb-1">Create a new company</h3>
@@ -145,16 +187,13 @@ const OrgSetupScreen: React.FC<Props> = ({ userEmail, onComplete, onSignOut }) =
                 </p>
               </button>
               <button
-                onClick={() => {
-                  setMode("join");
-                  setError(null);
-                }}
-                className="p-6 text-left rounded-xl border-2 border-slate-200 dark:border-slate-700 hover:border-indigo-500 hover:bg-indigo-50 dark:hover:bg-indigo-900/20 transition-all group"
+                onClick={() => { setMode("join"); setError(null); }}
+                className="p-6 text-left rounded-xl border-2 border-slate-200 dark:border-slate-700 hover:border-indigo-500 hover:bg-indigo-50 dark:hover:bg-indigo-900/20 transition-all"
               >
                 <Users className="w-8 h-8 text-indigo-600 mb-4" />
                 <h3 className="font-bold text-slate-800 dark:text-white mb-1">Join with invite token</h3>
                 <p className="text-sm text-slate-500 dark:text-slate-400">
-                  Got an invite from a team admin? Paste the token here to join their workspace.
+                  Got an invite from a team admin? Enter the token to join their workspace.
                 </p>
               </button>
             </div>
@@ -174,23 +213,15 @@ const OrgSetupScreen: React.FC<Props> = ({ userEmail, onComplete, onSignOut }) =
                   className="w-full p-3 border border-slate-300 dark:border-slate-600 rounded-lg bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-white focus:ring-2 focus:ring-esg-500 focus:border-esg-500"
                   autoFocus
                 />
-                <p className="text-xs text-slate-500 mt-2">
-                  You can fill out the rest of your company profile later.
-                </p>
+                <p className="text-xs text-slate-500 mt-2">You can fill out the rest of your company profile later.</p>
               </div>
               <div className="flex gap-2 justify-end">
-                <button
-                  type="button"
-                  onClick={() => setMode("choice")}
-                  className="px-4 py-2 text-slate-600 dark:text-slate-300 font-medium hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg flex items-center gap-2"
-                >
+                <button type="button" onClick={() => setMode("choice")}
+                  className="px-4 py-2 text-slate-600 dark:text-slate-300 font-medium hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg flex items-center gap-2">
                   <ArrowLeft className="w-4 h-4" /> Back
                 </button>
-                <button
-                  type="submit"
-                  disabled={isLoading}
-                  className="px-6 py-2 bg-esg-600 text-white font-medium rounded-lg hover:bg-esg-700 shadow-lg shadow-esg-600/20 transition-all flex items-center gap-2 disabled:opacity-50"
-                >
+                <button type="submit" disabled={isLoading}
+                  className="px-6 py-2 bg-esg-600 text-white font-medium rounded-lg hover:bg-esg-700 shadow-lg shadow-esg-600/20 transition-all flex items-center gap-2 disabled:opacity-50">
                   {isLoading && <Loader2 className="w-4 h-4 animate-spin" />}
                   Create workspace
                 </button>
@@ -208,27 +239,21 @@ const OrgSetupScreen: React.FC<Props> = ({ userEmail, onComplete, onSignOut }) =
                   type="text"
                   value={inviteToken}
                   onChange={(e) => setInviteToken(e.target.value)}
-                  placeholder="paste the token from your invite email"
+                  placeholder="Paste the token from your invitation email"
                   className="w-full p-3 border border-slate-300 dark:border-slate-600 rounded-lg bg-slate-50 dark:bg-slate-950 text-slate-900 dark:text-white focus:ring-2 focus:ring-indigo-500 focus:border-indigo-500 font-mono text-sm"
                   autoFocus
                 />
                 <p className="text-xs text-slate-500 mt-2">
-                  The token is the long ID inside your invitation email link.
+                  The token is the UUID inside your invitation email link.
                 </p>
               </div>
               <div className="flex gap-2 justify-end">
-                <button
-                  type="button"
-                  onClick={() => setMode("choice")}
-                  className="px-4 py-2 text-slate-600 dark:text-slate-300 font-medium hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg flex items-center gap-2"
-                >
+                <button type="button" onClick={() => setMode("choice")}
+                  className="px-4 py-2 text-slate-600 dark:text-slate-300 font-medium hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg flex items-center gap-2">
                   <ArrowLeft className="w-4 h-4" /> Back
                 </button>
-                <button
-                  type="submit"
-                  disabled={isLoading}
-                  className="px-6 py-2 bg-indigo-600 text-white font-medium rounded-lg hover:bg-indigo-700 shadow-lg shadow-indigo-600/20 transition-all flex items-center gap-2 disabled:opacity-50"
-                >
+                <button type="submit" disabled={isLoading}
+                  className="px-6 py-2 bg-indigo-600 text-white font-medium rounded-lg hover:bg-indigo-700 shadow-lg shadow-indigo-600/20 transition-all flex items-center gap-2 disabled:opacity-50">
                   {isLoading && <Loader2 className="w-4 h-4 animate-spin" />}
                   Join workspace
                 </button>
@@ -238,10 +263,8 @@ const OrgSetupScreen: React.FC<Props> = ({ userEmail, onComplete, onSignOut }) =
         </div>
 
         <div className="text-center mt-6">
-          <button
-            onClick={onSignOut}
-            className="text-sm text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 hover:underline"
-          >
+          <button onClick={onSignOut}
+            className="text-sm text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 hover:underline">
             Sign out
           </button>
         </div>

--- a/netlify/functions/invite.ts
+++ b/netlify/functions/invite.ts
@@ -11,12 +11,21 @@ const json = (statusCode: number, body: unknown) => ({
 });
 
 /**
- * Send (or resend) an invite email for an existing invite record.
- * - New users  → inviteUserByEmail creates their account + sends the email.
- * - Existing users → inviteUserByEmail may throw; fall back to generateLink
- *   (magic-link type) which works for any user and returns a direct URL we
- *   surface to the admin as a copy-able fallback link.
- * Returns { link } when email delivery is uncertain so the caller can display it.
+ * Send (or resend) an invite email.
+ *
+ * Strategy:
+ * 1. inviteUserByEmail  — creates the Supabase Auth user (if new) AND sends the
+ *    branded invite email. Works perfectly for first-time invitees.
+ * 2. signInWithOtp      — for users already registered in Supabase Auth,
+ *    inviteUserByEmail throws "User already registered". signInWithOtp sends
+ *    a magic-link email to any existing user and honours the same redirectTo.
+ *    shouldCreateUser: false ensures we don't accidentally create duplicates.
+ *
+ * generateLink is intentionally NOT used as a fallback because it only returns
+ * a URL — it does not deliver any email.
+ *
+ * Returns { link: null } when an email was dispatched, or { link: string } as
+ * a last-resort copy-able URL if both email paths fail.
  */
 async function sendInviteEmail(
   admin: any,
@@ -27,29 +36,46 @@ async function sendInviteEmail(
   const redirectTo = `${appUrl}?invite_token=${inviteToken}`;
   const data = { company_name: companyName, app_name: "Aeternum Ally" };
 
-  // First attempt: works for new users and usually for existing ones too.
+  // Path 1: new users — creates account + sends invite email via Supabase template.
   try {
-    await admin.auth.admin.inviteUserByEmail(email, { redirectTo, data });
-    return { link: null }; // email sent via Supabase template
-  } catch (e) {
-    console.warn("inviteUserByEmail failed, falling back to generateLink:", e);
+    const { error } = await admin.auth.admin.inviteUserByEmail(email, { redirectTo, data });
+    if (!error) return { link: null };
+    console.warn("inviteUserByEmail error:", error.message);
+  } catch (e: any) {
+    console.warn("inviteUserByEmail threw:", e?.message ?? e);
   }
 
-  // Fallback: generate a magic-link for existing users.
+  // Path 2: existing users — sends a magic-link email that redirects to our app.
+  // signInWithOtp actually delivers an email, unlike generateLink which only
+  // returns a URL.
+  try {
+    const { error } = await admin.auth.signInWithOtp({
+      email,
+      options: {
+        emailRedirectTo: redirectTo,
+        shouldCreateUser: false,
+      },
+    });
+    if (!error) return { link: null };
+    console.warn("signInWithOtp error:", error.message);
+  } catch (e: any) {
+    console.warn("signInWithOtp threw:", e?.message ?? e);
+  }
+
+  // Last resort: generate a link the admin can copy and share manually.
+  // This does NOT send an email.
   try {
     const { data: linkData, error } = await admin.auth.admin.generateLink({
       type: "magiclink",
       email,
-      options: { redirectTo, data },
+      options: { redirectTo },
     });
-    if (error) throw error;
-    // generateLink does NOT send an email itself — return the link so the admin
-    // can copy-paste it and share directly with the invitee.
-    return { link: linkData?.properties?.action_link ?? null };
-  } catch (e) {
-    console.warn("generateLink also failed:", e);
-    return { link: null };
+    if (!error) return { link: linkData?.properties?.action_link ?? null };
+  } catch (e: any) {
+    console.warn("generateLink threw:", e?.message ?? e);
   }
+
+  return { link: null };
 }
 
 const handler = async (event: any) => {


### PR DESCRIPTION
## Summary

Two fixes to the invitation flow that eliminated the need for users to manually paste a token.

### Auto-join on sign-in (`OrgSetupScreen`)

When a signed-in user has no organisation, the screen now:
1. Checks the URL for an explicit `?invite_token=` (direct link flow)
2. Falls back to querying `organization_invites` by the user's email — if a valid pending invite exists, it is accepted automatically
3. Shows a **"Joining [Company Name]…"** splash while the accept call runs
4. Only falls back to the manual token input if both above fail (e.g. expired invite)

This means invited users are joined to their team immediately after signing in — no token copy-paste required, regardless of whether the token survived Supabase's redirect.

### Resend email for existing users (`invite.ts`)

`generateLink` only returns a URL — it never delivers an email. For users already registered in Supabase Auth, `inviteUserByEmail` throws "User already registered".

New `sendInviteEmail` strategy:
| Step | Method | Sends email? |
|---|---|---|
| 1 | `inviteUserByEmail` | ✅ New users |
| 2 | `signInWithOtp` (shouldCreateUser: false) | ✅ Existing users |
| 3 | `generateLink` | ❌ Last-resort copy-able link only |

## Test plan

- [ ] Invite a **new** email → user clicks link → signs up → auto-joined to workspace with "Joining…" splash
- [ ] Invite an **existing** user → Resend clicked → email received in inbox
- [ ] Invited user signs in (without clicking link) → auto-detected by email → auto-joined
- [ ] Expired OTP link → amber banner shown → manual token input available as fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)