### PR TITLE
docs: address review findings — version headers, hardening backlog, rollback

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- Version: 1.0.0 — Last updated: 2026-05-01 -->
+
 # Aeternum Ally 🌿
 > **AI-Powered Sustainability Management & Reporting for SMEs**
 
@@ -73,11 +75,26 @@ Generates a report compliant with **ESRS 2 (General Disclosures)** and **Topical
 
 ---
 
+## 🛠️ Quick start
+
+Prerequisites: **Node 20+**, **npm**, a **Supabase** project, a **Google Gemini API key**.
+
+```bash
+git clone <this-repo>
+cd Aeternum-Ally
+cp .env.example .env          # then fill in the 5 required vars
+npm install
+npm run dev:netlify           # Vite + Netlify Functions on http://localhost:8888
+```
+
+Full setup (Supabase project, schema, migrations, Netlify deploy) is in [`docs/DEPLOYMENT.md`](./docs/DEPLOYMENT.md).
+
+> ⚠️ Always use `npm run dev:netlify` (not `npm run dev`) when working on API code — the latter does not expose `/.netlify/functions/*`.
+
+---
+
 ## 📚 Documentation
 
 *   **[Tech Stack](./docs/TECH_STACK.md)** — Architecture, frontend/backend stack, database schema, RLS, security model
 *   **[Deployment](./docs/DEPLOYMENT.md)** — Setup, environment variables, deploy flow, schema migrations, local development, troubleshooting
 
----
-
-*Built for the Google Gemini Developer Competition.*

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,3 +1,5 @@
+<!-- Version: 1.0.0 — Last updated: 2026-05-01 -->
+
 # Deployment Guide
 
 Step-by-step guide for deploying Aeternum Ally. See [`TECH_STACK.md`](./TECH_STACK.md) for architecture context.
