### PR TITLE
docs: add License section to README announcing BSL 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,3 +98,21 @@ Full setup (Supabase project, schema, migrations, Netlify deploy) is in [`docs/D
 *   **[Tech Stack](./docs/TECH_STACK.md)** — Architecture, frontend/backend stack, database schema, RLS, security model
 *   **[Deployment](./docs/DEPLOYMENT.md)** — Setup, environment variables, deploy flow, schema migrations, local development, troubleshooting
 
+---
+
+## 📄 License
+
+Aeternum Ally is **source-available** under the [Business Source License 1.1](./LICENSE).
+
+**You may:**
+- Self-host it for your own organisation's internal use.
+- Run a single-tenant deployment on behalf of one identifiable end client (e.g. a consulting engagement).
+- Read, modify, and contribute back to the source.
+
+**You may not:**
+- Operate Aeternum Ally as a multi-tenant hosted service.
+- Provide automated provisioning of Aeternum Ally instances to third parties.
+- Otherwise offer the software as a competing SaaS product.
+
+Each release automatically converts to **Apache License 2.0** four years after its publication date. See [LICENSE](./LICENSE) for the precise terms.
+


### PR DESCRIPTION
Documents the planned licensing model in user-facing terms: self-host and single-tenant consulting use are allowed; multi-tenant SaaS and automated provisioning are not. Each release auto-converts to Apache-2.0 four years after publication.

The actual LICENSE file is intentionally not added in this commit — it will land in a follow-up PR after review of the exact wording. The link to ./LICENSE is a forward reference and will resolve once that file is committed.