### PR TITLE
refactor: pass structured CompanyProfile to all AI prompts

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useMemo, useEffect } from 'react';
+import React, { useState, useEffect } from 'react';
 import { AssessmentData, ESRSTopic, SustainabilityBusinessModel, SwotAnalysis, CompanyProfile, KPI, BSCPerspective } from './types';
 import AssessmentForm from './components/AssessmentForm';
 import MaterialityMatrix from './components/MaterialityMatrix';
@@ -158,25 +158,6 @@ const App: React.FC = () => {
   };
 
   const materialTopics = assessments.filter(a => a.isMaterial);
-
-  const derivedCompanyDescription = useMemo(() => `
-    Company: ${profile.data.name} (Tax ID: ${profile.data.taxId}).
-    Industry: ${profile.data.industry} (ISIC: ${profile.data.isicCode}).
-    Scale: ${profile.data.employeeCount} employees, Revenue: ${profile.data.revenueRange}.
-    Description: ${profile.data.description}.
-    Mission: ${profile.data.mission}.
-    Vision: ${profile.data.vision}.
-    Key Products: ${profile.data.productsServices}.
-
-    Business Model Context:
-    Value Proposition: ${canvas.data.valueProposition}.
-    Key Activities: ${canvas.data.keyActivities}.
-    Partners: ${canvas.data.keyPartners}.
-    Resources: ${canvas.data.keyResources}.
-    Target Customers: ${canvas.data.customerSegments}.
-    Eco-Social Benefits: ${canvas.data.ecoSocialBenefits}.
-    Eco-Social Costs: ${canvas.data.ecoSocialCosts}.
-  `.trim(), [profile.data, canvas.data]);
 
   // ----- Loading / auth gates -----
   if (authLoading) return <FullScreenLoader label="Signing you in…" />;
@@ -370,7 +351,7 @@ const App: React.FC = () => {
                     kpis={kpis}
                     onSaveKpi={handleSaveKpi}
                     onDeleteKpi={handleDeleteKpi}
-                    companyDescription={derivedCompanyDescription}
+                    profile={profile.data}
                   />
                 )}
 
