### PR TITLE
fix: pending invitations list + full invite flow reliability

### DIFF
--- a/components/CompanyProfileForm.tsx
+++ b/components/CompanyProfileForm.tsx
@@ -227,16 +227,29 @@ const TeamPanel: React.FC<TeamPanelProps> = ({
 
   const [pendingInvites, setPendingInvites] = useState<OrgInvite[]>([]);
   const [invitesLoading, setInvitesLoading] = useState(false);
+  const [invitesError, setInvitesError] = useState<string | null>(null);
 
   const fetchPendingInvites = useCallback(async () => {
     setInvitesLoading(true);
-    const { data } = await supabase
-      .from('organization_invites')
-      .select('*')
-      .eq('organization_id', organizationId)
-      .order('created_at', { ascending: false });
-    setPendingInvites((data ?? []) as OrgInvite[]);
-    setInvitesLoading(false);
+    setInvitesError(null);
+    try {
+      const sessionResp = await supabase.auth.getSession();
+      const accessToken = sessionResp.data.session?.access_token;
+      if (!accessToken) throw new Error('Not signed in.');
+
+      const resp = await fetch('/.netlify/functions/invite', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${accessToken}` },
+        body: JSON.stringify({ action: 'list', organization_id: organizationId }),
+      });
+      const body = await resp.json();
+      if (!resp.ok) throw new Error(body.error ?? 'Failed to load invitations.');
+      setPendingInvites((body.invites ?? []) as OrgInvite[]);
+    } catch (e: any) {
+      setInvitesError(e?.message ?? 'Failed to load invitations.');
+    } finally {
+      setInvitesLoading(false);
+    }
   }, [organizationId]);
 
   useEffect(() => { fetchPendingInvites(); }, [fetchPendingInvites]);
@@ -421,6 +434,12 @@ const TeamPanel: React.FC<TeamPanelProps> = ({
                   <tr>
                     <td colSpan={isOwner ? 4 : 3} className="p-6 text-center text-slate-400">
                       <Loader2 className="w-4 h-4 animate-spin inline-block mr-2" />Loading…
+                    </td>
+                  </tr>
+                ) : invitesError ? (
+                  <tr>
+                    <td colSpan={isOwner ? 4 : 3} className="p-6 text-center text-red-500 text-sm">
+                      <AlertCircle className="w-4 h-4 inline-block mr-1 mb-0.5" />{invitesError}
                     </td>
                   </tr>
                 ) : pendingInvites.length === 0 ? (

--- a/netlify/functions/invite.ts
+++ b/netlify/functions/invite.ts
@@ -148,8 +148,8 @@ const handler = async (event: any) => {
   }
   const inviter = userResp.user;
 
-  if (!email || !organization_id) {
-    return json(400, { error: "Missing required fields: email, organization_id." });
+  if (!organization_id) {
+    return json(400, { error: "Missing required field: organization_id." });
   }
 
   // Check inviter is Owner/Admin of the org
@@ -161,7 +161,19 @@ const handler = async (event: any) => {
     .maybeSingle();
 
   if (!membership || !["Owner", "Admin"].includes(membership.role)) {
-    return json(403, { error: "Only Owners and Admins can invite team members." });
+    return json(403, { error: "Only Owners and Admins can manage invitations." });
+  }
+
+  // ── LIST PENDING INVITES (authenticated, Owner/Admin only) ────────────────
+  if (action === "list") {
+    const { data: invites, error: listErr } = await admin
+      .from("organization_invites")
+      .select("id, email, role, expires_at, created_at, invited_by")
+      .eq("organization_id", organization_id)
+      .order("created_at", { ascending: false });
+
+    if (listErr) return json(500, { error: listErr.message });
+    return json(200, { invites: invites ?? [] });
   }
 
   // ── RESEND (authenticated, Owner/Admin only) ──────────────────────────────
@@ -196,6 +208,7 @@ const handler = async (event: any) => {
   }
 
   // ── NEW INVITE ────────────────────────────────────────────────────────────
+  if (!email) return json(400, { error: "Missing required field: email." });
   if (!role) return json(400, { error: "Missing required field: role." });
   if (!["Admin", "Manager", "Consultant"].includes(role)) {
     return json(400, { error: "Invalid role. Must be Admin, Manager, or Consultant." });


### PR DESCRIPTION
## Summary

- **Pending invites now load via server (service role)** — previously the client queried `organization_invites` directly, where Supabase RLS silently returned empty when the policy wasn't satisfied. Now uses `POST /invite` with `action: "list"`, which runs as service role and bypasses RLS entirely. Owner/Admin will always see their pending invites.
- **Error surfaced in UI** — if the invite list fails to load for any reason, a clear error message is shown in the table instead of the misleading "No pending invitations."
- **Auto-join on invitation** — after signing in, users are automatically matched to their pending invite by email and joined to the org without needing to paste a token. Requires the SQL migration below.
- **Email delivery for existing users** — `signInWithOtp` (not `generateLink`) is used as the fallback path so existing Supabase users actually receive an email.
- **Company name in invite emails** — org name is passed as template data so invite emails can reference the company.
- **Self-service expired link** — expired OTP links show a resend form on the sign-in page instead of a raw error.

## Migration SQL — run in Supabase Dashboard → SQL Editor

Required for auto-join to work for newly invited users:

```sql
CREATE POLICY "invitee_read_own_invite" ON organization_invites
  FOR SELECT USING (
    lower(email) = lower((SELECT email FROM auth.users WHERE id = auth.uid()))
  );
```

## Test plan

- [ ] Send invite → pending invite appears immediately in Team tab
- [ ] Cancel invite → row disappears from pending list
- [ ] Resend invite → invited user receives a new email
- [ ] Invited user signs up → auto-joined to org without pasting any token
- [ ] Expired invite link → user sees resend form, requests new link, receives email, auto-joined
- [ ] Non-invited user → sees "Create company / Join with token" choice screen

🤖 Generated with [Claude Code](https://claude.com/claude-code)