### PR TITLE
fix: log sustainability statement generation errors to error_log

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -447,7 +447,7 @@ const App: React.FC = () => {
                 )}
 
                 {view === 'report' && (
-                  <SustainabilityStatement profile={profile.data} assessments={assessments} canvas={canvas.data} />
+                  <SustainabilityStatement profile={profile.data} assessments={assessments} canvas={canvas.data} organizationId={organization.id} />
                 )}
               </>
             )}

--- a/components/SustainabilityStatement.tsx
+++ b/components/SustainabilityStatement.tsx
@@ -3,15 +3,17 @@ import React, { useState } from 'react';
 import { CompanyProfile, AssessmentData, SustainabilityBusinessModel } from '../types';
 import { GRI_MAPPING } from '../constants';
 import { generateSustainabilityStatement, GeneratedStatement } from '../services/geminiService';
+import { logError } from '../services/errorLogService';
 import { FileText, Download, Loader2, Book, RefreshCw, ShieldCheck, AlertCircle } from 'lucide-react';
 
 interface Props {
   profile: CompanyProfile;
   assessments: AssessmentData[];
   canvas: SustainabilityBusinessModel;
+  organizationId: string;
 }
 
-const SustainabilityStatement: React.FC<Props> = ({ profile, assessments, canvas }) => {
+const SustainabilityStatement: React.FC<Props> = ({ profile, assessments, canvas, organizationId }) => {
   const [generatedContent, setGeneratedContent] = useState<GeneratedStatement | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -25,7 +27,15 @@ const SustainabilityStatement: React.FC<Props> = ({ profile, assessments, canvas
       const result = await generateSustainabilityStatement(profile, materialTopics);
       setGeneratedContent(result);
     } catch (e: any) {
-      setError(e?.message ?? 'Failed to generate the report. Please try again.');
+      const msg = e?.message ?? 'Failed to generate the report. Please try again.';
+      setError(msg);
+      logError({
+        context: 'sustainability-statement',
+        action: 'generate_report',
+        error: e,
+        organizationId,
+        metadata: { topic_count: materialTopics.length },
+      });
     } finally {
       setLoading(false);
     }


### PR DESCRIPTION
## Problem

When the Sustainability Statement generation fails with a 504 (or any other error), nothing was written to `error_log`. Two reasons:
1. `SustainabilityStatement.tsx` caught errors but never called `logError`
2. 504s come from Netlify timing out *before* `api.ts` runs, so the server-side logging in the function never fires — the client is the only place this can be captured

## Fix

- Add `organizationId` prop to `SustainabilityStatement`
- Call `logError` in the catch block with `context = 'sustainability-statement'`, `action = 'generate_report'`, and `metadata.topic_count`
- Pass `organization.id` from `App.tsx`

After this fix, errors will appear in `error_log` and can be queried:
```sql
SELECT * FROM error_log
WHERE context = 'sustainability-statement'
ORDER BY created_at DESC;
```

## Test plan
- [ ] Trigger a generation failure (e.g. disconnect network) — row appears in `error_log`
- [ ] Successful generation — no error row written
- [ ] `topic_count` in metadata matches the number of material topics

🤖 Generated with [Claude Code](https://claude.com/claude-code)