### PR TITLE
feat: expand layout to fill full width on large/zoomed-out screens

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -420,7 +420,7 @@ const App: React.FC = () => {
                         <button onClick={() => { setIsFormOpen(true); setEditingAssessment(null); }} className="bg-esg-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-esg-700 transition-colors shadow-lg shadow-esg-900/20 w-full sm:w-auto">
                           New Assessment
                         </button>
-                        <div className="mt-12 text-left max-w-5xl mx-auto">
+                        <div className="mt-12 text-left w-full">
                           <div className="flex justify-between items-center border-b border-slate-200 dark:border-slate-700 pb-4 mb-4">
                             <h3 className="font-bold text-slate-800 dark:text-white">Assessment History</h3>
                           </div>
@@ -434,7 +434,7 @@ const App: React.FC = () => {
                         </div>
                       </div>
                     ) : (
-                      <div className="max-w-3xl mx-auto">
+                      <div className="max-w-4xl mx-auto">
                         <AssessmentForm
                           profile={profile.data}
                           onSave={handleSaveAssessment}

--- a/components/BusinessModelCanvas.tsx
+++ b/components/BusinessModelCanvas.tsx
@@ -101,7 +101,7 @@ const BusinessModelCanvas: React.FC<Props> = ({ data, onChange, profile, saveSta
 
   // --- Render: Wizard View ---
   const renderWizard = () => (
-    <div className="max-w-4xl mx-auto">
+    <div className="max-w-5xl mx-auto">
       {/* Progress Bar */}
       <div className="mb-8">
         <div className="flex items-center justify-between text-sm font-medium text-slate-500 dark:text-slate-400 mb-2">

--- a/components/CompanyProfileForm.tsx
+++ b/components/CompanyProfileForm.tsx
@@ -43,7 +43,7 @@ const CompanyProfileForm: React.FC<Props> = ({
   const canManageTeam = currentUserRole === 'Owner' || currentUserRole === 'Admin';
 
   return (
-    <div className="max-w-5xl mx-auto animate-in fade-in duration-500">
+    <div className="w-full animate-in fade-in duration-500">
       <div className="flex flex-col sm:flex-row justify-between items-start mb-8 gap-4">
         <div>
           <h2 className="text-2xl font-bold text-slate-800 dark:text-white">Company Profile</h2>

--- a/components/PerformanceDashboard.tsx
+++ b/components/PerformanceDashboard.tsx
@@ -116,7 +116,7 @@ const StrategyMap: React.FC<{ kpis: KPI[], onEdit: (k: KPI) => void }> = ({ kpis
                                         No KPIs defined yet.
                                     </div>
                                 ) : (
-                                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-4">
                                         {pKpis.map(kpi => (
                                             <StrategyCard key={kpi.id} kpi={kpi} allKpis={kpis} onClick={() => onEdit(kpi)} />
                                         ))}

--- a/components/SustainabilityStatement.tsx
+++ b/components/SustainabilityStatement.tsx
@@ -46,7 +46,7 @@ const SustainabilityStatement: React.FC<Props> = ({ profile, assessments, canvas
   }
 
   return (
-    <div className="max-w-5xl mx-auto space-y-8 animate-in fade-in duration-500">
+    <div className="w-full space-y-8 animate-in fade-in duration-500">
       {error && (
         <div className="flex items-start gap-2 p-4 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-700 dark:text-red-300 print:hidden">
           <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />

--- a/components/SwotAnalysisWizard.tsx
+++ b/components/SwotAnalysisWizard.tsx
@@ -190,7 +190,7 @@ const SwotAnalysisWizard: React.FC<Props> = ({ data, onChange, profile, bmcData,
   );
 
   return (
-    <div className="max-w-5xl mx-auto">
+    <div className="w-full">
         {/* Responsive Stepper */}
         <div className="mb-8 flex items-center justify-center">
             <div className={`flex items-center ${step >= 0 ? 'text-indigo-600 dark:text-indigo-400' : 'text-slate-400'}`}>


### PR DESCRIPTION
## Summary

Removes fixed `max-w` constraints on all major content screens so the layout expands to use the full available window width when zoomed out or on high-resolution displays.

| Screen | Before | After |
|---|---|---|
| Company Profile | `max-w-5xl` (1024px) | `w-full` |
| SWOT Analysis | `max-w-5xl` (1024px) | `w-full` |
| Sustainability Statement (shell) | `max-w-5xl` (1024px) | `w-full` |
| Business Model Canvas (wizard) | `max-w-4xl` (896px) | `max-w-5xl` (1024px) |
| Assessments history list | `max-w-5xl` (1024px) | `w-full` |
| Assessment form | `max-w-3xl` (768px) | `max-w-4xl` (896px) |
| KPI map grid | 3 columns max | 4 columns at `2xl` |

**Not changed:** The sustainability report body (`max-w-4xl`) is intentionally kept narrow — long prose text should not span the full screen width.

## Test plan
- [ ] Company Profile — tabs and form grids expand on wide screen / zoomed out
- [ ] Business Model Canvas — canvas grid fills width; wizard is slightly wider
- [ ] SWOT Analysis — 2×2 grid fills width
- [ ] KPI Performance — BSC map shows 4 columns at ≥1536px viewport width
- [ ] Assessments — history list fills width; form is reasonably sized
- [ ] Sustainability Statement — outer shell expands but prose body stays readable

🤖 Generated with [Claude Code](https://claude.com/claude-code)