### PR TITLE
fix: KPI AI Suggest missing description + restyle button

### DIFF
--- a/components/PerformanceDashboard.tsx
+++ b/components/PerformanceDashboard.tsx
@@ -309,7 +309,7 @@ const KPIForm: React.FC<KPIFormProps> = ({ initialData, onClose, onSave, profile
                                     type="button"
                                     onClick={handleAiSuggest}
                                     disabled={loadingAi}
-                                    className="text-xs bg-esg-100 text-esg-700 dark:bg-esg-900 dark:text-esg-300 px-2 py-1 rounded flex items-center gap-1 hover:bg-esg-200 disabled:opacity-50"
+                                    className="text-xs bg-esg-600 text-white px-3 py-1.5 rounded-lg flex items-center gap-1.5 hover:bg-esg-700 transition-colors font-medium shadow-sm disabled:opacity-50"
                                 >
                                     {loadingAi ? <Loader2 className="w-3 h-3 animate-spin" /> : <Settings className="w-3 h-3" />}
                                     {loadingAi ? 'Generating…' : 'AI Suggest'}

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -403,6 +403,7 @@ async function generateKPISuggestions(
         type: Type.ARRAY,
         items: {
           type: Type.OBJECT,
+          required: ["name", "description", "unit", "targetSuggestion", "frequency"],
           properties: {
             name: { type: Type.STRING },
             description: { type: Type.STRING },


### PR DESCRIPTION
## Summary

- **Description not populating**: Gemini's `responseSchema` for KPI suggestions was missing a `required` array, so Gemini could silently omit fields (description was the most common victim). Added `required: ["name", "description", "unit", "targetSuggestion", "frequency"]` to enforce all 5 fields.
- **Button style**: Restyled the AI Suggest button from the light teal outline (`bg-esg-100 text-esg-700`) to solid green matching the Save button (`bg-esg-600 text-white hover:bg-esg-700`).

## Test plan
- [ ] Open New KPI form, click AI Suggest → all fields populate including Description
- [ ] AI Suggest button appears solid green, matching Save button style

🤖 Generated with [Claude Code](https://claude.com/claude-code)