@@ -404,8 +385,7 @@ const App: React.FC = () => {
                   <BusinessModelCanvas
                     data={canvas.data}
                     onChange={canvas.setData}
-                    companyName={profile.data.name}
-                    companyDescription={derivedCompanyDescription}
+                    profile={profile.data}
                     saveStatus={canvas.saveStatus}
                     isDirty={canvas.isDirty}
                     onSave={canvas.save}
@@ -417,8 +397,7 @@ const App: React.FC = () => {
                   <SwotAnalysisWizard
                     data={swot.data}
                     onChange={swot.setData}
-                    companyName={profile.data.name}
-                    companyDescription={derivedCompanyDescription}
+                    profile={profile.data}
                     bmcData={canvas.data}
                     saveStatus={swot.saveStatus}
                     isDirty={swot.isDirty}
@@ -457,7 +436,7 @@ const App: React.FC = () => {
                     ) : (
                       <div className="max-w-3xl mx-auto">
                         <AssessmentForm
-                          companyDescription={derivedCompanyDescription}
+                          profile={profile.data}
                           onSave={handleSaveAssessment}
                           onCancel={() => { setIsFormOpen(false); setEditingAssessment(null); }}
                           initialData={editingAssessment}

--- a/components/AssessmentForm.tsx
+++ b/components/AssessmentForm.tsx
@@ -1,18 +1,18 @@
 
 import React, { useState, useEffect } from 'react';
-import { AssessmentData, ESRSTopic, ImpactScore, FinancialScore } from '../types';
+import { AssessmentData, ESRSTopic, ImpactScore, FinancialScore, CompanyProfile } from '../types';
 import { SCALE_OPTIONS, LIKELIHOOD_OPTIONS, calculateImpactMateriality, calculateFinancialMateriality, TOPICS } from '../constants';
 import { generateAssessmentSuggestions } from '../services/geminiService';
 import { AlertCircle, TrendingUp, Cpu, Loader2, Save, X } from 'lucide-react';
 
 interface Props {
-  companyDescription: string;
+  profile: CompanyProfile;
   onSave: (data: AssessmentData) => void;
   onCancel: () => void;
   initialData?: AssessmentData | null;
 }
 
-const AssessmentForm: React.FC<Props> = ({ companyDescription, onSave, onCancel, initialData }) => {
+const AssessmentForm: React.FC<Props> = ({ profile, onSave, onCancel, initialData }) => {
   const [topic, setTopic] = useState<ESRSTopic>(ESRSTopic.E1);
   const [impactDesc, setImpactDesc] = useState('');
   const [financialDesc, setFinancialDesc] = useState('');
@@ -50,7 +50,7 @@ const AssessmentForm: React.FC<Props> = ({ companyDescription, onSave, onCancel,
 
   const handleAutoFill = async () => {
     setLoadingAI(true);
-    const suggestions = await generateAssessmentSuggestions(companyDescription, topic);
+    const suggestions = await generateAssessmentSuggestions(profile, topic);
     setImpactDesc(suggestions.impactSuggestion);
     setFinancialDesc(suggestions.financialSuggestion);
     setLoadingAI(false);

--- a/components/BusinessModelCanvas.tsx
+++ b/components/BusinessModelCanvas.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState } from 'react';
-import { SustainabilityBusinessModel } from '../types';
+import { SustainabilityBusinessModel, CompanyProfile } from '../types';
 import { Info, Wand2, ArrowRight, ArrowLeft, Grid, Check, Loader2, PlayCircle } from 'lucide-react';
 import { generateCanvasSuggestion } from '../services/geminiService';
 import SaveIndicator from './SaveIndicator';
@@ -9,8 +9,7 @@ import type { SaveStatus } from '../hooks/useOrgData';
 interface Props {
   data: SustainabilityBusinessModel;
   onChange: (data: SustainabilityBusinessModel) => void;
-  companyName: string;
-  companyDescription: string;
+  profile: CompanyProfile;
   saveStatus: SaveStatus;
   isDirty: boolean;
   onSave: () => void;
@@ -75,7 +74,7 @@ const WIZARD_STEPS: Step[] = [
   }
 ];
 
-const BusinessModelCanvas: React.FC<Props> = ({ data, onChange, companyName, companyDescription, saveStatus, isDirty, onSave, saveError }) => {
+const BusinessModelCanvas: React.FC<Props> = ({ data, onChange, profile, saveStatus, isDirty, onSave, saveError }) => {
   const [mode, setMode] = useState<'grid' | 'wizard'>('wizard');
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
   const [loadingField, setLoadingField] = useState<string | null>(null);
@@ -90,7 +89,7 @@ const BusinessModelCanvas: React.FC<Props> = ({ data, onChange, companyName, com
 
   const handleAiSuggest = async (field: CanvasField, label: string) => {
     setLoadingField(field);
-    const suggestion = await generateCanvasSuggestion(companyName, companyDescription, label);
+    const suggestion = await generateCanvasSuggestion(profile, label);
     if (suggestion) {
       // Append if not empty, or replace if empty
       const currentVal = data[field];

--- a/components/CompanyProfileForm.tsx
+++ b/components/CompanyProfileForm.tsx
@@ -11,6 +11,7 @@ import SaveIndicator from './SaveIndicator';
 import type { SaveStatus } from '../hooks/useOrgData';
 import { supabase } from '../lib/supabaseClient';
 import { removeMember, updateMemberRole, cancelInvite } from '../services/dbService';
+import { logError } from '../services/errorLogService';
 import AIUsagePanel from './AIUsagePanel';
 
 interface Props {
@@ -229,6 +230,7 @@ const TeamPanel: React.FC<TeamPanelProps> = ({
   const [pendingInvites, setPendingInvites] = useState<OrgInvite[]>([]);
   const [invitesLoading, setInvitesLoading] = useState(false);
   const [invitesError, setInvitesError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
 
   const fetchPendingInvites = useCallback(async () => {
     setInvitesLoading(true);
@@ -285,17 +287,27 @@ const TeamPanel: React.FC<TeamPanelProps> = ({
 
   const handleDeactivate = async (memberId: string, email: string | null) => {
     if (!window.confirm(`Deactivate access for ${email ?? 'this member'}? They will lose access immediately.`)) return;
+    setActionError(null);
     try {
       await removeMember(memberId);
-    } catch (error: any) { alert(`Failed to deactivate: ${error.message}`); return; }
+    } catch (error: any) {
+      setActionError(`Failed to deactivate: ${error.message}`);
+      logError({ context: "member-management", action: "deactivate_member", error, organizationId });
+      return;
+    }
     await onMembersChanged();
   };
 
   const handleCancelInvite = async (inviteId: string, email: string) => {
     if (!window.confirm(`Cancel invitation for ${email}?`)) return;
+    setActionError(null);
     try {
       await cancelInvite(inviteId);
-    } catch (error: any) { alert(`Failed to cancel invitation: ${error.message}`); return; }
+    } catch (error: any) {
+      setActionError(`Failed to cancel invitation: ${error.message}`);
+      logError({ context: "member-management", action: "cancel_invite", error, organizationId });
+      return;
+    }
     await fetchPendingInvites();
   };
 
@@ -325,16 +337,22 @@ const TeamPanel: React.FC<TeamPanelProps> = ({
         alert(`Invitation resent to ${email}. The new link is valid for 1 hour.`);
       }
     } catch (err: any) {
-      alert(err?.message ?? 'Failed to resend invitation.');
+      setActionError(err?.message ?? 'Failed to resend invitation.');
+      logError({ context: "member-management", action: "resend_invite", error: err, organizationId });
     } finally {
       setResendingId(null);
     }
   };
 
   const handleRoleChange = async (memberId: string, newRole: OrgRole) => {
+    setActionError(null);
     try {
       await updateMemberRole(memberId, newRole);
-    } catch (error: any) { alert(`Failed to update role: ${error.message}`); return; }
+    } catch (error: any) {
+      setActionError(`Failed to update role: ${error.message}`);
+      logError({ context: "member-management", action: "update_role", error, organizationId });
+      return;
+    }
     await onMembersChanged();
   };
 
@@ -349,6 +367,12 @@ const TeamPanel: React.FC<TeamPanelProps> = ({
 
   return (
     <div className="space-y-8">
+
+      {actionError && (
+        <div className="flex items-start gap-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded text-sm text-red-700 dark:text-red-300">
+          <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" /> {actionError}
+        </div>
+      )}
 
       {/* ── Invite form ────────────────────────────────────────────── */}
       {canManage && (

--- a/components/OrgSetupScreen.tsx
+++ b/components/OrgSetupScreen.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from "react";
 import { Building2, Users, Loader2, AlertCircle, CheckCircle2, ArrowLeft } from "lucide-react";
 import { supabase } from "../lib/supabaseClient";
 import { lookupPendingInvite, createOrganizationWithOwner } from "../services/dbService";
+import { logError } from "../services/errorLogService";
 
 interface Props {
   userEmail: string;
@@ -101,6 +102,7 @@ const OrgSetupScreen: React.FC<Props> = ({ userEmail, onComplete, onSignOut }) =
     } catch (e: any) {
       setError(e?.message ?? "Failed to accept invitation.");
       setMode("join");
+      logError({ context: "accept-invite", action: "accept_invite", error: e, metadata: { invite_token: token } });
     } finally {
       setIsLoading(false);
     }
@@ -116,6 +118,7 @@ const OrgSetupScreen: React.FC<Props> = ({ userEmail, onComplete, onSignOut }) =
       onComplete();
     } catch (e: any) {
       setError(e?.message ?? "Failed to create organization. Please try again.");
+      logError({ context: "org-setup", action: "create_org", error: e, metadata: { company_name: companyName.trim() } });
     } finally {
       setIsLoading(false);
     }

--- a/components/PerformanceDashboard.tsx
+++ b/components/PerformanceDashboard.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState } from 'react';
-import { KPI, BSCPerspective, RACI } from '../types';
+import { KPI, BSCPerspective, RACI, CompanyProfile } from '../types';
 import { generateKPISuggestions } from '../services/geminiService';
 import {
   TrendingUp, Users, Settings, BookOpen, Plus,
@@ -12,7 +12,7 @@ interface Props {
   kpis: KPI[];
   onSaveKpi: (kpi: KPI) => Promise<void>;
   onDeleteKpi: (id: string) => Promise<void>;
-  companyDescription: string;
+  profile: CompanyProfile;
 }
 
 const PERSPECTIVE_CONFIG = {
@@ -22,7 +22,7 @@ const PERSPECTIVE_CONFIG = {
   [BSCPerspective.LEARNING]: { color: 'bg-purple-100 text-purple-800', border: 'border-purple-200', icon: <BookOpen className="w-5 h-5" /> },
 };
 
-const PerformanceDashboard: React.FC<Props> = ({ kpis, onSaveKpi, onDeleteKpi, companyDescription }) => {
+const PerformanceDashboard: React.FC<Props> = ({ kpis, onSaveKpi, onDeleteKpi, profile }) => {
   const [viewMode, setViewMode] = useState<'map' | 'tracking'>('map');
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [editingKpi, setEditingKpi] = useState<KPI | null>(null);
@@ -70,7 +70,7 @@ const PerformanceDashboard: React.FC<Props> = ({ kpis, onSaveKpi, onDeleteKpi, c
                 await onSaveKpi(kpi);
                 setIsFormOpen(false);
             }}
-            companyDescription={companyDescription}
+            profile={profile}
             allKpis={kpis}
         />
       )}
@@ -222,12 +222,12 @@ interface KPIFormProps {
   initialData: KPI | null;
   onClose: () => void;
   onSave: (kpi: KPI) => Promise<void> | void;
-  companyDescription: string;
+  profile: CompanyProfile;
   allKpis: KPI[];
 }
 
 // --- Sub-Component: KPI Form (Modal) ---
-const KPIForm: React.FC<KPIFormProps> = ({ initialData, onClose, onSave, companyDescription, allKpis }) => {
+const KPIForm: React.FC<KPIFormProps> = ({ initialData, onClose, onSave, profile, allKpis }) => {
     const [formData, setFormData] = useState<KPI>(initialData || {
         id: '',
         name: '',
@@ -245,7 +245,7 @@ const KPIForm: React.FC<KPIFormProps> = ({ initialData, onClose, onSave, company
 
     const handleAiSuggest = async () => {
         setLoadingAi(true);
-        const suggestions = await generateKPISuggestions(companyDescription, formData.perspective);
+        const suggestions = await generateKPISuggestions(profile, formData.perspective);
         if (suggestions && suggestions.length > 0) {
             // Take the first one or ask user (Simplified: Take first)
             const s = suggestions[0];

--- a/components/PerformanceDashboard.tsx
+++ b/components/PerformanceDashboard.tsx
@@ -242,22 +242,30 @@ const KPIForm: React.FC<KPIFormProps> = ({ initialData, onClose, onSave, profile
         history: []
     });
     const [loadingAi, setLoadingAi] = useState(false);
+    const [aiError, setAiError] = useState<string | null>(null);
 
     const handleAiSuggest = async () => {
         setLoadingAi(true);
-        const suggestions = await generateKPISuggestions(profile, formData.perspective);
-        if (suggestions && suggestions.length > 0) {
-            // Take the first one or ask user (Simplified: Take first)
-            const s = suggestions[0];
-            setFormData(prev => ({
-                ...prev,
-                name: s.name,
-                description: s.description,
-                unit: s.unit,
-                targetValue: s.targetSuggestion
-            }));
+        setAiError(null);
+        try {
+            const suggestions = await generateKPISuggestions(profile, formData.perspective);
+            if (suggestions && suggestions.length > 0) {
+                const s = suggestions[0];
+                const validFrequencies = ['Monthly', 'Quarterly', 'Annually'];
+                setFormData(prev => ({
+                    ...prev,
+                    name: s.name,
+                    description: s.description,
+                    unit: s.unit,
+                    targetValue: s.targetSuggestion,
+                    frequency: validFrequencies.includes(s.frequency) ? s.frequency : prev.frequency,
+                }));
+            }
+        } catch (err) {
+            setAiError(err instanceof Error ? err.message : 'AI suggestion failed. Please try again.');
+        } finally {
+            setLoadingAi(false);
         }
-        setLoadingAi(false);
     };
 
     const handleSubmit = async (e: React.FormEvent) => {
@@ -297,16 +305,19 @@ const KPIForm: React.FC<KPIFormProps> = ({ initialData, onClose, onSave, profile
                         <div className="md:col-span-2">
                              <div className="flex justify-between items-center mb-1">
                                 <label className="block text-sm font-semibold text-slate-700 dark:text-slate-300">KPI Name</label>
-                                <button 
-                                    type="button" 
+                                <button
+                                    type="button"
                                     onClick={handleAiSuggest}
                                     disabled={loadingAi}
-                                    className="text-xs bg-esg-100 text-esg-700 dark:bg-esg-900 dark:text-esg-300 px-2 py-1 rounded flex items-center gap-1 hover:bg-esg-200"
+                                    className="text-xs bg-esg-100 text-esg-700 dark:bg-esg-900 dark:text-esg-300 px-2 py-1 rounded flex items-center gap-1 hover:bg-esg-200 disabled:opacity-50"
                                 >
                                     {loadingAi ? <Loader2 className="w-3 h-3 animate-spin" /> : <Settings className="w-3 h-3" />}
-                                    AI Suggest
+                                    {loadingAi ? 'Generating…' : 'AI Suggest'}
                                 </button>
                              </div>
+                             {aiError && (
+                                <p className="text-xs text-red-500 mb-1">{aiError}</p>
+                             )}
                              <input 
                                 required
                                 value={formData.name}

--- a/components/SustainabilityStatement.tsx
+++ b/components/SustainabilityStatement.tsx
@@ -67,14 +67,19 @@ const SustainabilityStatement: React.FC<Props> = ({ profile, assessments, canvas
         </div>
         <div className="flex gap-2 w-full sm:w-auto">
           {!generatedContent ? (
-            <button 
+            <div className="flex flex-col items-end gap-1 w-full sm:w-auto">
+              <button
                 onClick={handleGenerate}
                 disabled={loading}
-                className="flex items-center justify-center gap-2 bg-esg-600 text-white px-6 py-2.5 rounded-lg font-medium hover:bg-esg-700 shadow-lg shadow-esg-600/20 transition-all w-full sm:w-auto"
-            >
+                className="flex items-center justify-center gap-2 bg-esg-600 text-white px-6 py-2.5 rounded-lg font-medium hover:bg-esg-700 shadow-lg shadow-esg-600/20 transition-all w-full sm:w-auto disabled:opacity-60"
+              >
                 {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : <RefreshCw className="w-4 h-4" />}
-                Generate Report (AI)
-            </button>
+                {loading ? `Generating… (${materialTopics.length} topic${materialTopics.length !== 1 ? 's' : ''})` : 'Generate Report (AI)'}
+              </button>
+              {loading && (
+                <p className="text-xs text-slate-400">This may take up to 30 seconds</p>
+              )}
+            </div>
           ) : (
              <button 
                 onClick={() => window.print()}

--- a/components/SwotAnalysisWizard.tsx
+++ b/components/SwotAnalysisWizard.tsx
@@ -1,6 +1,6 @@
 
 import React, { useState } from 'react';
-import { SwotAnalysis, SustainabilityBusinessModel } from '../types';
+import { SwotAnalysis, SustainabilityBusinessModel, CompanyProfile } from '../types';
 import { generateSwotInternal, generateSwotExternal } from '../services/geminiService';
 import { ArrowRight, ArrowLeft, Loader2, Globe, ShieldAlert, TrendingUp, Zap, AlertTriangle } from 'lucide-react';
 import SaveIndicator from './SaveIndicator';
@@ -9,8 +9,7 @@ import type { SaveStatus } from '../hooks/useOrgData';
 interface Props {
   data: SwotAnalysis;
   onChange: (data: SwotAnalysis) => void;
-  companyName: string;
-  companyDescription: string;
+  profile: CompanyProfile;
   bmcData: SustainabilityBusinessModel;
   saveStatus: SaveStatus;
   isDirty: boolean;
@@ -18,13 +17,13 @@ interface Props {
   saveError?: string | null;
 }
 
-const SwotAnalysisWizard: React.FC<Props> = ({ data, onChange, companyName, companyDescription, bmcData, saveStatus, isDirty, onSave, saveError }) => {
+const SwotAnalysisWizard: React.FC<Props> = ({ data, onChange, profile, bmcData, saveStatus, isDirty, onSave, saveError }) => {
   const [step, setStep] = useState<number>(0);
   const [loadingMap, setLoadingMap] = useState<Record<string, boolean>>({});
 
   const handleGenerateInternal = async () => {
     setLoadingMap({ ...loadingMap, internal: true });
-    const result = await generateSwotInternal(companyName, bmcData);
+    const result = await generateSwotInternal(profile, bmcData);
     onChange({
       ...data,
       strengths: result.strengths || data.strengths,
@@ -35,7 +34,7 @@ const SwotAnalysisWizard: React.FC<Props> = ({ data, onChange, companyName, comp
 
   const handleGenerateExternal = async (field: 'opportunities' | 'threats') => {
     setLoadingMap({ ...loadingMap, [field]: true });
-    const result = await generateSwotExternal(companyName, companyDescription, field === 'opportunities' ? 'OPPORTUNITIES' : 'THREATS');
+    const result = await generateSwotExternal(profile, field === 'opportunities' ? 'OPPORTUNITIES' : 'THREATS');
     onChange({
       ...data,
       [field]: result

--- a/hooks/useOrgData.ts
+++ b/hooks/useOrgData.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { fetchSingleton, upsertSingleton } from "../services/dbService";
+import { logError } from "../services/errorLogService";
 
 export type SaveStatus = "idle" | "saving" | "saved" | "error";
 
@@ -74,6 +75,7 @@ export function useOrgData<T>({
         if (cancelled) return;
         setErrorMessage(error.message);
         setIsLoading(false);
+        logError({ context: "db-load", action: `load_${table}`, error, organizationId: orgId });
       });
 
     return () => {
@@ -100,6 +102,7 @@ export function useOrgData<T>({
     } catch (error: any) {
       setSaveStatus("error");
       setErrorMessage(error.message);
+      logError({ context: "db-save", action: `save_${table}`, error, organizationId: currentOrgId });
       return;
     }
 

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,9 @@
   publish = "dist"
   functions = "netlify/functions"
 
+[functions]
+  timeout = 26
+
 [dev]
   command = "npm run dev"
   port = 8888

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,9 +3,6 @@
   publish = "dist"
   functions = "netlify/functions"
 
-[functions]
-  timeout = 26
-
 [dev]
   command = "npm run dev"
   port = 8888

--- a/netlify/functions/accept-invite.ts
+++ b/netlify/functions/accept-invite.ts
@@ -9,6 +9,26 @@ const json = (statusCode: number, body: unknown) => ({
   body: JSON.stringify(body),
 });
 
+async function logServerError(
+  admin: any,
+  entry: {
+    organization_id?: string | null;
+    user_id?: string | null;
+    user_email?: string | null;
+    context: string;
+    action: string;
+    error_message: string;
+    http_status?: number | null;
+    metadata?: Record<string, unknown> | null;
+  }
+) {
+  try {
+    await admin.from("error_log").insert({ source: "server", ...entry });
+  } catch {
+    // best-effort
+  }
+}
+
 const handler = async (event: any) => {
   if (event.httpMethod !== "POST") {
     return { statusCode: 405, body: "Method Not Allowed" };
@@ -88,6 +108,15 @@ const handler = async (event: any) => {
       await admin.from("organization_invites").delete().eq("id", invite_token);
       return json(200, { success: true, organization_id: invite.organization_id, company_name: companyName });
     }
+    await logServerError(admin, {
+      organization_id: invite.organization_id,
+      user_id: user.id,
+      user_email: user.email,
+      context: "accept-invite",
+      action: "add_member",
+      error_message: memberErr.message,
+      metadata: { invite_token, role: invite.role },
+    });
     return json(500, { error: memberErr.message });
   }
 

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -155,6 +155,7 @@ const handler = async (event: any) => {
       duration_ms: durationMs,
       success,
       error_message: success ? null : errorMessage,
+      http_status: success ? null : upstreamStatus,
       estimated_cost_usd: success ? Number(estimateCost(model, inputTokens, outputTokens).toFixed(6)) : 0,
     });
   } catch (logErr) {

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -478,41 +478,57 @@ async function generateSustainabilityStatement(
     `;
   });
 
-  // Fire all calls in parallel
-  const [headerResp, ...topicResps] = await Promise.all([
-    ai.models.generateContent({
-      model,
-      contents: headerPrompt,
-      config: {
-        responseMimeType: "application/json",
-        responseSchema: {
-          type: Type.OBJECT,
-          properties: {
-            generalDisclosure: { type: Type.STRING },
-            strategyDisclosure: { type: Type.STRING },
-          },
+  const topicConfig = {
+    responseMimeType: "application/json",
+    responseSchema: {
+      type: Type.OBJECT,
+      properties: {
+        topicId: { type: Type.STRING },
+        topicName: { type: Type.STRING },
+        disclosureContent: { type: Type.STRING },
+      },
+    },
+  };
+
+  // Fire header and topic batches. Topics run in batches of 3 (sequential batches,
+  // parallel within each batch) to avoid Gemini rate limits and stay within the
+  // Netlify function timeout. Header fires concurrently with the first batch.
+  const BATCH_SIZE = 3;
+  const topicBatches: string[][] = [];
+  for (let i = 0; i < topicPrompts.length; i += BATCH_SIZE) {
+    topicBatches.push(topicPrompts.slice(i, i + BATCH_SIZE));
+  }
+
+  const headerRespPromise = ai.models.generateContent({
+    model,
+    contents: headerPrompt,
+    config: {
+      responseMimeType: "application/json",
+      responseSchema: {
+        type: Type.OBJECT,
+        properties: {
+          generalDisclosure: { type: Type.STRING },
+          strategyDisclosure: { type: Type.STRING },
         },
       },
-    }),
-    ...topicPrompts.map((prompt: string) =>
-      ai.models.generateContent({
-        model,
-        contents: prompt,
-        config: {
-          responseMimeType: "application/json",
-          responseSchema: {
-            type: Type.OBJECT,
-            properties: {
-              topicId: { type: Type.STRING },
-              topicName: { type: Type.STRING },
-              disclosureContent: { type: Type.STRING },
-            },
-          },
-        },
-      })
-    ),
-  ]);
+    },
+  });
 
+  const topicResps: any[] = [];
+  let firstBatch = true;
+  for (const batch of topicBatches) {
+    const batchCalls = batch.map((prompt: string) =>
+      ai.models.generateContent({ model, contents: prompt, config: topicConfig })
+    );
+    // Run header concurrently with the first topic batch
+    const results = firstBatch
+      ? (await Promise.all([headerRespPromise, ...batchCalls])).slice(1)
+      : await Promise.all(batchCalls);
+    topicResps.push(...results);
+    firstBatch = false;
+  }
+
+  const headerResp = await headerRespPromise;
   const header = JSON.parse(headerResp.text || "{}");
   const topics = topicResps.map((r: any) => JSON.parse(r.text || "{}"));
 

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -211,6 +211,18 @@ function extractTokens(response: any): { inputTokens: number; outputTokens: numb
   };
 }
 
+// Build a consistent company context block from a structured profile object.
+function buildCompanyContext(profile: any): string {
+  return [
+    `Company: ${profile.name} (${profile.industry}, ISIC: ${profile.isicCode})`,
+    `Scale: ${profile.employeeCount} employees, Revenue: ${profile.revenueRange}`,
+    `Description: ${profile.description}`,
+    `Mission: ${profile.mission}`,
+    `Vision: ${profile.vision}`,
+    `Key Products / Services: ${profile.productsServices}`,
+  ].join('\n');
+}
+
 // =============================================================
 // Action implementations
 // =============================================================
@@ -218,18 +230,18 @@ function extractTokens(response: any): { inputTokens: number; outputTokens: numb
 async function generateAssessmentSuggestions(
   ai: GoogleGenAI,
   model: string,
-  { companyDescription, topic }: any
+  { profile, topic }: any
 ) {
   const prompt = `
     Act as a senior sustainability consultant specializing in ESRS (European Sustainability Reporting Standards).
 
-    Analyze the following company: "${companyDescription}".
+    ${buildCompanyContext(profile)}
 
     For the ESRS Topic: "${topic}", provide:
     1. A summary of potential "Impacts" (Inside-out): How the company impacts people and the environment regarding this topic.
     2. A summary of potential "Risks & Opportunities" (Outside-in): How this sustainability matter triggers financial effects on the company.
 
-    Keep descriptions concise (under 50 words each) and specific to the industry.
+    Keep descriptions concise (under 50 words each) and specific to the company's industry and products/services.
   `;
 
   const response = await ai.models.generateContent({
@@ -256,19 +268,17 @@ async function generateAssessmentSuggestions(
 async function generateCanvasSuggestion(
   ai: GoogleGenAI,
   model: string,
-  { companyName, companyDescription, fieldLabel }: any
+  { profile, fieldLabel }: any
 ) {
   const prompt = `
     Act as a business strategy consultant specializing in Sustainable Business Model Canvas.
 
-    Context:
-    Company Name: "${companyName}"
-    Description: "${companyDescription}"
+    ${buildCompanyContext(profile)}
 
     Task:
     Suggest content for the "${fieldLabel}" block of the Business Model Canvas.
-    The suggestion should be specific to the industry, concise, and formatted as a list of key points (bullet points).
-    If the field is "Eco-Social Costs" or "Eco-Social Benefits", focus strictly on environmental and social externalities.
+    The suggestion should be specific to the company's industry and products/services, concise, and formatted as a list of key points (bullet points).
+    If the field is "Eco-Social Costs" or "Eco-Social Benefits", focus strictly on environmental and social externalities relevant to this company.
 
     Output plain text only.
   `;
@@ -283,20 +293,29 @@ async function generateCanvasSuggestion(
 async function generateSwotInternal(
   ai: GoogleGenAI,
   model: string,
-  { companyName, bmcData }: any
+  { profile, bmcData }: any
 ) {
   const prompt = `
     Act as a strategic business analyst.
 
-    Based on the following Business Model Canvas data for "${companyName}", suggest list of:
+    ${buildCompanyContext(profile)}
+
+    Based on the full Business Model Canvas data for "${profile.name}" below, suggest a list of:
     1. STRENGTHS (Internal positive factors)
     2. WEAKNESSES (Internal negative factors)
 
     BMC Data:
-    - Value Prop: ${bmcData.valueProposition}
-    - Key Resources: ${bmcData.keyResources}
+    - Value Proposition: ${bmcData.valueProposition}
+    - Key Partners: ${bmcData.keyPartners}
     - Key Activities: ${bmcData.keyActivities}
+    - Key Resources: ${bmcData.keyResources}
+    - Customer Relationships: ${bmcData.customerRelationships}
+    - Channels: ${bmcData.channels}
+    - Customer Segments: ${bmcData.customerSegments}
     - Cost Structure: ${bmcData.costStructure}
+    - Revenue Streams: ${bmcData.revenueStreams}
+    - Eco-Social Benefits: ${bmcData.ecoSocialBenefits}
+    - Eco-Social Costs: ${bmcData.ecoSocialCosts}
 
     Return the response in JSON format with keys "strengths" and "weaknesses".
     Provide bullet points using a hyphen (-).
@@ -326,12 +345,11 @@ async function generateSwotInternal(
 async function generateSwotExternal(
   ai: GoogleGenAI,
   model: string,
-  { companyName, companyDescription, type }: any
+  { profile, type }: any
 ) {
   const prompt = `
     Act as a market researcher. Search for recent news, market trends, and regulatory changes relevant to:
-    Company: "${companyName}"
-    Context: "${companyDescription}"
+    ${buildCompanyContext(profile)}
 
     Based on the search results, list the key ${type} (External factors) for this business.
     Focus on:
@@ -358,14 +376,14 @@ async function generateSwotExternal(
 async function generateKPISuggestions(
   ai: GoogleGenAI,
   model: string,
-  { companyDescription, perspective }: any
+  { profile, perspective }: any
 ) {
   const prompt = `
     Act as a Strategy Performance Manager using the Balanced Scorecard framework.
 
-    Company Context: "${companyDescription}"
+    ${buildCompanyContext(profile)}
 
-    Task: Suggest 3 strategic KPIs for the "${perspective}" perspective.
+    Task: Suggest 3 strategic KPIs for the "${perspective}" perspective aligned with the company's mission and vision.
 
     Format the response as a JSON Array of objects, where each object has:
     - name: KPI Name (Short title)
@@ -413,23 +431,25 @@ async function generateSustainabilityStatement(
     };
   }
 
+  const companyContext = buildCompanyContext(profile);
+
   const topicSummary = materialAssessments
-    .map((a: any) => `- ${a.topic}: impact: ${a.impactDescription}; financial: ${a.financialDescription}`)
+    .map((a: any) => `- ${a.topic} (impact score: ${a.impactMaterialityValue}/100, financial score: ${a.financialMaterialityValue}/100): impact: ${a.impactDescription}; financial: ${a.financialDescription}`)
     .join("\n");
 
   // ── Call 1: Header sections (fast — no per-topic content) ──────────────────
   const headerPrompt = `
     Act as a Sustainability Reporting Officer drafting a "Sustainability Statement" aligned with ESRS and GRI Standards.
 
-    Company: ${profile.name} (${profile.industry})
-    Mission: ${profile.mission}
-    Material topics identified:
+    ${companyContext}
+
+    Material topics identified (above threshold of 40/100 on either axis):
     ${topicSummary}
 
     Generate ONLY the two header sections below as JSON.
 
-    1. generalDisclosure: "Basis of Preparation" (ESRS 2 BP-1/BP-2). Explain the Double Materiality approach (impact materiality + financial materiality). ~120 words.
-    2. strategyDisclosure: "Strategy & Business Model" (ESRS 2 SBM-3). Summarise how the business model interacts with these material impacts and risks. ~150 words.
+    1. generalDisclosure: "Basis of Preparation" (ESRS 2 BP-1/BP-2). Explain the Double Materiality approach (impact materiality + financial materiality) as applied by this company. Reference the company's scale and sector. ~120 words.
+    2. strategyDisclosure: "Strategy & Business Model" (ESRS 2 SBM-3). Summarise how the company's specific products/services and business model interact with the material impacts and risks identified. ~150 words.
   `;
 
   // ── Calls 2…N: One call per topic (run in parallel) ────────────────────────
@@ -438,18 +458,19 @@ async function generateSustainabilityStatement(
     return `
       Act as a Sustainability Reporting Officer drafting topical disclosures aligned with ESRS and GRI Standards.
 
-      Company: ${profile.name} (${profile.industry})
+      ${companyContext}
+
       Topic: ${a.topic} (code: "${topicCode}")
-      Impact description: ${a.impactDescription}
-      Financial description: ${a.financialDescription}
+      Impact materiality score: ${a.impactMaterialityValue}/100 — ${a.impactDescription}
+      Financial materiality score: ${a.financialMaterialityValue}/100 — ${a.financialDescription}
 
       Write a structured narrative disclosure for this single topic as JSON with:
       - topicId: the short code only — "${topicCode}"
       - topicName: the full string — "${a.topic}"
       - disclosureContent: 200-300 word multi-paragraph narrative covering:
-          • Policies (ESRS MDR-P)
-          • Actions & Resources (MDR-A)
-          • Metrics & Targets (MDR-M)
+          • Policies (ESRS MDR-P) — reference the company's specific context
+          • Actions & Resources (MDR-A) — tie to the company's products/services and scale
+          • Metrics & Targets (MDR-M) — suggest targets appropriate for a ${profile.employeeCount}-scale company
         Reference the relevant GRI Standard number (e.g. GRI 305 for climate, GRI 303 for water).
         Use plain text with line breaks between paragraphs; no markdown.
     `;

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -390,6 +390,7 @@ async function generateKPISuggestions(
     - description: Why this is important for this company.
     - unit: Measurement unit (e.g., %, THB, #)
     - targetSuggestion: A placeholder target value (number) appropriate for an SME.
+    - frequency: How often this should be measured — one of "Monthly", "Quarterly", or "Annually".
   `;
 
   const response = await ai.models.generateContent({
@@ -406,6 +407,7 @@ async function generateKPISuggestions(
             description: { type: Type.STRING },
             unit: { type: Type.STRING },
             targetSuggestion: { type: Type.NUMBER },
+            frequency: { type: Type.STRING },
           },
         },
       },

--- a/netlify/functions/invite.ts
+++ b/netlify/functions/invite.ts
@@ -4,6 +4,26 @@ const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
 const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const appUrl = process.env.VITE_APP_URL || "http://localhost:8888";
 
+async function logServerError(
+  admin: any,
+  entry: {
+    organization_id?: string | null;
+    user_id?: string | null;
+    user_email?: string | null;
+    context: string;
+    action: string;
+    error_message: string;
+    http_status?: number | null;
+    metadata?: Record<string, unknown> | null;
+  }
+) {
+  try {
+    await admin.from("error_log").insert({ source: "server", ...entry });
+  } catch {
+    // best-effort
+  }
+}
+
 const json = (statusCode: number, body: unknown) => ({
   statusCode,
   headers: { "Content-Type": "application/json" },
@@ -31,7 +51,9 @@ async function sendInviteEmail(
   admin: any,
   email: string,
   inviteToken: string,
-  companyName: string
+  companyName: string,
+  organizationId?: string | null,
+  inviterId?: string | null,
 ): Promise<{ link: string | null }> {
   // Path 1 uses the full token URL so new users land with the token in the URL.
   // Paths 2 & 3 use the base URL only — auto-join is email-based so the token
@@ -40,6 +62,8 @@ async function sendInviteEmail(
   const redirectWithToken = `${appUrl}?invite_token=${inviteToken}`;
   const redirectBase = appUrl;
   const data = { company_name: companyName, app_name: "Aeternum Ally" };
+
+  const emailMetadata = { email, invite_token: inviteToken };
 
   // Path 1: new users — creates account + sends invite email via Supabase template.
   try {
@@ -82,6 +106,16 @@ async function sendInviteEmail(
   } catch (e: any) {
     console.warn("generateLink threw:", e?.message ?? e);
   }
+
+  // All email paths failed — log it so we can identify delivery problems.
+  await logServerError(admin, {
+    organization_id: organizationId,
+    user_id: inviterId,
+    context: "invite",
+    action: "send_email",
+    error_message: "All email delivery paths failed (inviteUserByEmail, signInWithOtp, generateLink)",
+    metadata: emailMetadata,
+  });
 
   return { link: null };
 }
@@ -132,7 +166,7 @@ const handler = async (event: any) => {
         .eq("organization_id", invite.organization_id)
         .maybeSingle();
       const companyName = profile?.name ?? "your team";
-      const { link } = await sendInviteEmail(admin, invite.email, invite.id, companyName);
+      const { link } = await sendInviteEmail(admin, invite.email, invite.id, companyName, invite.organization_id, null);
       void link;
     }
 
@@ -204,7 +238,7 @@ const handler = async (event: any) => {
       .maybeSingle();
     const companyName = profile?.name ?? "your team";
 
-    const { link } = await sendInviteEmail(admin, existingInvite.email, existingInvite.id, companyName);
+    const { link } = await sendInviteEmail(admin, existingInvite.email, existingInvite.id, companyName, organization_id, inviter.id);
 
     return json(200, {
       success: true,
@@ -252,6 +286,15 @@ const handler = async (event: any) => {
     .select()
     .single();
   if (insertErr || !invite) {
+    await logServerError(admin, {
+      organization_id,
+      user_id: inviter.id,
+      user_email: inviter.email,
+      context: "invite",
+      action: "create_invite",
+      error_message: insertErr?.message ?? "Failed to create invitation.",
+      metadata: { email: normalizedEmail, role },
+    });
     return json(500, { error: insertErr?.message ?? "Failed to create invitation." });
   }
 

--- a/services/errorLogService.ts
+++ b/services/errorLogService.ts
@@ -1,0 +1,42 @@
+import { supabase } from "../lib/supabaseClient";
+
+export interface ErrorLogEntry {
+  context: string;
+  action?: string;
+  error: unknown;
+  organizationId?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Log an application error to the error_log table.
+ * Never throws — logging must not break the caller's flow.
+ */
+export async function logError({
+  context,
+  action,
+  error,
+  organizationId,
+  metadata,
+}: ErrorLogEntry): Promise<void> {
+  try {
+    const message = error instanceof Error ? error.message : String(error);
+    const httpStatus: number | null = (error as any)?.status ?? null;
+
+    const { data: { user } } = await supabase.auth.getUser();
+
+    await supabase.from("error_log").insert({
+      organization_id: organizationId ?? null,
+      user_id: user?.id ?? null,
+      user_email: user?.email ?? null,
+      source: "client",
+      context,
+      action: action ?? null,
+      error_message: message,
+      http_status: httpStatus,
+      metadata: metadata ?? null,
+    });
+  } catch {
+    // Intentionally silent — logging failure must never surface to the user.
+  }
+}

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -105,11 +105,7 @@ export const generateKPISuggestions = async (
   profile: CompanyProfile,
   perspective: BSCPerspective
 ) => {
-  try {
-    return await callApi("generateKPISuggestions", { profile, perspective });
-  } catch (error) {
-    return [];
-  }
+  return await callApi("generateKPISuggestions", { profile, perspective });
 };
 
 export interface GeneratedStatement {

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -56,11 +56,11 @@ function errorMessage(error: unknown): string {
 }
 
 export const generateAssessmentSuggestions = async (
-  companyDescription: string,
+  profile: CompanyProfile,
   topic: ESRSTopic
 ) => {
   try {
-    return await callApi("generateAssessmentSuggestions", { companyDescription, topic });
+    return await callApi("generateAssessmentSuggestions", { profile, topic });
   } catch (error) {
     const msg = errorMessage(error);
     return { impactSuggestion: msg, financialSuggestion: msg };
@@ -68,23 +68,22 @@ export const generateAssessmentSuggestions = async (
 };
 
 export const generateCanvasSuggestion = async (
-  companyName: string,
-  companyDescription: string,
+  profile: CompanyProfile,
   fieldLabel: string
 ) => {
   try {
-    return await callApi("generateCanvasSuggestion", { companyName, companyDescription, fieldLabel });
+    return await callApi("generateCanvasSuggestion", { profile, fieldLabel });
   } catch (error) {
     return errorMessage(error);
   }
 };
 
 export const generateSwotInternal = async (
-  companyName: string,
+  profile: CompanyProfile,
   bmcData: SustainabilityBusinessModel
 ) => {
   try {
-    return await callApi("generateSwotInternal", { companyName, bmcData });
+    return await callApi("generateSwotInternal", { profile, bmcData });
   } catch (error) {
     const msg = errorMessage(error);
     return { strengths: msg, weaknesses: msg };
@@ -92,23 +91,22 @@ export const generateSwotInternal = async (
 };
 
 export const generateSwotExternal = async (
-  companyName: string,
-  companyDescription: string,
+  profile: CompanyProfile,
   type: "OPPORTUNITIES" | "THREATS"
 ) => {
   try {
-    return await callApi("generateSwotExternal", { companyName, companyDescription, type });
+    return await callApi("generateSwotExternal", { profile, type });
   } catch (error) {
     return errorMessage(error);
   }
 };
 
 export const generateKPISuggestions = async (
-  companyDescription: string,
+  profile: CompanyProfile,
   perspective: BSCPerspective
 ) => {
   try {
-    return await callApi("generateKPISuggestions", { companyDescription, perspective });
+    return await callApi("generateKPISuggestions", { profile, perspective });
   } catch (error) {
     return [];
   }

--- a/supabase/migrations/003_ai_usage_log_http_status.sql
+++ b/supabase/migrations/003_ai_usage_log_http_status.sql
@@ -1,0 +1,7 @@
+-- Add http_status to ai_usage_log so upstream error codes (503, 429, etc.)
+-- can be queried directly without string-matching error_message.
+ALTER TABLE ai_usage_log
+  ADD COLUMN http_status int;
+
+CREATE INDEX idx_ai_usage_status ON ai_usage_log (http_status)
+  WHERE http_status IS NOT NULL;

--- a/supabase/migrations/004_error_log.sql
+++ b/supabase/migrations/004_error_log.sql
@@ -1,0 +1,58 @@
+-- Centralised error log for server-side and client-side errors.
+--
+-- Key columns for troubleshooting:
+--   source   → 'server' (Netlify function) | 'client' (browser)
+--   context  → feature area: 'invite' | 'accept-invite' | 'db-save' | 'db-load'
+--              | 'member-management' | 'org-setup'
+--   action   → specific operation: 'send_email' | 'create_invite' | 'add_member'
+--              | 'save_canvas' | 'deactivate_member' | 'update_role' | etc.
+--   http_status → upstream HTTP code when applicable (503, 500, 404 …)
+--   metadata → jsonb bag for extra debugging context (table name, ids, etc.)
+--
+-- Useful queries:
+--
+--   -- All invite email failures in the last 7 days
+--   SELECT * FROM error_log
+--   WHERE context = 'invite' AND action = 'send_email'
+--     AND created_at > now() - interval '7 days'
+--   ORDER BY created_at DESC;
+--
+--   -- Orgs with repeated DB save failures
+--   SELECT organization_id, count(*) AS failures
+--   FROM error_log
+--   WHERE context = 'db-save'
+--   GROUP BY organization_id ORDER BY failures DESC;
+
+CREATE TABLE error_log (
+  id              uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid        REFERENCES organizations(id) ON DELETE SET NULL,
+  user_id         uuid        REFERENCES auth.users(id)   ON DELETE SET NULL,
+  user_email      text,
+  source          text        NOT NULL CHECK (source IN ('server', 'client')),
+  context         text        NOT NULL,
+  action          text,
+  error_message   text        NOT NULL,
+  http_status     int,
+  metadata        jsonb,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_error_log_org_date    ON error_log (organization_id, created_at DESC);
+CREATE INDEX idx_error_log_context     ON error_log (context, action);
+CREATE INDEX idx_error_log_created_at  ON error_log (created_at DESC);
+
+ALTER TABLE error_log ENABLE ROW LEVEL SECURITY;
+
+-- Owners and Admins can read their org's errors.
+CREATE POLICY "admins_read_errors" ON error_log
+  FOR SELECT USING (
+    organization_id IS NOT NULL
+    AND user_org_role(organization_id) IN ('Owner', 'Admin')
+  );
+
+-- Any authenticated user can insert their own errors.
+CREATE POLICY "users_insert_errors" ON error_log
+  FOR INSERT WITH CHECK (
+    user_id = auth.uid()
+    OR user_id IS NULL
+  );

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -292,11 +292,13 @@ CREATE TABLE ai_usage_log (
   duration_ms         int,
   success             boolean NOT NULL DEFAULT true,
   error_message       text,
+  http_status         int,
   estimated_cost_usd  numeric(12, 6),
   created_at          timestamptz NOT NULL DEFAULT now()
 );
 CREATE INDEX idx_ai_usage_org_date   ON ai_usage_log (organization_id, created_at DESC);
 CREATE INDEX idx_ai_usage_org_action ON ai_usage_log (organization_id, action);
+CREATE INDEX idx_ai_usage_status     ON ai_usage_log (http_status) WHERE http_status IS NOT NULL;
 
 ALTER TABLE ai_usage_log ENABLE ROW LEVEL SECURITY;
 CREATE POLICY "members_read_usage" ON ai_usage_log

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -305,6 +305,32 @@ CREATE POLICY "members_read_usage" ON ai_usage_log
   FOR SELECT USING (is_org_member(organization_id));
 -- (No INSERT/UPDATE/DELETE policies — only the server's service role can write)
 
+CREATE TABLE error_log (
+  id              uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id uuid        REFERENCES organizations(id) ON DELETE SET NULL,
+  user_id         uuid        REFERENCES auth.users(id)   ON DELETE SET NULL,
+  user_email      text,
+  source          text        NOT NULL CHECK (source IN ('server', 'client')),
+  context         text        NOT NULL,
+  action          text,
+  error_message   text        NOT NULL,
+  http_status     int,
+  metadata        jsonb,
+  created_at      timestamptz NOT NULL DEFAULT now()
+);
+CREATE INDEX idx_error_log_org_date    ON error_log (organization_id, created_at DESC);
+CREATE INDEX idx_error_log_context     ON error_log (context, action);
+CREATE INDEX idx_error_log_created_at  ON error_log (created_at DESC);
+
+ALTER TABLE error_log ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "admins_read_errors" ON error_log
+  FOR SELECT USING (
+    organization_id IS NOT NULL
+    AND user_org_role(organization_id) IN ('Owner', 'Admin')
+  );
+CREATE POLICY "users_insert_errors" ON error_log
+  FOR INSERT WITH CHECK (user_id = auth.uid() OR user_id IS NULL);
+
 -- ============================================================
 -- ATOMIC ORG CREATION RPC
 -- Bypasses RLS only for this scoped flow: a signed-in user


### PR DESCRIPTION
## Summary

- **Structured AI context**: All 5 Gemini prompt functions now accept a `CompanyProfile` object instead of fragile string props. Server-side `buildCompanyContext()` formats 6 fields (name, industry, ISIC, scale, description, mission, vision, products/services) into a consistent block for every prompt.
- **KPI AI Suggest fixed**: `generateKPISuggestions` now re-throws errors instead of silently returning `[]`; `KPIForm` shows inline error state and populates `frequency` from suggestions.
- **Sustainability Statement timeout fix**: Topic processing batched in groups of 3 (sequential batches) to stay within Netlify's function timeout. UI shows topic count + "may take up to 30 seconds" during generation.
- **Error observability**: Full `error_log` table (`migration 004`) capturing server-side and client-side errors with `source`, `context`, `action`, `http_status`, `metadata` columns.
  - Server: `invite.ts` logs all-email-paths-fail and invite DB insert errors; `accept-invite.ts` logs member insert errors
  - Client: `errorLogService.ts` silent logging service; hooked into `useOrgData` (db-load/db-save), `CompanyProfileForm` (member management — replaces `alert()` with inline errors), `OrgSetupScreen` (accept-invite, create-org)
- **`ai_usage_log` extended**: Added `http_status` column (migration 003) for clean querying of upstream API errors.

## Migrations to run in Supabase SQL Editor (in order)
1. `supabase/migrations/003_ai_usage_log_http_status.sql` — adds `http_status` to `ai_usage_log`
2. `supabase/migrations/004_error_log.sql` — creates `error_log` table with RLS

## Netlify dashboard action required
Set function timeout to **26 seconds**: Site settings → Functions → Timeout

## Test plan
- [ ] Invite a new user → email arrives; invite appears in pending list
- [ ] Resend invite → email arrives (or fallback link shown for existing Supabase users)
- [ ] Accept invite via email link → joins org correctly
- [ ] KPI form → AI Suggest populates name, description, unit, target, frequency
- [ ] KPI form → AI Suggest error (e.g. bad network) shows inline error message
- [ ] Sustainability Statement → generates without 504; shows topic count in button
- [ ] Company profile auto-save → saves correctly; save errors shown in UI
- [ ] Member deactivate/role change/cancel invite → errors shown inline (no browser alert)
- [ ] Verify `error_log` rows appear in Supabase after triggering a save error

🤖 Generated with [Claude Code](https://claude.com/claude-code)