### PR TITLE
fix: auto-join on invitation — RLS policy + company name from server

### DIFF
--- a/components/OrgSetupScreen.tsx
+++ b/components/OrgSetupScreen.tsx
@@ -54,13 +54,8 @@ const OrgSetupScreen: React.FC<Props> = ({ userEmail, onComplete, onSignOut }) =
         .maybeSingle();
 
       if (invite) {
-        // Fetch company name for the friendly "Joining X..." message
-        const { data: profile } = await supabase
-          .from("company_profiles")
-          .select("name")
-          .eq("organization_id", invite.organization_id)
-          .maybeSingle();
-        setJoiningCompany(profile?.name ?? "your team");
+        // Company name is returned by accept-invite (service role can read it).
+        // Don't query company_profiles here — RLS blocks it for non-members.
         await autoAccept(invite.id);
         return;
       }

--- a/netlify/functions/accept-invite.ts
+++ b/netlify/functions/accept-invite.ts
@@ -66,6 +66,14 @@ const handler = async (event: any) => {
     });
   }
 
+  // Fetch company name for the welcome message (best-effort)
+  const { data: profile } = await admin
+    .from("company_profiles")
+    .select("name")
+    .eq("organization_id", invite.organization_id)
+    .maybeSingle();
+  const companyName: string = profile?.name || "";
+
   // Add to org
   const { error: memberErr } = await admin.from("organization_members").insert({
     organization_id: invite.organization_id,
@@ -78,7 +86,7 @@ const handler = async (event: any) => {
     if (memberErr.code === "23505") {
       // already a member — clean up the invite anyway
       await admin.from("organization_invites").delete().eq("id", invite_token);
-      return json(200, { success: true, organization_id: invite.organization_id });
+      return json(200, { success: true, organization_id: invite.organization_id, company_name: companyName });
     }
     return json(500, { error: memberErr.message });
   }
@@ -86,7 +94,7 @@ const handler = async (event: any) => {
   // Burn the invite
   await admin.from("organization_invites").delete().eq("id", invite_token);
 
-  return json(200, { success: true, organization_id: invite.organization_id });
+  return json(200, { success: true, organization_id: invite.organization_id, company_name: companyName });
 };
 
 export { handler };

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -223,6 +223,13 @@ CREATE POLICY "admins_manage_invites" ON organization_invites
     AND user_org_role(organization_id) IN ('Owner', 'Admin')
   );
 
+-- Invites: an authenticated user can read their OWN pending invite
+-- (needed for auto-join on sign-in before they are a member of any org)
+CREATE POLICY "invitee_read_own_invite" ON organization_invites
+  FOR SELECT USING (
+    lower(email) = lower((SELECT email FROM auth.users WHERE id = auth.uid()))
+  );
+
 -- Data tables: all members can read; Owner/Admin/Manager can write
 DO $$
 DECLARE tbl text;


### PR DESCRIPTION
## Summary

- **Root cause fixed**: Newly invited users (not yet org members) could not read their own `organization_invites` row — the old RLS policy only allowed existing members (Owner/Admin) to see invites. This caused the auto-lookup by email to silently return `null`, so auto-join never triggered.
- **New RLS policy** (`invitee_read_own_invite`): allows any authenticated user to SELECT rows from `organization_invites` where the `email` column matches their own auth email. Run the migration SQL below in Supabase Dashboard.
- **Company name via service role**: `accept-invite` function now fetches and returns `company_name` from `company_profiles` using the service-role client (bypasses RLS), so `OrgSetupScreen` no longer needs a blocked client-side query against `company_profiles`.
- **Robust token flow**: `OrgSetupScreen` uses the DB row `id` from the email lookup directly, so it no longer depends on the `?invite_token=` URL param surviving Supabase's magic-link redirect.

## Migration SQL — run in Supabase Dashboard → SQL Editor

```sql
CREATE POLICY "invitee_read_own_invite" ON organization_invites
  FOR SELECT USING (
    lower(email) = lower((SELECT email FROM auth.users WHERE id = auth.uid()))
  );
```

## Test plan

- [ ] Invite a brand-new email → user signs up via invite email → lands on app → automatically joined to org (no token entry needed)
- [ ] Invite an existing Supabase user → they receive magic-link email → sign in → auto-joined
- [ ] Invite link expires → user sees expired-link screen → requests resend → new email arrives → clicks → auto-joined
- [ ] User with no invite sees the "Create company / Join with token" choice screen
- [ ] Owner/Admin can still cancel invite and deactivate members from Team panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)