@@ -22,7 +24,7 @@ Step-by-step guide for deploying Aeternum Ally. See [`TECH_STACK.md`](./TECH_STA
 | Env | Frontend URL | Branch | Netlify site | Supabase project |
 |---|---|---|---|---|
 | Production | _(your prod domain)_ | `main` | Production site | Production project |
-| Demo / Test | `demo.aeternumally.com` | `main` (separate site) | Demo site | Test project (`tlyuhlyrkztypqdgixze`) |
+| Demo / Test | `demo.aeternumally.com` | `main` (separate site) | Demo site | _(separate Supabase project — ID stored in Netlify env vars only)_ |
 
 Branch / preview deploys inherit env vars from their parent site.
 
@@ -126,6 +128,18 @@ For each PR that touches `supabase/schema.sql` or adds a `supabase/migrations/*.
 
 > ⚠️ Run schema migrations **before** merging the code PR if the new code depends on the schema change. Otherwise the deploy will fail at runtime.
 
+#### Rollback procedure
+
+There is no automatic rollback. If a migration breaks production:
+
+1. **Revert the code** first — push a revert PR so the new app no longer expects the new schema.
+2. **Write a hand-rolled rollback SQL** (e.g. `migrations/00X_rollback_<thing>.sql`) that undoes the failed change. Examples: `DROP POLICY`, `DROP COLUMN`, restore the previous function body.
+3. Run the rollback SQL via Supabase Dashboard → SQL Editor.
+4. Verify the schema matches the prior known-good state and the app is healthy.
+5. Restore from a Supabase backup only as a last resort — it loses all data written since the snapshot.
+
+Always test migrations on the demo/test environment before applying them to production.
+
 ### Env-var changes
 
 After updating env vars in Netlify, you must **redeploy** for them to take effect:
@@ -144,6 +158,8 @@ npm run dev:netlify     # runs Vite + Netlify Functions on port 8888
 ```
 
 `npm run dev` (Vite alone) **won't** expose `/.netlify/functions/*` — always use `dev:netlify` when developing API-touching code.
+
+> ℹ️ The `[dev]` block in `netlify.toml` declares `command = "npm run dev"` because Netlify CLI runs Vite as a child process and proxies it on port 8888. The script you invoke from your shell is still `npm run dev:netlify` (which is `netlify dev` under the hood). Don't run `npm run dev` directly when developing functions.
 
 To test the invite flow locally, the Supabase project's **Site URL / Redirect URLs** must include `http://localhost:8888`.
 
@@ -183,18 +199,40 @@ Netlify Functions have a hard 30s timeout. If a Gemini call exceeds it:
 ### Build fails with "Configuration property functions.timeout must be an object"
 The `[functions] timeout = N` syntax is invalid in `netlify.toml`. Remove it — function timeouts can only be configured by upgrading the Netlify plan.
 
+### Supabase email quota suddenly exhausted / abuse on `request_resend`
+The unauthenticated `request_resend` action on `invite.ts` has **no rate limit** in the current build. If you see a spike in Supabase email sends or quota errors:
+1. Temporarily disable the action by short-circuiting the `if (action === "request_resend")` block to return 200 without sending.
+2. Add a Netlify edge rate-limit rule on `/.netlify/functions/invite` keyed on IP.
+3. Track the long-term fix in the [hardening backlog](./TECH_STACK.md#known-gaps--hardening-backlog).
+
 ---
 
 ## Production hardening checklist
 
-Before opening to real customers:
+Before opening to real customers, work through this list. See [`TECH_STACK.md`](./TECH_STACK.md#known-gaps--hardening-backlog) for the threat-model rationale behind the security items.
 
+### Infrastructure
 - [ ] SMTP configured in Supabase for branded, reliable email delivery
-- [ ] Tailwind installed as a PostCSS plugin (currently CDN — see browser console warning)
 - [ ] Custom domain with HTTPS (Netlify auto-provisions Let's Encrypt)
 - [ ] Supabase project on a paid tier (free tier pauses after inactivity)
-- [ ] Database backups enabled in Supabase
-- [ ] Open Dependabot alerts triaged (currently 3 moderate, all in dev/transitive deps)
+- [ ] Database backups enabled and **restore tested** at least once
 - [ ] Error monitoring (Sentry / similar) wired up
 - [ ] Analytics (PostHog / Plausible / GA) added
 - [ ] Privacy policy + Terms of Service linked from the app
+
+### Security (functions)
+- [ ] **CORS:** add `Access-Control-Allow-Origin` (allowlist `VITE_APP_URL` only) + `OPTIONS` pre-flight on all three Netlify Functions
+- [ ] **Rate limit `request_resend`** (Netlify edge rule or in-function token bucket) to prevent email-quota drain
+- [ ] **HTTP method guard** on `invite.ts` (currently missing — `accept-invite.ts` has it)
+- [ ] **AI model allowlist** — validate `organization_ai_settings.model` server-side against the `PRICING` map in `api.ts` before calling Gemini
+- [ ] **Prompt-injection hardening** — wrap user-supplied fields (company description, topic names) in delimited sections in `api.ts` prompt templates
+
+### Security (frontend / Supabase)
+- [ ] Tailwind installed as a PostCSS plugin (currently CDN — runtime third-party dependency, no SRI)
+- [ ] CSP header configured via Netlify `_headers` file
+- [ ] Supabase Auth password policy reviewed (min length, MFA where applicable)
+- [ ] Session token lifetime tuned to your risk tolerance (Supabase Auth → Settings)
+- [ ] **Key rotation runbook** documented for `GEMINI_API_KEY` and `SUPABASE_SERVICE_ROLE_KEY`
+
+### Dependencies
+- [ ] Dependabot / `npm audit` alerts triaged — record the resolution in the PR that closes them (don't leave specifics in this checklist)

--- a/docs/TECH_STACK.md
+++ b/docs/TECH_STACK.md
@@ -1,3 +1,5 @@
+<!-- Version: 1.0.0 — Last updated: 2026-05-01 -->
+
 # Tech Stack & Deployment
 
 ## Architecture overview
@@ -40,7 +42,11 @@ The browser talks to Supabase directly for most reads/writes (RLS enforces tenan
 
 ```
 components/    React UI components (one per feature screen)
-hooks/         Auth + per-org data hooks (useAuth, useOrganization, useOrgData)
+hooks/         Auth + per-org data hooks
+               - useAuth          — Supabase session + sign-in/out
+               - useOrganization  — current-org context, role, switch
+               - useOrgData       — loads & mutates all org-scoped tables
+                                    (canvas, SWOT, assessments, KPIs, profile)
 lib/           Supabase client singleton
 services/      dbService (CRUD wrappers), geminiService (AI call helpers)
 ```
@@ -58,6 +64,8 @@ Three serverless functions, all TypeScript, deployed to Netlify Functions runtim
 | `accept-invite.ts` | Validate an invite token, add the user to `organization_members`, return company name. | Bearer JWT |
 
 All three use the **Supabase service-role key** (server-side only) to perform privileged operations.
+
+> ℹ️ The `request_resend` action on `invite.ts` is intentionally unauthenticated so a user with an expired link can request a fresh one from the sign-in page. It always returns a generic 200 to avoid email enumeration. Because it is public, it is a candidate for abuse — see the [Security model summary](#security-model-summary) for current limitations.
 
 ---
 
@@ -100,10 +108,17 @@ Standard policy pattern:
 
 ### Migrations
 
-Source of truth is `supabase/schema.sql`. Incremental migrations live in `supabase/migrations/`:
+`supabase/schema.sql` is the canonical full-schema snapshot used for **fresh installs**. Incremental migrations live in `supabase/migrations/` and apply changes that landed after the snapshot was last regenerated:
 
 - `001_create_organization_with_owner.sql` — atomic org-creation RPC
 - `002_ai_settings_and_usage.sql` — per-org AI model + usage log
+
+**When to run what:**
+
+| Scenario | Run |
+|---|---|
+| New Supabase project (fresh install) | `schema.sql`, then every file in `migrations/` in numeric order |
+| Existing project, pulling latest code | Only the *new* migrations added since the last deploy |
 
 Run via Supabase Dashboard → SQL Editor for each environment.
 
@@ -158,4 +173,18 @@ See [`DEPLOYMENT.md`](./DEPLOYMENT.md) for:
 | Privilege escalation | INSERT/UPDATE/DELETE policies check `user_org_role()` |
 | Invite token reuse | Invites burned (deleted) on acceptance |
 | Expired links | Self-service resend on the sign-in page |
+| Email enumeration on resend | `request_resend` always returns a generic 200 regardless of whether an invite exists |
 | Secrets in git | `.env` gitignored; `.env.example` committed as template |
+
+### Known gaps / hardening backlog
+
+These are tracked, not yet implemented, and listed here so reviewers and operators are aware:
+
+| Gap | Risk | Planned mitigation |
+|---|---|---|
+| **No CORS headers** on Netlify Functions (no `Access-Control-Allow-*`, no `OPTIONS` handler) | Cross-origin SPA deployments may break; no origin allowlist | Add a shared CORS wrapper that allowlists `VITE_APP_URL` |
+| **No rate limit on `request_resend`** | An attacker can drain the Supabase email quota by spamming the endpoint | Netlify edge rule or token-bucket keyed on IP + email |
+| **No server-side AI model allowlist** | An Owner/Admin can write any string to `organization_ai_settings.model`; `api.ts` forwards it to Gemini without checking against the `PRICING` table | Validate `model` against the allowlist before calling Gemini |
+| **No prompt-injection sanitisation** | User-supplied fields (company description, topic names) are concatenated into Gemini prompts. A malicious member could inject instructions that manipulate AI output for the whole org. | Wrap user input in delimited, role-tagged sections; reject control sequences |
+| **Tailwind via CDN** in `index.html` | Runtime third-party dependency; no SRI hash | Move to PostCSS install (build-time) |
+| **No HTTP-method guard on `invite.ts`** | Non-POST requests fall through to body parsing | Add explicit `httpMethod` check (matches `accept-invite.ts`) |


### PR DESCRIPTION
## Summary

Adds a version + last-updated header to all three docs and folds in findings from a multi-hat (SaaS architect / security / senior dev / QA) review of the existing documentation.

- **README**: adds a quick-start with prerequisites and the `dev:netlify` callout; drops the competition footer.
- **TECH_STACK**: documents the unauthenticated `request_resend` sub-action and its email-enumeration mitigation, expands the `useOrgData` description, clarifies `schema.sql` (fresh install) vs. `migrations/` (incremental), and adds a **Known gaps / hardening backlog** table covering CORS, `request_resend` rate-limit, AI model allowlist, prompt injection, Tailwind CDN, and the missing HTTP-method guard on `invite.ts`.
- **DEPLOYMENT**: removes the hardcoded demo Supabase project ID, adds a **Rollback procedure**, explains the `netlify.toml [dev]` vs. `npm run dev:netlify` discrepancy, restructures the production hardening checklist by area (Infra / Functions / Frontend / Deps), and adds a Common Issues entry with an emergency mitigation for `request_resend` abuse.

## Why

The existing docs were accurate but had gaps that a security reviewer or a new operator would trip on: undocumented public endpoint, no rollback path, no rate-limit / CORS / prompt-injection notes in the security model, and a confusing local-dev setup. This PR closes those gaps without changing any application code — every gap surfaced is also tracked in the new hardening backlog so it can be picked up in a follow-up.

## Test plan

- [ ] Render the three docs on GitHub and verify formatting (tables, code blocks, anchors)
- [ ] Confirm the cross-doc anchor link `TECH_STACK.md#known-gaps--hardening-backlog` resolves
- [ ] Confirm no application code changed (`git diff --stat` shows only `*.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)