### PR TITLE
docs: add tech stack and deployment guides + repo cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ dist-ssr
 *.sln
 *.sw?
 .netlify/
+
+# Claude Code local settings
+.claude/

--- a/README.md
+++ b/README.md
@@ -73,17 +73,10 @@ Generates a report compliant with **ESRS 2 (General Disclosures)** and **Topical
 
 ---
 
-## 🛠 Tech Stack
-*   **Frontend:** React 19, TypeScript, Tailwind CSS
-*   **AI Engine:** Google Gemini 2.5 Flash (via `@google/genai` SDK)
-*   **Visualizations:** Recharts
-*   **Icons:** Lucide React
+## 📚 Documentation
 
-## 📦 Setup
-1.  Clone the repository.
-2.  Install dependencies: `npm install`
-3.  Set your API Key: `export API_KEY="your_gemini_api_key"`
-4.  Run the app: `npm start`
+*   **[Tech Stack](./docs/TECH_STACK.md)** — Architecture, frontend/backend stack, database schema, RLS, security model
+*   **[Deployment](./docs/DEPLOYMENT.md)** — Setup, environment variables, deploy flow, schema migrations, local development, troubleshooting
 
 ---
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,200 @@
+# Deployment Guide
+
+Step-by-step guide for deploying Aeternum Ally. See [`TECH_STACK.md`](./TECH_STACK.md) for architecture context.
+
+---
+
+## Hosting overview
+
+| Layer | Provider | What's there |
+|---|---|---|
+| Frontend (SPA) | **Netlify** | Static build output (`dist/`) on Netlify CDN |
+| Backend (API) | **Netlify Functions** | `netlify/functions/*.ts` deployed as serverless functions |
+| Database + Auth | **Supabase** | Postgres, Row-Level Security, Auth (magic link / invite emails) |
+| AI | **Google Gemini API** | Called server-side only, key never exposed to browser |
+
+**One Netlify site + one Supabase project per environment.** Production and test/demo are completely separate stacks (different URLs, different DBs, different env vars).
+
+---
+
+## Environments
+
+| Env | Frontend URL | Branch | Netlify site | Supabase project |
+|---|---|---|---|---|
+| Production | _(your prod domain)_ | `main` | Production site | Production project |
+| Demo / Test | `demo.aeternumally.com` | `main` (separate site) | Demo site | Test project (`tlyuhlyrkztypqdgixze`) |
+
+Branch / preview deploys inherit env vars from their parent site.
+
+---
+
+## Environment variables
+
+Set these in **Netlify Dashboard → Site settings → Environment variables** for each site.
+
+| Variable | Public? | Where used | Example |
+|---|---|---|---|
+| `VITE_SUPABASE_URL` | ✅ public (in browser bundle) | Frontend + Functions | `https://xxxxx.supabase.co` |
+| `VITE_SUPABASE_ANON_KEY` | ✅ public | Frontend | `eyJhbGc...` (RLS-protected) |
+| `VITE_APP_URL` | ✅ public | Frontend + Functions | `https://demo.aeternumally.com` |
+| `SUPABASE_SERVICE_ROLE_KEY` | 🔒 **server-only** | Functions only | `eyJhbGc...` (bypasses RLS) |
+| `GEMINI_API_KEY` | 🔒 **server-only** | Functions only | `AIza...` |
+
+> ⚠️ **Never** prefix server-only secrets with `VITE_` — Vite would inline them into the browser bundle.
+
+> ⚠️ `VITE_APP_URL` should be the **base URL only**, no trailing slash, no query params. Used as the redirect target for invite emails.
+
+---
+
+## First-time setup
+
+### 1. Supabase project
+
+1. Create project at [supabase.com](https://supabase.com).
+2. Open **SQL Editor** and run `supabase/schema.sql` in full.
+3. Run every file in `supabase/migrations/` in order:
+   - `001_create_organization_with_owner.sql`
+   - `002_ai_settings_and_usage.sql`
+4. **Auth → URL Configuration:**
+   - Site URL → `https://your-app-url`
+   - Redirect URLs → add `https://your-app-url` (base only is enough; auto-join is email-based)
+5. **Auth → Email Templates** *(optional but recommended):*
+   - Customise the **Invite** and **Magic Link** templates. Use `{{ .Data.company_name }}` and `{{ .Data.app_name }}` to reference custom data passed from `invite.ts`.
+6. **Auth → SMTP Settings** *(optional but recommended for production):*
+   - Configure a real SMTP provider (Resend / SendGrid / Mailgun).
+   - Without this, Supabase's built-in sender is heavily rate-limited and may silently drop emails.
+7. Copy these from **Project Settings → API**:
+   - Project URL → `VITE_SUPABASE_URL`
+   - `anon` public key → `VITE_SUPABASE_ANON_KEY`
+   - `service_role` key → `SUPABASE_SERVICE_ROLE_KEY`
+
+### 2. Google Gemini API key
+
+1. Get a key from [Google AI Studio](https://aistudio.google.com/apikey).
+2. Save it for `GEMINI_API_KEY` in Netlify.
+
+### 3. Netlify site
+
+1. **Add new site → Import from Git → select repo**.
+2. Build settings (auto-detected from `netlify.toml`):
+   - Build command: `npm run build`
+   - Publish directory: `dist`
+   - Functions directory: `netlify/functions`
+3. **Site settings → Environment variables**: add all 5 vars from the table above.
+4. **Site settings → Domain management**: add your custom domain (e.g. `demo.aeternumally.com`) and follow DNS instructions.
+5. Trigger a deploy (or push to `main`).
+
+### 4. Smoke test
+
+After the first deploy:
+
+- [ ] Visit the URL → see sign-in screen
+- [ ] Sign up with a fresh email → magic-link email arrives
+- [ ] Click link → land on "Set up your company" screen
+- [ ] Create a workspace → land in dashboard
+- [ ] Invite a teammate (different email) → email arrives
+- [ ] Click invite link → auto-joins to org without pasting token
+- [ ] Open Company Profile → Team tab → see member list and pending invites
+
+If any step fails, check **Netlify → Functions → logs** and the browser console.
+
+---
+
+## Ongoing deploys
+
+### Code changes
+
+```
+Push to GitHub  ──▶  Netlify auto-build  ──▶  Live in ~2 min
+```
+
+- `main` → production site
+- Other branches → preview URLs (each PR gets one)
+- Failed builds: check **Netlify → Deploys → [build] → Deploy log**
+
+### Schema changes
+
+Database migrations are **manual** — Netlify does not run SQL.
+
+For each PR that touches `supabase/schema.sql` or adds a `supabase/migrations/*.sql` file:
+
+1. Open the PR description / commit message — it should call out the new SQL.
+2. Open **Supabase Dashboard → SQL Editor** for the target environment.
+3. Paste and run the new SQL.
+4. Verify (e.g. `SELECT policyname FROM pg_policies WHERE tablename = '...'`).
+5. Repeat for **every** environment (production + test).
+
+> ⚠️ Run schema migrations **before** merging the code PR if the new code depends on the schema change. Otherwise the deploy will fail at runtime.
+
+### Env-var changes
+
+After updating env vars in Netlify, you must **redeploy** for them to take effect:
+**Deploys → Trigger deploy → Clear cache and deploy site**.
+
+---
+
+## Local development
+
+```bash
+cp .env.example .env
+# fill in: VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY, VITE_APP_URL=http://localhost:8888,
+#         SUPABASE_SERVICE_ROLE_KEY, GEMINI_API_KEY
+npm install
+npm run dev:netlify     # runs Vite + Netlify Functions on port 8888
+```
+
+`npm run dev` (Vite alone) **won't** expose `/.netlify/functions/*` — always use `dev:netlify` when developing API-touching code.
+
+To test the invite flow locally, the Supabase project's **Site URL / Redirect URLs** must include `http://localhost:8888`.
+
+---
+
+## Common issues
+
+### `403 Forbidden` on a Supabase REST call
+RLS policy is blocking the request. Check:
+- The right policies exist: `SELECT policyname FROM pg_policies WHERE tablename = '<table>';`
+- Helper functions are present: `\df is_org_member`
+- For invitee read: policy uses `auth.jwt() ->> 'email'`, **not** `(SELECT email FROM auth.users …)` — the `authenticated` role has no SELECT on `auth.users`.
+
+### Invite emails not arriving
+1. Check Supabase **Auth → Logs** for delivery errors.
+2. Confirm SMTP is configured (otherwise built-in sender rate-limits aggressively).
+3. For existing users, the function falls back to `signInWithOtp`. Make sure your `VITE_APP_URL` is in the Redirect URLs allow-list.
+4. As a last resort, the admin Team panel shows a copy-able fallback link when delivery fails — share it manually.
+
+### "One more step to get started" appears for invited users
+Auto-join failed. Cause is almost always:
+- The `invitee_read_own_invite` RLS policy is missing on this Supabase project, **or**
+- The policy uses the broken `auth.users` subquery form. Replace it with:
+  ```sql
+  DROP POLICY "invitee_read_own_invite" ON organization_invites;
+  CREATE POLICY "invitee_read_own_invite" ON organization_invites
+    FOR SELECT USING (
+      lower(email) = lower(auth.jwt() ->> 'email')
+    );
+  ```
+
+### Function timeout (30s) on AI generation
+Netlify Functions have a hard 30s timeout. If a Gemini call exceeds it:
+- Parallelise calls with `Promise.all` instead of running them serially (already done for Sustainability Statement).
+- Reduce prompt size or pick a faster model (`gemini-2.5-flash-lite`).
+
+### Build fails with "Configuration property functions.timeout must be an object"
+The `[functions] timeout = N` syntax is invalid in `netlify.toml`. Remove it — function timeouts can only be configured by upgrading the Netlify plan.
+
+---
+
+## Production hardening checklist
+
+Before opening to real customers:
+
+- [ ] SMTP configured in Supabase for branded, reliable email delivery
+- [ ] Tailwind installed as a PostCSS plugin (currently CDN — see browser console warning)
+- [ ] Custom domain with HTTPS (Netlify auto-provisions Let's Encrypt)
+- [ ] Supabase project on a paid tier (free tier pauses after inactivity)
+- [ ] Database backups enabled in Supabase
+- [ ] Open Dependabot alerts triaged (currently 3 moderate, all in dev/transitive deps)
+- [ ] Error monitoring (Sentry / similar) wired up
+- [ ] Analytics (PostHog / Plausible / GA) added
+- [ ] Privacy policy + Terms of Service linked from the app

--- a/docs/TECH_STACK.md
+++ b/docs/TECH_STACK.md
@@ -1,0 +1,161 @@
+# Tech Stack & Deployment
+
+## Architecture overview
+
+```
+┌─────────────────┐      ┌────────────────────┐      ┌──────────────────┐
+│   React SPA     │─────▶│  Netlify Functions │─────▶│  Supabase        │
+│  (Vite, TS)     │◀─────│   (Node, TS)       │◀─────│  (Postgres+Auth) │
+└─────────────────┘      └────────────────────┘      └──────────────────┘
+        │                          │                          ▲
+        │                          ▼                          │
+        │                  ┌──────────────┐                   │
+        └─────────────────▶│  Gemini API  │                   │
+            (server only)  └──────────────┘                   │
+                                                              │
+        ┌─────────────────────────────────────────────────────┘
+        │  RLS-protected direct access for read/write of
+        │  org-scoped tables using anon key + JWT
+        └─
+```
+
+The browser talks to Supabase directly for most reads/writes (RLS enforces tenant isolation). Netlify Functions are used only for operations that require the **service role** (bypassing RLS): invitations, accepting invites, and proxying Gemini calls so the API key never reaches the client.
+
+---
+
+## Frontend
+
+| Layer | Choice | Notes |
+|---|---|---|
+| Framework | **React 19** | Function components + hooks |
+| Build | **Vite 6** | Fast dev server, ES module output |
+| Language | **TypeScript 5.8** | Strict mode |
+| Styling | **Tailwind CSS** | Loaded via CDN in `index.html` (note: production-grade install pending — currently shows a console warning) |
+| Icons | **lucide-react** | |
+| Charts | **recharts** | KPI dashboards & materiality matrix |
+| AI client | **@google/genai** | Used only inside Netlify Functions, not in the browser bundle |
+| Auth/data | **@supabase/supabase-js** | Anon key in browser; RLS enforces access |
+
+### Key directories
+
+```
+components/    React UI components (one per feature screen)
+hooks/         Auth + per-org data hooks (useAuth, useOrganization, useOrgData)
+lib/           Supabase client singleton
+services/      dbService (CRUD wrappers), geminiService (AI call helpers)
+```
+
+---
+
+## Backend (Netlify Functions)
+
+Three serverless functions, all TypeScript, deployed to Netlify Functions runtime:
+
+| Function | Purpose | Auth |
+|---|---|---|
+| `api.ts` | Proxies Gemini calls (Sustainability Statement, IRO suggestions, etc.). Logs token usage to `ai_usage_log`. | Bearer JWT (org member) |
+| `invite.ts` | Create / list / resend / cancel invitations. Sends emails via Supabase Auth. | Bearer JWT (Owner/Admin) — except `request_resend` (unauthenticated, for expired-link self-service) |
+| `accept-invite.ts` | Validate an invite token, add the user to `organization_members`, return company name. | Bearer JWT |
+
+All three use the **Supabase service-role key** (server-side only) to perform privileged operations.
+
+---
+
+## Database (Supabase / Postgres)
+
+Single Postgres database, multi-tenant via `organization_id` foreign keys and RLS policies.
+
+### Core tables
+
+```
+organizations              ─┐
+organization_members       ─┤  Tenant root
+organization_invites       ─┘
+
+company_profiles           ─┐
+business_model_canvases    ─┤  One row per org
+swot_analyses              ─┤
+organization_ai_settings   ─┘
+
+assessments                ─┐  Many per org
+kpis                       ─┤  (org-scoped via FK + RLS)
+ai_usage_log               ─┘
+
+user_preferences           ─┐  Per user (not org-scoped)
+auth.users (Supabase)      ─┘
+```
+
+### Row-Level Security
+
+Two helper functions (`SECURITY DEFINER`) avoid recursive RLS:
+
+- `is_org_member(org_id)` — `EXISTS` check on `organization_members`
+- `user_org_role(org_id)` — returns the caller's role in the org
+
+Standard policy pattern:
+- **SELECT**: `is_org_member(organization_id)`
+- **INSERT/UPDATE/DELETE**: `user_org_role(organization_id) IN ('Owner', 'Admin', 'Manager')`
+- **Owner-only**: role check restricted to `'Owner'`
+- **Invitee read-own-invite**: `lower(email) = lower(auth.jwt() ->> 'email')` — needed so a newly invited user (not yet a member) can see their pending invite for auto-join
+
+### Migrations
+
+Source of truth is `supabase/schema.sql`. Incremental migrations live in `supabase/migrations/`:
+
+- `001_create_organization_with_owner.sql` — atomic org-creation RPC
+- `002_ai_settings_and_usage.sql` — per-org AI model + usage log
+
+Run via Supabase Dashboard → SQL Editor for each environment.
+
+---
+
+## External services
+
+| Service | Used for | Where |
+|---|---|---|
+| **Supabase** | Auth (email magic-link), Postgres, RLS, transactional emails (invite/magic-link templates) | All envs |
+| **Google Gemini API** | AI generation: IROs, KPIs, sustainability statement, BMC drafts | `api.ts` only |
+| **Netlify** | Static hosting (frontend), serverless functions (backend), env-var management | All envs |
+
+---
+
+## Environment variables
+
+Five env vars total — three public (Vite-prefixed, exposed to the browser) and two server-only:
+
+| Variable | Scope |
+|---|---|
+| `VITE_SUPABASE_URL` | Public |
+| `VITE_SUPABASE_ANON_KEY` | Public |
+| `VITE_APP_URL` | Public |
+| `SUPABASE_SERVICE_ROLE_KEY` | Server-only |
+| `GEMINI_API_KEY` | Server-only |
+
+`.env.example` is committed; `.env` is gitignored. See [`DEPLOYMENT.md`](./DEPLOYMENT.md) for full setup.
+
+---
+
+## Deployment
+
+Hosted on **Netlify** (frontend + functions) and **Supabase** (database + auth). One Netlify site + one Supabase project per environment (production / demo).
+
+See [`DEPLOYMENT.md`](./DEPLOYMENT.md) for:
+- First-time setup (Supabase + Netlify + env vars)
+- Deploy flow (Git → Netlify auto-build)
+- Schema migration process (manual, per environment)
+- Local development setup
+- Troubleshooting common issues
+
+---
+
+## Security model summary
+
+| Concern | Mitigation |
+|---|---|
+| Tenant isolation | Postgres RLS keyed on `organization_id` via membership helpers |
+| API keys | Gemini & service-role keys live only in Netlify env vars, never sent to browser |
+| Cross-tenant data leaks | Every table has SELECT policy gated by `is_org_member()` |
+| Privilege escalation | INSERT/UPDATE/DELETE policies check `user_org_role()` |
+| Invite token reuse | Invites burned (deleted) on acceptance |
+| Expired links | Self-service resend on the sign-in page |
+| Secrets in git | `.env` gitignored; `.env.example` committed as template |

--- a/metadata.json
+++ b/metadata.json
@@ -1,5 +1,0 @@
-{
-  "name": "Aeternum Ally",
-  "description": "An AI-powered SaaS platform for SMEs to conduct Double Materiality Assessments aligned with ESRS standards. Features automated IRO generation, scoring matrices, and sustainability reporting dashboards.",
-  "requestFramePermissions": []
-}


### PR DESCRIPTION
## Summary

- **`docs/TECH_STACK.md`** — architecture diagram, frontend/backend stack, database schema, RLS pattern, security model
- **`docs/DEPLOYMENT.md`** — env vars, first-time setup, deploy flow, manual schema migration steps, local dev, troubleshooting (incl. all the gotchas we hit: 403 from missing JWT-based RLS, invite email delivery, "One more step" trap, 30s function timeout)
- **`README.md`** — replaced inline tech-stack/setup blurb with links to the new docs
- **Cleanup** — removed unused \`metadata.json\` (Google AI Studio scaffold leftover) and added \`.claude/\` to \`.gitignore\`

## Test plan

- [ ] Open both docs on GitHub, confirm rendering and links work
- [ ] Confirm README \"📚 Documentation\" links resolve
- [ ] No code or config changes — no app behaviour to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)