### PR TITLE
#01 Migration: BMC and SWOT Fields to JSONB Arrays

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -26,18 +26,21 @@ import { Plus, FileText, BarChart3, CheckCircle, AlertTriangle, Grid, Moon, Sun,
 
 const DEFAULT_PROFILE: CompanyProfile = {
   name: '', taxId: '', industry: '', isicCode: '', foundingYear: '',
-  website: '', address: '', employeeCount: '', revenueRange: '',
+  website: '',
+  addressStreet: '', addressCity: '', addressState: '', addressPostalCode: '', addressCountry: '',
+  contactEmail: '', contactPhone: '',
+  employeeCount: '', revenueRange: '',
   description: '', mission: '', vision: '', productsServices: '',
 };
 
 const DEFAULT_CANVAS: SustainabilityBusinessModel = {
-  keyPartners: '', keyActivities: '', keyResources: '', valueProposition: '',
-  customerRelationships: '', channels: '', customerSegments: '',
-  costStructure: '', revenueStreams: '', ecoSocialCosts: '', ecoSocialBenefits: '',
+  keyPartners: [], keyActivities: [], keyResources: [], valueProposition: [],
+  customerRelationships: [], channels: [], customerSegments: [],
+  costStructure: [], revenueStreams: [], ecoSocialCosts: [], ecoSocialBenefits: [],
 };
 
 const DEFAULT_SWOT: SwotAnalysis = {
-  strengths: '', weaknesses: '', opportunities: '', threats: '',
+  strengths: [], weaknesses: [], opportunities: [], threats: [],
 };
 
 const App: React.FC = () => {

--- a/components/BusinessModelCanvas.tsx
+++ b/components/BusinessModelCanvas.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState } from 'react';
 import { SustainabilityBusinessModel, CompanyProfile } from '../types';
-import { Info, Wand2, ArrowRight, ArrowLeft, Grid, Check, Loader2, PlayCircle } from 'lucide-react';
+import { Info, Wand2, ArrowRight, ArrowLeft, Grid, Check, Loader2, PlayCircle, Plus, X } from 'lucide-react';
 import { generateCanvasSuggestion } from '../services/geminiService';
 import SaveIndicator from './SaveIndicator';
 import type { SaveStatus } from '../hooks/useOrgData';
@@ -74,6 +74,69 @@ const WIZARD_STEPS: Step[] = [
   }
 ];
 
+// ── Shared array editor (wizard view — spacious) ──────────────────────────────
+
+interface ArrayFieldEditorProps {
+  items: string[];
+  onChange: (items: string[]) => void;
+  placeholder?: string;
+}
+
+const ArrayFieldEditor: React.FC<ArrayFieldEditorProps> = ({ items, onChange, placeholder }) => {
+  const [draft, setDraft] = useState('');
+
+  const addItem = () => {
+    const trimmed = draft.trim();
+    if (!trimmed) return;
+    onChange([...items, trimmed]);
+    setDraft('');
+  };
+
+  const removeItem = (index: number) => {
+    onChange(items.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className="border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-950 focus-within:border-esg-400 transition-colors">
+      <ul className="p-3 space-y-2 min-h-[80px] max-h-56 overflow-y-auto">
+        {items.map((item, i) => (
+          <li key={i} className="flex items-center gap-2 group">
+            <span className="text-slate-300 dark:text-slate-600 text-sm flex-shrink-0">•</span>
+            <span className="flex-1 text-sm text-slate-700 dark:text-slate-200">{item}</span>
+            <button
+              onClick={() => removeItem(i)}
+              className="opacity-0 group-hover:opacity-100 text-slate-300 hover:text-red-500 dark:text-slate-600 dark:hover:text-red-400 transition-opacity p-0.5 rounded flex-shrink-0"
+            >
+              <X className="w-3 h-3" />
+            </button>
+          </li>
+        ))}
+        {items.length === 0 && (
+          <li className="text-sm text-slate-300 dark:text-slate-600 italic py-1">No items yet — add one below.</li>
+        )}
+      </ul>
+      <div className="border-t border-slate-100 dark:border-slate-700 p-2 flex gap-2">
+        <input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addItem(); } }}
+          placeholder={placeholder || 'Add item and press Enter…'}
+          className="flex-1 text-sm px-3 py-1.5 rounded-md border border-slate-200 dark:border-slate-600 bg-transparent text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-500 focus:outline-none focus:border-esg-400"
+        />
+        <button
+          onClick={addItem}
+          disabled={!draft.trim()}
+          className="text-sm px-3 py-1.5 bg-esg-600 text-white rounded-md hover:bg-esg-700 disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-1 transition-colors"
+        >
+          <Plus className="w-3 h-3" /> Add
+        </button>
+      </div>
+    </div>
+  );
+};
+
+// ── Main component ────────────────────────────────────────────────────────────
+
 const BusinessModelCanvas: React.FC<Props> = ({ data, onChange, profile, saveStatus, isDirty, onSave, saveError }) => {
   const [mode, setMode] = useState<'grid' | 'wizard'>('wizard');
   const [currentStepIndex, setCurrentStepIndex] = useState(0);
@@ -83,18 +146,17 @@ const BusinessModelCanvas: React.FC<Props> = ({ data, onChange, profile, saveSta
   const isFirstStep = currentStepIndex === 0;
   const isLastStep = currentStepIndex === WIZARD_STEPS.length - 1;
 
-  const handleChange = (field: CanvasField, value: string) => {
+  const handleChange = (field: CanvasField, value: string[]) => {
     onChange({ ...data, [field]: value });
   };
 
   const handleAiSuggest = async (field: CanvasField, label: string) => {
     setLoadingField(field);
     const suggestion = await generateCanvasSuggestion(profile, label);
-    if (suggestion) {
-      // Append if not empty, or replace if empty
-      const currentVal = data[field];
-      const newVal = currentVal ? `${currentVal}\n\n--- AI Suggestion ---\n${suggestion}` : suggestion;
-      handleChange(field, newVal);
+    if (suggestion.length > 0) {
+      const existing = data[field];
+      const merged = [...existing, ...suggestion.filter(s => !existing.includes(s))];
+      handleChange(field, merged);
     }
     setLoadingField(null);
   };
@@ -109,7 +171,7 @@ const BusinessModelCanvas: React.FC<Props> = ({ data, onChange, profile, saveSta
           <span>{Math.round(((currentStepIndex + 1) / WIZARD_STEPS.length) * 100)}% Completed</span>
         </div>
         <div className="w-full bg-slate-200 dark:bg-slate-700 rounded-full h-2">
-          <div 
+          <div
             className="bg-esg-600 h-2 rounded-full transition-all duration-500 ease-in-out"
             style={{ width: `${((currentStepIndex + 1) / WIZARD_STEPS.length) * 100}%` }}
           />
@@ -139,12 +201,11 @@ const BusinessModelCanvas: React.FC<Props> = ({ data, onChange, profile, saveSta
                   AI Suggest
                 </button>
               </div>
-              
-              <textarea
-                value={data[field.key]}
-                onChange={(e) => handleChange(field.key, e.target.value)}
-                className="w-full p-4 border border-slate-300 dark:border-slate-600 rounded-lg h-32 focus:ring-2 focus:ring-esg-500 focus:border-esg-500 transition-all text-sm leading-relaxed bg-white dark:bg-slate-950 text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-500"
-                placeholder={`Enter details for ${field.label}...`}
+
+              <ArrayFieldEditor
+                items={data[field.key]}
+                onChange={(items) => handleChange(field.key, items)}
+                placeholder={`Add ${field.label} item and press Enter…`}
               />
               <p className="text-xs text-slate-400 dark:text-slate-500 flex items-center gap-1">
                 <Info className="w-3 h-3" /> {field.hint}
@@ -167,12 +228,12 @@ const BusinessModelCanvas: React.FC<Props> = ({ data, onChange, profile, saveSta
         </button>
 
         {isLastStep ? (
-           <button
-           onClick={() => setMode('grid')}
-           className="flex items-center gap-2 bg-esg-600 text-white px-6 py-2 md:px-8 md:py-3 rounded-lg font-bold hover:bg-esg-700 shadow-lg shadow-esg-600/20 transition-all text-sm md:text-base"
-         >
-           Finish & View Canvas <Check className="w-5 h-5" />
-         </button>
+          <button
+            onClick={() => setMode('grid')}
+            className="flex items-center gap-2 bg-esg-600 text-white px-6 py-2 md:px-8 md:py-3 rounded-lg font-bold hover:bg-esg-700 shadow-lg shadow-esg-600/20 transition-all text-sm md:text-base"
+          >
+            Finish & View Canvas <Check className="w-5 h-5" />
+          </button>
         ) : (
           <button
             onClick={() => setCurrentStepIndex(prev => Math.min(WIZARD_STEPS.length - 1, prev + 1))}
@@ -185,128 +246,121 @@ const BusinessModelCanvas: React.FC<Props> = ({ data, onChange, profile, saveSta
     </div>
   );
 
-  // --- Render: Grid View (Original) ---
+  // --- Render: Grid View ---
   const renderGrid = () => (
     <div className="animate-in fade-in duration-500">
       <div className="bg-white dark:bg-slate-800 p-1 rounded-xl shadow-sm border border-slate-200 dark:border-slate-700 overflow-hidden transition-colors">
-        {/* Top Section: The Business Logic */}
-        {/* Responsive: Flex column on mobile, grid on desktop */}
+        {/* Top Section */}
         <div className="flex flex-col md:grid md:grid-cols-5 divide-y md:divide-y-0 md:divide-x divide-slate-200 dark:divide-slate-700">
-            
-            {/* Column 1: Upstream */}
-            <div className="flex flex-col divide-y divide-slate-200 dark:divide-slate-700">
-                <CanvasCard 
-                    title="Key Partners" 
-                    hint="Suppliers, NGOs, Gov bodies"
-                    value={data.keyPartners} 
-                    onChange={(v) => handleChange('keyPartners', v)} 
-                    className="h-auto md:h-full min-h-[160px]"
-                />
-            </div>
+          <div className="flex flex-col divide-y divide-slate-200 dark:divide-slate-700">
+            <CanvasCard
+              title="Key Partners"
+              hint="Suppliers, NGOs, Gov bodies"
+              value={data.keyPartners}
+              onChange={(v) => handleChange('keyPartners', v)}
+              className="h-auto md:h-full min-h-[160px]"
+            />
+          </div>
 
-            {/* Column 2: Activities & Resources */}
-            <div className="flex flex-col divide-y divide-slate-200 dark:divide-slate-700">
-                <CanvasCard 
-                    title="Key Activities" 
-                    hint="Production, Problem solving, Network"
-                    value={data.keyActivities} 
-                    onChange={(v) => handleChange('keyActivities', v)} 
-                    className="h-auto md:h-1/2 min-h-[160px]"
-                />
-                <CanvasCard 
-                    title="Key Resources" 
-                    hint="Physical, Intellectual, Human, Financial"
-                    value={data.keyResources} 
-                    onChange={(v) => handleChange('keyResources', v)} 
-                    className="h-auto md:h-1/2 min-h-[160px]"
-                />
-            </div>
+          <div className="flex flex-col divide-y divide-slate-200 dark:divide-slate-700">
+            <CanvasCard
+              title="Key Activities"
+              hint="Production, Problem solving, Network"
+              value={data.keyActivities}
+              onChange={(v) => handleChange('keyActivities', v)}
+              className="h-auto md:h-1/2 min-h-[160px]"
+            />
+            <CanvasCard
+              title="Key Resources"
+              hint="Physical, Intellectual, Human, Financial"
+              value={data.keyResources}
+              onChange={(v) => handleChange('keyResources', v)}
+              className="h-auto md:h-1/2 min-h-[160px]"
+            />
+          </div>
 
-            {/* Column 3: Value Proposition (Center) */}
-            <div className="flex flex-col">
-                <CanvasCard 
-                    title="Value Propositions" 
-                    hint="Product/Service value + Social/Eco value"
-                    value={data.valueProposition} 
-                    onChange={(v) => handleChange('valueProposition', v)} 
-                    className="h-auto md:h-full min-h-[200px] bg-esg-50/50 dark:bg-esg-900/10"
-                />
-            </div>
+          <div className="flex flex-col">
+            <CanvasCard
+              title="Value Propositions"
+              hint="Product/Service value + Social/Eco value"
+              value={data.valueProposition}
+              onChange={(v) => handleChange('valueProposition', v)}
+              className="h-auto md:h-full min-h-[200px] bg-esg-50/50 dark:bg-esg-900/10"
+            />
+          </div>
 
-            {/* Column 4: Relationships & Channels */}
-            <div className="flex flex-col divide-y divide-slate-200 dark:divide-slate-700">
-                <CanvasCard 
-                    title="Customer Relationships" 
-                    hint="Personal assistance, Automated, Communities"
-                    value={data.customerRelationships} 
-                    onChange={(v) => handleChange('customerRelationships', v)} 
-                    className="h-auto md:h-1/2 min-h-[160px]"
-                />
-                <CanvasCard 
-                    title="Channels" 
-                    hint="Awareness, Evaluation, Purchase, Delivery, After-sales"
-                    value={data.channels} 
-                    onChange={(v) => handleChange('channels', v)} 
-                    className="h-auto md:h-1/2 min-h-[160px]"
-                />
-            </div>
+          <div className="flex flex-col divide-y divide-slate-200 dark:divide-slate-700">
+            <CanvasCard
+              title="Customer Relationships"
+              hint="Personal assistance, Automated, Communities"
+              value={data.customerRelationships}
+              onChange={(v) => handleChange('customerRelationships', v)}
+              className="h-auto md:h-1/2 min-h-[160px]"
+            />
+            <CanvasCard
+              title="Channels"
+              hint="Awareness, Evaluation, Purchase, Delivery, After-sales"
+              value={data.channels}
+              onChange={(v) => handleChange('channels', v)}
+              className="h-auto md:h-1/2 min-h-[160px]"
+            />
+          </div>
 
-             {/* Column 5: Segments */}
-             <div className="flex flex-col">
-                <CanvasCard 
-                    title="Customer Segments" 
-                    hint="Mass market, Niche, Segmented, Diversified"
-                    value={data.customerSegments} 
-                    onChange={(v) => handleChange('customerSegments', v)} 
-                    className="h-auto md:h-full min-h-[160px]"
-                />
-            </div>
+          <div className="flex flex-col">
+            <CanvasCard
+              title="Customer Segments"
+              hint="Mass market, Niche, Segmented, Diversified"
+              value={data.customerSegments}
+              onChange={(v) => handleChange('customerSegments', v)}
+              className="h-auto md:h-full min-h-[160px]"
+            />
+          </div>
         </div>
 
-        {/* Bottom Section: Financials & Impact */}
+        {/* Bottom Section: Financials */}
         <div className="border-t border-slate-200 dark:border-slate-700">
-            <div className="flex flex-col md:grid md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-slate-200 dark:divide-slate-700">
-                <CanvasCard 
-                    title="Cost Structure" 
-                    hint="Fixed costs, Variable costs, Economies of scale"
-                    value={data.costStructure} 
-                    onChange={(v) => handleChange('costStructure', v)} 
-                    className="h-auto md:h-32 min-h-[140px]"
-                    height=""
-                />
-                <CanvasCard 
-                    title="Revenue Streams" 
-                    hint="Asset sale, Usage fee, Subscription, Licensing"
-                    value={data.revenueStreams} 
-                    onChange={(v) => handleChange('revenueStreams', v)} 
-                    className="h-auto md:h-32 min-h-[140px]"
-                    height=""
-                />
-            </div>
+          <div className="flex flex-col md:grid md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-slate-200 dark:divide-slate-700">
+            <CanvasCard
+              title="Cost Structure"
+              hint="Fixed costs, Variable costs, Economies of scale"
+              value={data.costStructure}
+              onChange={(v) => handleChange('costStructure', v)}
+              className="h-auto md:h-32 min-h-[140px]"
+              height=""
+            />
+            <CanvasCard
+              title="Revenue Streams"
+              hint="Asset sale, Usage fee, Subscription, Licensing"
+              value={data.revenueStreams}
+              onChange={(v) => handleChange('revenueStreams', v)}
+              className="h-auto md:h-32 min-h-[140px]"
+              height=""
+            />
+          </div>
         </div>
-        
+
         {/* Sustainability Layer */}
         <div className="border-t border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/50">
-             <div className="flex flex-col md:grid md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-slate-200 dark:divide-slate-700">
-                <CanvasCard 
-                    title="Eco-Social Costs" 
-                    hint="Pollution, Waste, Social stress (Negative externalities)"
-                    value={data.ecoSocialCosts} 
-                    onChange={(v) => handleChange('ecoSocialCosts', v)} 
-                    className="h-auto md:h-32 min-h-[140px]"
-                    height=""
-                    headerColor="text-red-600 dark:text-red-400"
-                />
-                <CanvasCard 
-                    title="Eco-Social Benefits" 
-                    hint="Carbon reduction, Community dev, Wellbeing (Positive externalities)"
-                    value={data.ecoSocialBenefits} 
-                    onChange={(v) => handleChange('ecoSocialBenefits', v)} 
-                    className="h-auto md:h-32 min-h-[140px]"
-                    height=""
-                    headerColor="text-esg-600 dark:text-esg-400"
-                />
-            </div>
+          <div className="flex flex-col md:grid md:grid-cols-2 divide-y md:divide-y-0 md:divide-x divide-slate-200 dark:divide-slate-700">
+            <CanvasCard
+              title="Eco-Social Costs"
+              hint="Pollution, Waste, Social stress (Negative externalities)"
+              value={data.ecoSocialCosts}
+              onChange={(v) => handleChange('ecoSocialCosts', v)}
+              className="h-auto md:h-32 min-h-[140px]"
+              height=""
+              headerColor="text-red-600 dark:text-red-400"
+            />
+            <CanvasCard
+              title="Eco-Social Benefits"
+              hint="Carbon reduction, Community dev, Wellbeing (Positive externalities)"
+              value={data.ecoSocialBenefits}
+              onChange={(v) => handleChange('ecoSocialBenefits', v)}
+              className="h-auto md:h-32 min-h-[140px]"
+              height=""
+              headerColor="text-esg-600 dark:text-esg-400"
+            />
+          </div>
         </div>
       </div>
     </div>
@@ -316,25 +370,25 @@ const BusinessModelCanvas: React.FC<Props> = ({ data, onChange, profile, saveSta
     <div className="space-y-6">
       <div className="flex flex-col md:flex-row justify-between items-start md:items-center gap-4">
         <div>
-            <h2 className="text-2xl font-bold text-slate-800 dark:text-white">Sustainability Business Model Canvas</h2>
-            <p className="text-slate-500 dark:text-slate-400 text-sm mt-1">Define your business logic including economic, environmental, and social layers.</p>
+          <h2 className="text-2xl font-bold text-slate-800 dark:text-white">Sustainability Business Model Canvas</h2>
+          <p className="text-slate-500 dark:text-slate-400 text-sm mt-1">Define your business logic including economic, environmental, and social layers.</p>
         </div>
         <div className="flex gap-2 w-full md:w-auto justify-between md:justify-end">
-             <div className="bg-slate-100 dark:bg-slate-700 p-1 rounded-lg flex text-sm font-medium">
-                <button 
-                    onClick={() => setMode('wizard')} 
-                    className={`px-3 py-1.5 rounded-md flex items-center gap-2 transition-all ${mode === 'wizard' ? 'bg-white dark:bg-slate-600 shadow text-slate-800 dark:text-white' : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200'}`}
-                >
-                    <PlayCircle className="w-4 h-4" /> <span className="hidden sm:inline">Wizard</span>
-                </button>
-                <button 
-                    onClick={() => setMode('grid')} 
-                    className={`px-3 py-1.5 rounded-md flex items-center gap-2 transition-all ${mode === 'grid' ? 'bg-white dark:bg-slate-600 shadow text-slate-800 dark:text-white' : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200'}`}
-                >
-                    <Grid className="w-4 h-4" /> <span className="hidden sm:inline">Canvas</span>
-                </button>
-             </div>
-             <SaveIndicator status={saveStatus} isDirty={isDirty} onSave={onSave} errorMessage={saveError} />
+          <div className="bg-slate-100 dark:bg-slate-700 p-1 rounded-lg flex text-sm font-medium">
+            <button
+              onClick={() => setMode('wizard')}
+              className={`px-3 py-1.5 rounded-md flex items-center gap-2 transition-all ${mode === 'wizard' ? 'bg-white dark:bg-slate-600 shadow text-slate-800 dark:text-white' : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200'}`}
+            >
+              <PlayCircle className="w-4 h-4" /> <span className="hidden sm:inline">Wizard</span>
+            </button>
+            <button
+              onClick={() => setMode('grid')}
+              className={`px-3 py-1.5 rounded-md flex items-center gap-2 transition-all ${mode === 'grid' ? 'bg-white dark:bg-slate-600 shadow text-slate-800 dark:text-white' : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200'}`}
+            >
+              <Grid className="w-4 h-4" /> <span className="hidden sm:inline">Canvas</span>
+            </button>
+          </div>
+          <SaveIndicator status={saveStatus} isDirty={isDirty} onSave={onSave} errorMessage={saveError} />
         </div>
       </div>
 
@@ -343,36 +397,85 @@ const BusinessModelCanvas: React.FC<Props> = ({ data, onChange, profile, saveSta
   );
 };
 
+// ── Compact card for grid view ────────────────────────────────────────────────
+
 interface CardProps {
   title: string;
-  value: string;
-  onChange: (val: string) => void;
+  value: string[];
+  onChange: (val: string[]) => void;
   hint?: string;
   className?: string;
   height?: string;
   headerColor?: string;
 }
 
-const CanvasCard: React.FC<CardProps> = ({ title, value, onChange, hint, className = '', height = 'h-full', headerColor = 'text-slate-700 dark:text-slate-300' }) => (
-  <div className={`p-4 ${className} ${height} flex flex-col group`}>
-    <div className="flex justify-between items-center mb-2">
-        <h3 className={`font-bold text-sm uppercase tracking-wide ${headerColor}`}>{title}</h3>
+const CanvasCard: React.FC<CardProps> = ({
+  title, value, onChange, hint,
+  className = '', height = 'h-full',
+  headerColor = 'text-slate-700 dark:text-slate-300'
+}) => {
+  const [draft, setDraft] = useState('');
+
+  const addItem = () => {
+    const trimmed = draft.trim();
+    if (!trimmed) return;
+    onChange([...value, trimmed]);
+    setDraft('');
+  };
+
+  const removeItem = (index: number) => {
+    onChange(value.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className={`p-3 ${className} ${height} flex flex-col`}>
+      <div className="flex justify-between items-center mb-2">
+        <h3 className={`font-bold text-xs uppercase tracking-wide ${headerColor}`}>{title}</h3>
         {hint && (
-            <div className="relative group/tooltip">
-                <Info className="w-3 h-3 text-slate-300 dark:text-slate-600 cursor-help" />
-                <div className="absolute right-0 top-4 w-48 bg-slate-800 text-white text-xs p-2 rounded shadow-lg opacity-0 group-hover/tooltip:opacity-100 transition-opacity pointer-events-none z-10 hidden md:block">
-                    {hint}
-                </div>
+          <div className="relative group/tooltip">
+            <Info className="w-3 h-3 text-slate-300 dark:text-slate-600 cursor-help" />
+            <div className="absolute right-0 top-4 w-48 bg-slate-800 text-white text-xs p-2 rounded shadow-lg opacity-0 group-hover/tooltip:opacity-100 transition-opacity pointer-events-none z-10 hidden md:block">
+              {hint}
             </div>
+          </div>
         )}
+      </div>
+
+      <ul className="flex-1 space-y-1 overflow-y-auto min-h-[40px] mb-2">
+        {value.map((item, i) => (
+          <li key={i} className="flex items-start gap-1 group/item">
+            <span className="text-slate-300 dark:text-slate-600 text-xs mt-0.5 flex-shrink-0">•</span>
+            <span className="flex-1 text-xs text-slate-600 dark:text-slate-300 leading-relaxed">{item}</span>
+            <button
+              onClick={() => removeItem(i)}
+              className="opacity-0 group-hover/item:opacity-100 text-slate-300 hover:text-red-400 dark:text-slate-600 dark:hover:text-red-400 flex-shrink-0 transition-opacity ml-0.5"
+            >
+              <X className="w-3 h-3" />
+            </button>
+          </li>
+        ))}
+        {value.length === 0 && (
+          <li className="text-xs text-slate-300 dark:text-slate-600 italic">None added</li>
+        )}
+      </ul>
+
+      <div className="flex gap-1">
+        <input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addItem(); } }}
+          placeholder="Add…"
+          className="flex-1 text-xs p-1.5 border border-slate-200 dark:border-slate-600 rounded bg-white dark:bg-slate-950 text-slate-900 dark:text-white placeholder-slate-300 dark:placeholder-slate-600 focus:outline-none focus:border-esg-400"
+        />
+        <button
+          onClick={addItem}
+          className="text-xs px-2 bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 rounded hover:bg-esg-50 hover:text-esg-600 dark:hover:bg-esg-900/20 dark:hover:text-esg-400 transition-colors"
+        >
+          +
+        </button>
+      </div>
     </div>
-    <textarea 
-      value={value}
-      onChange={(e) => onChange(e.target.value)}
-      className="w-full flex-1 resize-none text-sm text-slate-600 dark:text-slate-300 bg-transparent border border-transparent hover:border-slate-200 dark:hover:border-slate-600 focus:border-esg-400 focus:bg-white dark:focus:bg-slate-950 dark:focus:text-white focus:ring-0 rounded p-1 transition-all placeholder-slate-300 dark:placeholder-slate-600 min-h-[60px]"
-      placeholder={`Define ${title}...`}
-    />
-  </div>
-);
+  );
+};
 
 export default BusinessModelCanvas;

--- a/components/SwotAnalysisWizard.tsx
+++ b/components/SwotAnalysisWizard.tsx
@@ -2,7 +2,7 @@
 import React, { useState } from 'react';
 import { SwotAnalysis, SustainabilityBusinessModel, CompanyProfile } from '../types';
 import { generateSwotInternal, generateSwotExternal } from '../services/geminiService';
-import { ArrowRight, ArrowLeft, Loader2, Globe, ShieldAlert, TrendingUp, Zap, AlertTriangle } from 'lucide-react';
+import { ArrowRight, ArrowLeft, Loader2, Globe, ShieldAlert, TrendingUp, Zap, AlertTriangle, Plus, X } from 'lucide-react';
 import SaveIndicator from './SaveIndicator';
 import type { SaveStatus } from '../hooks/useOrgData';
 
@@ -17,29 +17,92 @@ interface Props {
   saveError?: string | null;
 }
 
+// ── Shared array editor ───────────────────────────────────────────────────────
+
+interface ArrayFieldEditorProps {
+  items: string[];
+  onChange: (items: string[]) => void;
+  placeholder?: string;
+  focusRingColor?: string;
+}
+
+const ArrayFieldEditor: React.FC<ArrayFieldEditorProps> = ({
+  items, onChange, placeholder, focusRingColor = 'focus:ring-indigo-500'
+}) => {
+  const [draft, setDraft] = useState('');
+
+  const addItem = () => {
+    const trimmed = draft.trim();
+    if (!trimmed) return;
+    onChange([...items, trimmed]);
+    setDraft('');
+  };
+
+  const removeItem = (index: number) => {
+    onChange(items.filter((_, i) => i !== index));
+  };
+
+  return (
+    <div className={`border border-slate-300 dark:border-slate-600 rounded-xl bg-white dark:bg-slate-950 focus-within:ring-2 ${focusRingColor} transition-all`}>
+      <ul className="p-4 space-y-2 min-h-[100px] max-h-52 overflow-y-auto">
+        {items.map((item, i) => (
+          <li key={i} className="flex items-center gap-2 group">
+            <span className="text-slate-300 dark:text-slate-600 text-sm flex-shrink-0">•</span>
+            <span className="flex-1 text-sm text-slate-700 dark:text-slate-200">{item}</span>
+            <button
+              onClick={() => removeItem(i)}
+              className="opacity-0 group-hover:opacity-100 text-slate-300 hover:text-red-500 dark:text-slate-600 dark:hover:text-red-400 transition-opacity p-0.5 rounded flex-shrink-0"
+            >
+              <X className="w-3 h-3" />
+            </button>
+          </li>
+        ))}
+        {items.length === 0 && (
+          <li className="text-sm text-slate-300 dark:text-slate-600 italic py-2">No items yet — add one below or use AI.</li>
+        )}
+      </ul>
+      <div className="border-t border-slate-100 dark:border-slate-700 p-3 flex gap-2">
+        <input
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => { if (e.key === 'Enter') { e.preventDefault(); addItem(); } }}
+          placeholder={placeholder || 'Add item and press Enter…'}
+          className="flex-1 text-sm px-3 py-1.5 rounded-md border border-slate-200 dark:border-slate-600 bg-transparent text-slate-900 dark:text-white placeholder-slate-400 dark:placeholder-slate-500 focus:outline-none focus:border-indigo-400"
+        />
+        <button
+          onClick={addItem}
+          disabled={!draft.trim()}
+          className="text-sm px-3 py-1.5 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 disabled:opacity-40 disabled:cursor-not-allowed flex items-center gap-1 transition-colors"
+        >
+          <Plus className="w-3 h-3" /> Add
+        </button>
+      </div>
+    </div>
+  );
+};
+
+// ── Main component ────────────────────────────────────────────────────────────
+
 const SwotAnalysisWizard: React.FC<Props> = ({ data, onChange, profile, bmcData, saveStatus, isDirty, onSave, saveError }) => {
   const [step, setStep] = useState<number>(0);
   const [loadingMap, setLoadingMap] = useState<Record<string, boolean>>({});
 
   const handleGenerateInternal = async () => {
-    setLoadingMap({ ...loadingMap, internal: true });
+    setLoadingMap(m => ({ ...m, internal: true }));
     const result = await generateSwotInternal(profile, bmcData);
     onChange({
       ...data,
-      strengths: result.strengths || data.strengths,
-      weaknesses: result.weaknesses || data.weaknesses
+      strengths: result.strengths.length > 0 ? result.strengths : data.strengths,
+      weaknesses: result.weaknesses.length > 0 ? result.weaknesses : data.weaknesses,
     });
-    setLoadingMap({ ...loadingMap, internal: false });
+    setLoadingMap(m => ({ ...m, internal: false }));
   };
 
   const handleGenerateExternal = async (field: 'opportunities' | 'threats') => {
-    setLoadingMap({ ...loadingMap, [field]: true });
+    setLoadingMap(m => ({ ...m, [field]: true }));
     const result = await generateSwotExternal(profile, field === 'opportunities' ? 'OPPORTUNITIES' : 'THREATS');
-    onChange({
-      ...data,
-      [field]: result
-    });
-    setLoadingMap({ ...loadingMap, [field]: false });
+    onChange({ ...data, [field]: result });
+    setLoadingMap(m => ({ ...m, [field]: false }));
   };
 
   const renderStepInternal = () => (
@@ -49,7 +112,7 @@ const SwotAnalysisWizard: React.FC<Props> = ({ data, onChange, profile, bmcData,
           <h3 className="text-xl font-bold text-slate-800 dark:text-white">Step 1: Internal Factors</h3>
           <p className="text-sm text-slate-500 dark:text-slate-400">Analyze your Strengths and Weaknesses based on your Business Model Canvas.</p>
         </div>
-        <button 
+        <button
           onClick={handleGenerateInternal}
           disabled={loadingMap.internal}
           className="flex items-center gap-2 bg-indigo-50 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-300 px-4 py-2 rounded-lg hover:bg-indigo-100 dark:hover:bg-indigo-900/50 transition-colors text-sm font-medium w-full sm:w-auto justify-center"
@@ -62,24 +125,24 @@ const SwotAnalysisWizard: React.FC<Props> = ({ data, onChange, profile, bmcData,
       <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
         <div className="space-y-2">
           <label className="flex items-center gap-2 font-bold text-emerald-700 dark:text-emerald-400">
-             <TrendingUp className="w-5 h-5" /> Strengths
+            <TrendingUp className="w-5 h-5" /> Strengths
           </label>
-          <textarea 
-            value={data.strengths}
-            onChange={(e) => onChange({ ...data, strengths: e.target.value })}
-            className="w-full h-48 md:h-64 p-4 border border-slate-300 dark:border-slate-600 rounded-xl bg-white dark:bg-slate-950 text-slate-900 dark:text-white focus:ring-2 focus:ring-emerald-500 text-sm leading-relaxed"
-            placeholder="e.g., - Strong proprietary technology&#10;- Loyal customer base..."
+          <ArrayFieldEditor
+            items={data.strengths}
+            onChange={(items) => onChange({ ...data, strengths: items })}
+            placeholder="e.g. Strong proprietary technology"
+            focusRingColor="focus:ring-emerald-500"
           />
         </div>
         <div className="space-y-2">
           <label className="flex items-center gap-2 font-bold text-amber-600 dark:text-amber-400">
-             <AlertTriangle className="w-5 h-5" /> Weaknesses
+            <AlertTriangle className="w-5 h-5" /> Weaknesses
           </label>
-          <textarea 
-            value={data.weaknesses}
-            onChange={(e) => onChange({ ...data, weaknesses: e.target.value })}
-            className="w-full h-48 md:h-64 p-4 border border-slate-300 dark:border-slate-600 rounded-xl bg-white dark:bg-slate-950 text-slate-900 dark:text-white focus:ring-2 focus:ring-amber-500 text-sm leading-relaxed"
-            placeholder="e.g., - High dependency on single supplier&#10;- Limited marketing budget..."
+          <ArrayFieldEditor
+            items={data.weaknesses}
+            onChange={(items) => onChange({ ...data, weaknesses: items })}
+            placeholder="e.g. High dependency on single supplier"
+            focusRingColor="focus:ring-amber-500"
           />
         </div>
       </div>
@@ -97,10 +160,10 @@ const SwotAnalysisWizard: React.FC<Props> = ({ data, onChange, profile, bmcData,
         {/* Opportunities */}
         <div className="space-y-2">
           <div className="flex justify-between items-center">
-             <label className="flex items-center gap-2 font-bold text-blue-600 dark:text-blue-400">
-                <Globe className="w-5 h-5" /> Opportunities
-             </label>
-             <button 
+            <label className="flex items-center gap-2 font-bold text-blue-600 dark:text-blue-400">
+              <Globe className="w-5 h-5" /> Opportunities
+            </label>
+            <button
               onClick={() => handleGenerateExternal('opportunities')}
               disabled={loadingMap.opportunities}
               className="flex items-center gap-1.5 text-xs bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-300 px-3 py-1.5 rounded-full hover:bg-blue-100 dark:hover:bg-blue-900/50 transition-colors"
@@ -109,22 +172,22 @@ const SwotAnalysisWizard: React.FC<Props> = ({ data, onChange, profile, bmcData,
               Search News
             </button>
           </div>
-          <textarea 
-            value={data.opportunities}
-            onChange={(e) => onChange({ ...data, opportunities: e.target.value })}
-            className="w-full h-48 md:h-64 p-4 border border-slate-300 dark:border-slate-600 rounded-xl bg-white dark:bg-slate-950 text-slate-900 dark:text-white focus:ring-2 focus:ring-blue-500 text-sm leading-relaxed"
-            placeholder="e.g., - Growing demand for sustainable products&#10;- New government grants..."
+          <ArrayFieldEditor
+            items={data.opportunities}
+            onChange={(items) => onChange({ ...data, opportunities: items })}
+            placeholder="e.g. Growing demand for sustainable products"
+            focusRingColor="focus:ring-blue-500"
           />
-           <p className="text-xs text-slate-400 dark:text-slate-500">AI searches for: Market trends, new regulations, competitor shifts.</p>
+          <p className="text-xs text-slate-400 dark:text-slate-500">AI searches for: Market trends, new regulations, competitor shifts.</p>
         </div>
 
         {/* Threats */}
         <div className="space-y-2">
           <div className="flex justify-between items-center">
-             <label className="flex items-center gap-2 font-bold text-red-600 dark:text-red-400">
-                <ShieldAlert className="w-5 h-5" /> Threats
-             </label>
-             <button 
+            <label className="flex items-center gap-2 font-bold text-red-600 dark:text-red-400">
+              <ShieldAlert className="w-5 h-5" /> Threats
+            </label>
+            <button
               onClick={() => handleGenerateExternal('threats')}
               disabled={loadingMap.threats}
               className="flex items-center gap-1.5 text-xs bg-red-50 dark:bg-red-900/30 text-red-600 dark:text-red-300 px-3 py-1.5 rounded-full hover:bg-red-100 dark:hover:bg-red-900/50 transition-colors"
@@ -133,11 +196,11 @@ const SwotAnalysisWizard: React.FC<Props> = ({ data, onChange, profile, bmcData,
               Search News
             </button>
           </div>
-          <textarea 
-            value={data.threats}
-            onChange={(e) => onChange({ ...data, threats: e.target.value })}
-            className="w-full h-48 md:h-64 p-4 border border-slate-300 dark:border-slate-600 rounded-xl bg-white dark:bg-slate-950 text-slate-900 dark:text-white focus:ring-2 focus:ring-red-500 text-sm leading-relaxed"
-            placeholder="e.g., - Supply chain disruptions&#10;- New tariffs..."
+          <ArrayFieldEditor
+            items={data.threats}
+            onChange={(items) => onChange({ ...data, threats: items })}
+            placeholder="e.g. Supply chain disruptions"
+            focusRingColor="focus:ring-red-500"
           />
           <p className="text-xs text-slate-400 dark:text-slate-500">AI searches for: Economic downturns, geopolitical risks, resource scarcity.</p>
         </div>
@@ -145,98 +208,111 @@ const SwotAnalysisWizard: React.FC<Props> = ({ data, onChange, profile, bmcData,
     </div>
   );
 
-  const renderMatrix = () => (
-    <div className="animate-in fade-in duration-500">
-       <div className="mb-6 flex justify-between items-end">
+  const renderMatrix = () => {
+    const QuadrantList = ({ items, emptyText }: { items: string[]; emptyText: string }) => (
+      <ul className="space-y-2">
+        {items.length > 0
+          ? items.map((item, i) => (
+              <li key={i} className="flex items-start gap-2 text-sm">
+                <span className="flex-shrink-0 mt-0.5">•</span>
+                <span>{item}</span>
+              </li>
+            ))
+          : <li className="text-sm italic opacity-60">{emptyText}</li>
+        }
+      </ul>
+    );
+
+    return (
+      <div className="animate-in fade-in duration-500">
+        <div className="mb-6 flex justify-between items-end">
           <div>
             <h3 className="text-xl font-bold text-slate-800 dark:text-white">SWOT Matrix</h3>
             <p className="text-sm text-slate-500 dark:text-slate-400">Strategic overview of your business position.</p>
           </div>
-          <button 
-            onClick={() => setStep(0)} 
-            className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline"
-          >
+          <button onClick={() => setStep(0)} className="text-sm text-indigo-600 dark:text-indigo-400 hover:underline">
             Edit Analysis
           </button>
-       </div>
+        </div>
 
-       <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:h-[600px]">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 md:h-[600px]">
           <div className="bg-emerald-50 dark:bg-emerald-900/20 border border-emerald-200 dark:border-emerald-800 rounded-xl p-6 overflow-y-auto min-h-[200px]">
-             <h4 className="font-bold text-emerald-800 dark:text-emerald-400 mb-4 flex items-center gap-2">
-                <TrendingUp className="w-5 h-5" /> STRENGTHS
-             </h4>
-             <div className="whitespace-pre-wrap text-sm text-emerald-900 dark:text-emerald-100">{data.strengths || "No strengths listed."}</div>
+            <h4 className="font-bold text-emerald-800 dark:text-emerald-400 mb-4 flex items-center gap-2">
+              <TrendingUp className="w-5 h-5" /> STRENGTHS
+            </h4>
+            <QuadrantList items={data.strengths} emptyText="No strengths listed." />
           </div>
           <div className="bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-xl p-6 overflow-y-auto min-h-[200px]">
-             <h4 className="font-bold text-amber-800 dark:text-amber-400 mb-4 flex items-center gap-2">
-                <AlertTriangle className="w-5 h-5" /> WEAKNESSES
-             </h4>
-             <div className="whitespace-pre-wrap text-sm text-amber-900 dark:text-amber-100">{data.weaknesses || "No weaknesses listed."}</div>
+            <h4 className="font-bold text-amber-800 dark:text-amber-400 mb-4 flex items-center gap-2">
+              <AlertTriangle className="w-5 h-5" /> WEAKNESSES
+            </h4>
+            <QuadrantList items={data.weaknesses} emptyText="No weaknesses listed." />
           </div>
           <div className="bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-xl p-6 overflow-y-auto min-h-[200px]">
-             <h4 className="font-bold text-blue-800 dark:text-blue-400 mb-4 flex items-center gap-2">
-                <Globe className="w-5 h-5" /> OPPORTUNITIES
-             </h4>
-             <div className="whitespace-pre-wrap text-sm text-blue-900 dark:text-blue-100">{data.opportunities || "No opportunities listed."}</div>
+            <h4 className="font-bold text-blue-800 dark:text-blue-400 mb-4 flex items-center gap-2">
+              <Globe className="w-5 h-5" /> OPPORTUNITIES
+            </h4>
+            <QuadrantList items={data.opportunities} emptyText="No opportunities listed." />
           </div>
           <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-xl p-6 overflow-y-auto min-h-[200px]">
-             <h4 className="font-bold text-red-800 dark:text-red-400 mb-4 flex items-center gap-2">
-                <ShieldAlert className="w-5 h-5" /> THREATS
-             </h4>
-             <div className="whitespace-pre-wrap text-sm text-red-900 dark:text-red-100">{data.threats || "No threats listed."}</div>
+            <h4 className="font-bold text-red-800 dark:text-red-400 mb-4 flex items-center gap-2">
+              <ShieldAlert className="w-5 h-5" /> THREATS
+            </h4>
+            <QuadrantList items={data.threats} emptyText="No threats listed." />
           </div>
-       </div>
-    </div>
-  );
+        </div>
+      </div>
+    );
+  };
 
   return (
     <div className="w-full">
-        {/* Responsive Stepper */}
-        <div className="mb-8 flex items-center justify-center">
-            <div className={`flex items-center ${step >= 0 ? 'text-indigo-600 dark:text-indigo-400' : 'text-slate-400'}`}>
-                <span className={`w-8 h-8 rounded-full border-2 flex items-center justify-center font-bold text-sm ${step === 0 ? 'border-indigo-600 bg-indigo-600 text-white' : 'border-current'}`}>1</span>
-                <span className="ml-2 font-medium hidden sm:block">Internal</span>
-            </div>
-            <div className={`w-8 sm:w-16 h-0.5 mx-2 sm:mx-4 ${step >= 1 ? 'bg-indigo-600 dark:bg-indigo-400' : 'bg-slate-300 dark:bg-slate-700'}`} />
-            <div className={`flex items-center ${step >= 1 ? 'text-indigo-600 dark:text-indigo-400' : 'text-slate-400'}`}>
-                <span className={`w-8 h-8 rounded-full border-2 flex items-center justify-center font-bold text-sm ${step === 1 ? 'border-indigo-600 bg-indigo-600 text-white' : 'border-current'}`}>2</span>
-                <span className="ml-2 font-medium hidden sm:block">External</span>
-            </div>
-            <div className={`w-8 sm:w-16 h-0.5 mx-2 sm:mx-4 ${step >= 2 ? 'bg-indigo-600 dark:bg-indigo-400' : 'bg-slate-300 dark:bg-slate-700'}`} />
-            <div className={`flex items-center ${step >= 2 ? 'text-indigo-600 dark:text-indigo-400' : 'text-slate-400'}`}>
-                <span className={`w-8 h-8 rounded-full border-2 flex items-center justify-center font-bold text-sm ${step === 2 ? 'border-indigo-600 bg-indigo-600 text-white' : 'border-current'}`}>3</span>
-                <span className="ml-2 font-medium hidden sm:block">Review</span>
-            </div>
+      {/* Stepper */}
+      <div className="mb-8 flex items-center justify-center">
+        <div className={`flex items-center ${step >= 0 ? 'text-indigo-600 dark:text-indigo-400' : 'text-slate-400'}`}>
+          <span className={`w-8 h-8 rounded-full border-2 flex items-center justify-center font-bold text-sm ${step === 0 ? 'border-indigo-600 bg-indigo-600 text-white' : 'border-current'}`}>1</span>
+          <span className="ml-2 font-medium hidden sm:block">Internal</span>
         </div>
-
-        <div className="bg-white dark:bg-slate-800 p-4 md:p-8 rounded-xl shadow-lg border border-slate-200 dark:border-slate-700 transition-colors min-h-[500px]">
-            {step === 0 && renderStepInternal()}
-            {step === 1 && renderStepExternal()}
-            {step === 2 && renderMatrix()}
+        <div className={`w-8 sm:w-16 h-0.5 mx-2 sm:mx-4 ${step >= 1 ? 'bg-indigo-600 dark:bg-indigo-400' : 'bg-slate-300 dark:bg-slate-700'}`} />
+        <div className={`flex items-center ${step >= 1 ? 'text-indigo-600 dark:text-indigo-400' : 'text-slate-400'}`}>
+          <span className={`w-8 h-8 rounded-full border-2 flex items-center justify-center font-bold text-sm ${step === 1 ? 'border-indigo-600 bg-indigo-600 text-white' : 'border-current'}`}>2</span>
+          <span className="ml-2 font-medium hidden sm:block">External</span>
         </div>
-
-        <div className="flex justify-between mt-8">
-            <button
-                onClick={() => setStep(prev => Math.max(0, prev - 1))}
-                disabled={step === 0}
-                className={`flex items-center gap-2 px-4 py-2 md:px-6 md:py-3 rounded-lg font-medium transition-colors ${
-                    step === 0 ? 'text-slate-300 dark:text-slate-600 cursor-not-allowed' : 'text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800'
-                }`}
-            >
-                <ArrowLeft className="w-4 h-4" /> Back
-            </button>
-
-            {step < 2 ? (
-                 <button
-                 onClick={() => setStep(prev => prev + 1)}
-                 className="flex items-center gap-2 bg-slate-900 dark:bg-white text-white dark:text-slate-900 px-6 py-2 md:px-8 md:py-3 rounded-lg font-bold hover:bg-slate-800 dark:hover:bg-slate-100 shadow-lg transition-all"
-               >
-                 Next Step <ArrowRight className="w-4 h-4" />
-               </button>
-            ) : (
-                <SaveIndicator status={saveStatus} isDirty={isDirty} onSave={onSave} errorMessage={saveError} />
-            )}
+        <div className={`w-8 sm:w-16 h-0.5 mx-2 sm:mx-4 ${step >= 2 ? 'bg-indigo-600 dark:bg-indigo-400' : 'bg-slate-300 dark:bg-slate-700'}`} />
+        <div className={`flex items-center ${step >= 2 ? 'text-indigo-600 dark:text-indigo-400' : 'text-slate-400'}`}>
+          <span className={`w-8 h-8 rounded-full border-2 flex items-center justify-center font-bold text-sm ${step === 2 ? 'border-indigo-600 bg-indigo-600 text-white' : 'border-current'}`}>3</span>
+          <span className="ml-2 font-medium hidden sm:block">Review</span>
         </div>
+      </div>
+
+      <div className="bg-white dark:bg-slate-800 p-4 md:p-8 rounded-xl shadow-lg border border-slate-200 dark:border-slate-700 transition-colors min-h-[500px]">
+        {step === 0 && renderStepInternal()}
+        {step === 1 && renderStepExternal()}
+        {step === 2 && renderMatrix()}
+      </div>
+
+      <div className="flex justify-between mt-8">
+        <button
+          onClick={() => setStep(prev => Math.max(0, prev - 1))}
+          disabled={step === 0}
+          className={`flex items-center gap-2 px-4 py-2 md:px-6 md:py-3 rounded-lg font-medium transition-colors ${
+            step === 0 ? 'text-slate-300 dark:text-slate-600 cursor-not-allowed' : 'text-slate-600 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800'
+          }`}
+        >
+          <ArrowLeft className="w-4 h-4" /> Back
+        </button>
+
+        {step < 2 ? (
+          <button
+            onClick={() => setStep(prev => prev + 1)}
+            className="flex items-center gap-2 bg-slate-900 dark:bg-white text-white dark:text-slate-900 px-6 py-2 md:px-8 md:py-3 rounded-lg font-bold hover:bg-slate-800 dark:hover:bg-slate-100 shadow-lg transition-all"
+          >
+            Next Step <ArrowRight className="w-4 h-4" />
+          </button>
+        ) : (
+          <SaveIndicator status={saveStatus} isDirty={isDirty} onSave={onSave} errorMessage={saveError} />
+        )}
+      </div>
     </div>
   );
 };

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -278,15 +278,35 @@ async function generateCanvasSuggestion(
 
     Task:
     Suggest content for the "${fieldLabel}" block of the Business Model Canvas.
-    The suggestion should be specific to the company's industry and products/services, concise, and formatted as a list of key points (bullet points).
-    If the field is "Eco-Social Costs" or "Eco-Social Benefits", focus strictly on environmental and social externalities relevant to this company.
+    Each suggestion should be a short, distinct point specific to the company's industry and products/services.
+    If the field is "Eco-Social Costs" or "Eco-Social Benefits", focus strictly on environmental and social externalities.
 
-    Output plain text only.
+    CRITICAL: Return ONLY a valid JSON array of strings. Each string is one concise point (under 15 words).
+    No markdown, no backticks, no explanation.
   `;
 
-  const response = await ai.models.generateContent({ model, contents: prompt });
+  const response = await ai.models.generateContent({
+    model,
+    contents: prompt,
+    config: {
+      responseMimeType: "application/json",
+      responseSchema: {
+        type: Type.ARRAY,
+        items: { type: Type.STRING },
+      },
+    },
+  });
+
+  let parsed: string[] = [];
+  try {
+    parsed = JSON.parse(response.text || "[]");
+  } catch {
+    const match = response.text?.match(/\[.*\]/s);
+    if (match) parsed = JSON.parse(match[0]);
+  }
+
   return {
-    result: response.text?.trim() || "",
+    result: Array.isArray(parsed) ? parsed : [],
     ...extractTokens(response),
   };
 }
@@ -306,20 +326,20 @@ async function generateSwotInternal(
     2. WEAKNESSES (Internal negative factors)
 
     BMC Data:
-    - Value Proposition: ${bmcData.valueProposition}
-    - Key Partners: ${bmcData.keyPartners}
-    - Key Activities: ${bmcData.keyActivities}
-    - Key Resources: ${bmcData.keyResources}
-    - Customer Relationships: ${bmcData.customerRelationships}
-    - Channels: ${bmcData.channels}
-    - Customer Segments: ${bmcData.customerSegments}
-    - Cost Structure: ${bmcData.costStructure}
-    - Revenue Streams: ${bmcData.revenueStreams}
-    - Eco-Social Benefits: ${bmcData.ecoSocialBenefits}
-    - Eco-Social Costs: ${bmcData.ecoSocialCosts}
+    - Value Proposition: ${Array.isArray(bmcData.valueProposition) ? bmcData.valueProposition.join(', ') : bmcData.valueProposition}
+    - Key Partners: ${Array.isArray(bmcData.keyPartners) ? bmcData.keyPartners.join(', ') : bmcData.keyPartners}
+    - Key Activities: ${Array.isArray(bmcData.keyActivities) ? bmcData.keyActivities.join(', ') : bmcData.keyActivities}
+    - Key Resources: ${Array.isArray(bmcData.keyResources) ? bmcData.keyResources.join(', ') : bmcData.keyResources}
+    - Customer Relationships: ${Array.isArray(bmcData.customerRelationships) ? bmcData.customerRelationships.join(', ') : bmcData.customerRelationships}
+    - Channels: ${Array.isArray(bmcData.channels) ? bmcData.channels.join(', ') : bmcData.channels}
+    - Customer Segments: ${Array.isArray(bmcData.customerSegments) ? bmcData.customerSegments.join(', ') : bmcData.customerSegments}
+    - Cost Structure: ${Array.isArray(bmcData.costStructure) ? bmcData.costStructure.join(', ') : bmcData.costStructure}
+    - Revenue Streams: ${Array.isArray(bmcData.revenueStreams) ? bmcData.revenueStreams.join(', ') : bmcData.revenueStreams}
+    - Eco-Social Benefits: ${Array.isArray(bmcData.ecoSocialBenefits) ? bmcData.ecoSocialBenefits.join(', ') : bmcData.ecoSocialBenefits}
+    - Eco-Social Costs: ${Array.isArray(bmcData.ecoSocialCosts) ? bmcData.ecoSocialCosts.join(', ') : bmcData.ecoSocialCosts}
 
-    Return the response in JSON format with keys "strengths" and "weaknesses".
-    Provide bullet points using a hyphen (-).
+    CRITICAL: Return ONLY a JSON object with keys "strengths" and "weaknesses".
+    Each value must be an array of short, distinct strings (one factor per item, under 15 words each).
   `;
 
   const response = await ai.models.generateContent({
@@ -330,8 +350,8 @@ async function generateSwotInternal(
       responseSchema: {
         type: Type.OBJECT,
         properties: {
-          strengths: { type: Type.STRING },
-          weaknesses: { type: Type.STRING },
+          strengths: { type: Type.ARRAY, items: { type: Type.STRING } },
+          weaknesses: { type: Type.ARRAY, items: { type: Type.STRING } },
         },
       },
     },
@@ -362,14 +382,20 @@ async function generateSwotExternal(
     Provide the answer as a bulleted list. Cite sources if possible.
   `;
 
+  // Google Search grounding is incompatible with JSON schema mode; parse text manually.
   const response = await ai.models.generateContent({
     model,
     contents: prompt,
     config: { tools: [{ googleSearch: {} }] },
   });
 
+  const items = (response.text || "")
+    .split("\n")
+    .map((line: string) => line.replace(/^[\s•\-\*–\d\.]+/, "").replace(/\*+/g, "").trim())
+    .filter((line: string) => line.length > 0 && !line.startsWith("---") && !line.startsWith("#"));
+
   return {
-    result: response.text?.trim() || "",
+    result: items,
     ...extractTokens(response),
   };
 }

--- a/services/dbService.ts
+++ b/services/dbService.ts
@@ -227,18 +227,28 @@ export const toDbProfile = (data: CompanyProfile) => ({
 // BUSINESS MODEL CANVAS  (1 row per org)
 // =================================================================
 
+// Normalise a DB jsonb field → string[]. Handles both the new jsonb array
+// format and the legacy text format (in case of partial migrations).
+function toStringArray(val: any): string[] {
+  if (Array.isArray(val)) return val.filter((v) => typeof v === "string");
+  if (typeof val === "string" && val.trim()) {
+    return val.split("\n").map((s) => s.replace(/^[\s•\-\*–]+/, "").trim()).filter(Boolean);
+  }
+  return [];
+}
+
 export const fromDbCanvas = (row: any): SustainabilityBusinessModel => ({
-  keyPartners: row.key_partners ?? "",
-  keyActivities: row.key_activities ?? "",
-  keyResources: row.key_resources ?? "",
-  valueProposition: row.value_proposition ?? "",
-  customerRelationships: row.customer_relationships ?? "",
-  channels: row.channels ?? "",
-  customerSegments: row.customer_segments ?? "",
-  costStructure: row.cost_structure ?? "",
-  revenueStreams: row.revenue_streams ?? "",
-  ecoSocialCosts: row.eco_social_costs ?? "",
-  ecoSocialBenefits: row.eco_social_benefits ?? "",
+  keyPartners: toStringArray(row.key_partners),
+  keyActivities: toStringArray(row.key_activities),
+  keyResources: toStringArray(row.key_resources),
+  valueProposition: toStringArray(row.value_proposition),
+  customerRelationships: toStringArray(row.customer_relationships),
+  channels: toStringArray(row.channels),
+  customerSegments: toStringArray(row.customer_segments),
+  costStructure: toStringArray(row.cost_structure),
+  revenueStreams: toStringArray(row.revenue_streams),
+  ecoSocialCosts: toStringArray(row.eco_social_costs),
+  ecoSocialBenefits: toStringArray(row.eco_social_benefits),
 });
 
 export const toDbCanvas = (data: SustainabilityBusinessModel) => ({
@@ -260,10 +270,10 @@ export const toDbCanvas = (data: SustainabilityBusinessModel) => ({
 // =================================================================
 
 export const fromDbSwot = (row: any): SwotAnalysis => ({
-  strengths: row.strengths ?? "",
-  weaknesses: row.weaknesses ?? "",
-  opportunities: row.opportunities ?? "",
-  threats: row.threats ?? "",
+  strengths: toStringArray(row.strengths),
+  weaknesses: toStringArray(row.weaknesses),
+  opportunities: toStringArray(row.opportunities),
+  threats: toStringArray(row.threats),
 });
 
 export const toDbSwot = (data: SwotAnalysis) => ({

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -70,34 +70,33 @@ export const generateAssessmentSuggestions = async (
 export const generateCanvasSuggestion = async (
   profile: CompanyProfile,
   fieldLabel: string
-) => {
+): Promise<string[]> => {
   try {
     return await callApi("generateCanvasSuggestion", { profile, fieldLabel });
-  } catch (error) {
-    return errorMessage(error);
+  } catch {
+    return [];
   }
 };
 
 export const generateSwotInternal = async (
   profile: CompanyProfile,
   bmcData: SustainabilityBusinessModel
-) => {
+): Promise<{ strengths: string[]; weaknesses: string[] }> => {
   try {
     return await callApi("generateSwotInternal", { profile, bmcData });
-  } catch (error) {
-    const msg = errorMessage(error);
-    return { strengths: msg, weaknesses: msg };
+  } catch {
+    return { strengths: [], weaknesses: [] };
   }
 };
 
 export const generateSwotExternal = async (
   profile: CompanyProfile,
   type: "OPPORTUNITIES" | "THREATS"
-) => {
+): Promise<string[]> => {
   try {
     return await callApi("generateSwotExternal", { profile, type });
-  } catch (error) {
-    return errorMessage(error);
+  } catch {
+    return [];
   }
 };
 

--- a/supabase/migrations/006_bmc_swot_jsonb.sql
+++ b/supabase/migrations/006_bmc_swot_jsonb.sql
@@ -1,0 +1,98 @@
+-- Migration 006: Convert BMC and SWOT text fields to jsonb arrays
+-- Issue: #01 — Migration: BMC and SWOT Fields to JSONB Arrays
+--
+-- Rollback plan (run if needed):
+--   ALTER TABLE business_model_canvases
+--     ALTER COLUMN key_partners TYPE text USING array_to_string(ARRAY(SELECT jsonb_array_elements_text(key_partners)), E'\n'),
+--     ALTER COLUMN key_activities TYPE text USING array_to_string(ARRAY(SELECT jsonb_array_elements_text(key_activities)), E'\n'),
+--     ALTER COLUMN key_resources TYPE text USING array_to_string(ARRAY(SELECT jsonb_array_elements_text(key_resources)), E'\n'),
+--     ALTER COLUMN value_proposition TYPE text USING array_to_string(ARRAY(SELECT jsonb_array_elements_text(value_proposition)), E'\n'),
+--     ALTER COLUMN customer_relationships TYPE text USING array_to_string(ARRAY(SELECT jsonb_array_elements_text(customer_relationships)), E'\n'),
+--     ALTER COLUMN channels TYPE text USING array_to_string(ARRAY(SELECT jsonb_array_elements_text(channels)), E'\n'),
+--     ALTER COLUMN customer_segments TYPE text USING array_to_string(ARRAY(SELECT jsonb_array_elements_text(customer_segments)), E'\n'),
+--     ALTER COLUMN cost_structure TYPE text USING array_to_string(ARRAY(SELECT jsonb_array_elements_text(cost_structure)), E'\n'),
+--     ALTER COLUMN revenue_streams TYPE text USING array_to_string(ARRAY(SELECT jsonb_array_elements_text(revenue_streams)), E'\n'),
+--     ALTER COLUMN eco_social_costs TYPE text USING array_to_string(ARRAY(SELECT jsonb_array_elements_text(eco_social_costs)), E'\n'),
+--     ALTER COLUMN eco_social_benefits TYPE text USING array_to_string(ARRAY(SELECT jsonb_array_elements_text(eco_social_benefits)), E'\n');
+--   ALTER TABLE swot_analyses
+--     ALTER COLUMN strengths TYPE text USING array_to_string(ARRAY(SELECT jsonb_array_elements_text(strengths)), E'\n'),
+--     ALTER COLUMN weaknesses TYPE text USING array_to_string(ARRAY(SELECT jsonb_array_elements_text(weaknesses)), E'\n'),
+--     ALTER COLUMN opportunities TYPE text USING array_to_string(ARRAY(SELECT jsonb_array_elements_text(opportunities)), E'\n'),
+--     ALTER COLUMN threats TYPE text USING array_to_string(ARRAY(SELECT jsonb_array_elements_text(threats)), E'\n');
+--   DROP FUNCTION IF EXISTS parse_bullet_to_jsonb(text);
+
+-- Step 1: Parser function — converts bullet-list text to jsonb string array
+CREATE OR REPLACE FUNCTION parse_bullet_to_jsonb(input_text text)
+RETURNS jsonb
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  lines text[];
+  cleaned text[];
+  line text;
+BEGIN
+  IF input_text IS NULL OR trim(input_text) = '' THEN
+    RETURN '[]'::jsonb;
+  END IF;
+
+  lines := string_to_array(input_text, E'\n');
+
+  FOREACH line IN ARRAY lines
+  LOOP
+    -- Strip leading bullets (•, -, *, –), whitespace
+    line := regexp_replace(line, '^[\s•\-\*–]+', '', 'g');
+    line := trim(line);
+    -- Skip separator lines (e.g. "--- AI Suggestion ---") and blanks
+    IF line != '' AND line NOT LIKE '---%' THEN
+      cleaned := array_append(cleaned, line);
+    END IF;
+  END LOOP;
+
+  IF cleaned IS NULL THEN
+    RETURN '[]'::jsonb;
+  END IF;
+
+  RETURN to_jsonb(cleaned);
+END;
+$$;
+
+-- Step 2: Migrate business_model_canvases columns text → jsonb
+ALTER TABLE business_model_canvases
+  ALTER COLUMN key_partners       TYPE jsonb USING parse_bullet_to_jsonb(key_partners),
+  ALTER COLUMN key_activities     TYPE jsonb USING parse_bullet_to_jsonb(key_activities),
+  ALTER COLUMN key_resources      TYPE jsonb USING parse_bullet_to_jsonb(key_resources),
+  ALTER COLUMN value_proposition  TYPE jsonb USING parse_bullet_to_jsonb(value_proposition),
+  ALTER COLUMN customer_relationships TYPE jsonb USING parse_bullet_to_jsonb(customer_relationships),
+  ALTER COLUMN channels           TYPE jsonb USING parse_bullet_to_jsonb(channels),
+  ALTER COLUMN customer_segments  TYPE jsonb USING parse_bullet_to_jsonb(customer_segments),
+  ALTER COLUMN cost_structure     TYPE jsonb USING parse_bullet_to_jsonb(cost_structure),
+  ALTER COLUMN revenue_streams    TYPE jsonb USING parse_bullet_to_jsonb(revenue_streams),
+  ALTER COLUMN eco_social_costs   TYPE jsonb USING parse_bullet_to_jsonb(eco_social_costs),
+  ALTER COLUMN eco_social_benefits TYPE jsonb USING parse_bullet_to_jsonb(eco_social_benefits);
+
+-- Set defaults so new rows get empty arrays instead of null
+ALTER TABLE business_model_canvases
+  ALTER COLUMN key_partners           SET DEFAULT '[]',
+  ALTER COLUMN key_activities         SET DEFAULT '[]',
+  ALTER COLUMN key_resources          SET DEFAULT '[]',
+  ALTER COLUMN value_proposition      SET DEFAULT '[]',
+  ALTER COLUMN customer_relationships SET DEFAULT '[]',
+  ALTER COLUMN channels               SET DEFAULT '[]',
+  ALTER COLUMN customer_segments      SET DEFAULT '[]',
+  ALTER COLUMN cost_structure         SET DEFAULT '[]',
+  ALTER COLUMN revenue_streams        SET DEFAULT '[]',
+  ALTER COLUMN eco_social_costs       SET DEFAULT '[]',
+  ALTER COLUMN eco_social_benefits    SET DEFAULT '[]';
+
+-- Step 3: Migrate swot_analyses columns text → jsonb
+ALTER TABLE swot_analyses
+  ALTER COLUMN strengths     TYPE jsonb USING parse_bullet_to_jsonb(strengths),
+  ALTER COLUMN weaknesses    TYPE jsonb USING parse_bullet_to_jsonb(weaknesses),
+  ALTER COLUMN opportunities TYPE jsonb USING parse_bullet_to_jsonb(opportunities),
+  ALTER COLUMN threats       TYPE jsonb USING parse_bullet_to_jsonb(threats);
+
+ALTER TABLE swot_analyses
+  ALTER COLUMN strengths     SET DEFAULT '[]',
+  ALTER COLUMN weaknesses    SET DEFAULT '[]',
+  ALTER COLUMN opportunities SET DEFAULT '[]',
+  ALTER COLUMN threats       SET DEFAULT '[]';

--- a/supabase/migrations/006_bmc_swot_jsonb.sql
+++ b/supabase/migrations/006_bmc_swot_jsonb.sql
@@ -56,35 +56,53 @@ BEGIN
 END;
 $$;
 
--- Step 2: Migrate business_model_canvases columns text → jsonb
+-- Step 2: Drop existing text defaults, migrate columns text → jsonb, set new defaults
 ALTER TABLE business_model_canvases
-  ALTER COLUMN key_partners       TYPE jsonb USING parse_bullet_to_jsonb(key_partners),
-  ALTER COLUMN key_activities     TYPE jsonb USING parse_bullet_to_jsonb(key_activities),
-  ALTER COLUMN key_resources      TYPE jsonb USING parse_bullet_to_jsonb(key_resources),
-  ALTER COLUMN value_proposition  TYPE jsonb USING parse_bullet_to_jsonb(value_proposition),
+  ALTER COLUMN key_partners           DROP DEFAULT,
+  ALTER COLUMN key_activities         DROP DEFAULT,
+  ALTER COLUMN key_resources          DROP DEFAULT,
+  ALTER COLUMN value_proposition      DROP DEFAULT,
+  ALTER COLUMN customer_relationships DROP DEFAULT,
+  ALTER COLUMN channels               DROP DEFAULT,
+  ALTER COLUMN customer_segments      DROP DEFAULT,
+  ALTER COLUMN cost_structure         DROP DEFAULT,
+  ALTER COLUMN revenue_streams        DROP DEFAULT,
+  ALTER COLUMN eco_social_costs       DROP DEFAULT,
+  ALTER COLUMN eco_social_benefits    DROP DEFAULT;
+
+ALTER TABLE business_model_canvases
+  ALTER COLUMN key_partners           TYPE jsonb USING parse_bullet_to_jsonb(key_partners),
+  ALTER COLUMN key_activities         TYPE jsonb USING parse_bullet_to_jsonb(key_activities),
+  ALTER COLUMN key_resources          TYPE jsonb USING parse_bullet_to_jsonb(key_resources),
+  ALTER COLUMN value_proposition      TYPE jsonb USING parse_bullet_to_jsonb(value_proposition),
   ALTER COLUMN customer_relationships TYPE jsonb USING parse_bullet_to_jsonb(customer_relationships),
-  ALTER COLUMN channels           TYPE jsonb USING parse_bullet_to_jsonb(channels),
-  ALTER COLUMN customer_segments  TYPE jsonb USING parse_bullet_to_jsonb(customer_segments),
-  ALTER COLUMN cost_structure     TYPE jsonb USING parse_bullet_to_jsonb(cost_structure),
-  ALTER COLUMN revenue_streams    TYPE jsonb USING parse_bullet_to_jsonb(revenue_streams),
-  ALTER COLUMN eco_social_costs   TYPE jsonb USING parse_bullet_to_jsonb(eco_social_costs),
-  ALTER COLUMN eco_social_benefits TYPE jsonb USING parse_bullet_to_jsonb(eco_social_benefits);
+  ALTER COLUMN channels               TYPE jsonb USING parse_bullet_to_jsonb(channels),
+  ALTER COLUMN customer_segments      TYPE jsonb USING parse_bullet_to_jsonb(customer_segments),
+  ALTER COLUMN cost_structure         TYPE jsonb USING parse_bullet_to_jsonb(cost_structure),
+  ALTER COLUMN revenue_streams        TYPE jsonb USING parse_bullet_to_jsonb(revenue_streams),
+  ALTER COLUMN eco_social_costs       TYPE jsonb USING parse_bullet_to_jsonb(eco_social_costs),
+  ALTER COLUMN eco_social_benefits    TYPE jsonb USING parse_bullet_to_jsonb(eco_social_benefits);
 
--- Set defaults so new rows get empty arrays instead of null
 ALTER TABLE business_model_canvases
-  ALTER COLUMN key_partners           SET DEFAULT '[]',
-  ALTER COLUMN key_activities         SET DEFAULT '[]',
-  ALTER COLUMN key_resources          SET DEFAULT '[]',
-  ALTER COLUMN value_proposition      SET DEFAULT '[]',
-  ALTER COLUMN customer_relationships SET DEFAULT '[]',
-  ALTER COLUMN channels               SET DEFAULT '[]',
-  ALTER COLUMN customer_segments      SET DEFAULT '[]',
-  ALTER COLUMN cost_structure         SET DEFAULT '[]',
-  ALTER COLUMN revenue_streams        SET DEFAULT '[]',
-  ALTER COLUMN eco_social_costs       SET DEFAULT '[]',
-  ALTER COLUMN eco_social_benefits    SET DEFAULT '[]';
+  ALTER COLUMN key_partners           SET DEFAULT '[]'::jsonb,
+  ALTER COLUMN key_activities         SET DEFAULT '[]'::jsonb,
+  ALTER COLUMN key_resources          SET DEFAULT '[]'::jsonb,
+  ALTER COLUMN value_proposition      SET DEFAULT '[]'::jsonb,
+  ALTER COLUMN customer_relationships SET DEFAULT '[]'::jsonb,
+  ALTER COLUMN channels               SET DEFAULT '[]'::jsonb,
+  ALTER COLUMN customer_segments      SET DEFAULT '[]'::jsonb,
+  ALTER COLUMN cost_structure         SET DEFAULT '[]'::jsonb,
+  ALTER COLUMN revenue_streams        SET DEFAULT '[]'::jsonb,
+  ALTER COLUMN eco_social_costs       SET DEFAULT '[]'::jsonb,
+  ALTER COLUMN eco_social_benefits    SET DEFAULT '[]'::jsonb;
 
--- Step 3: Migrate swot_analyses columns text → jsonb
+-- Step 3: Drop existing text defaults, migrate swot_analyses columns text → jsonb, set new defaults
+ALTER TABLE swot_analyses
+  ALTER COLUMN strengths     DROP DEFAULT,
+  ALTER COLUMN weaknesses    DROP DEFAULT,
+  ALTER COLUMN opportunities DROP DEFAULT,
+  ALTER COLUMN threats       DROP DEFAULT;
+
 ALTER TABLE swot_analyses
   ALTER COLUMN strengths     TYPE jsonb USING parse_bullet_to_jsonb(strengths),
   ALTER COLUMN weaknesses    TYPE jsonb USING parse_bullet_to_jsonb(weaknesses),
@@ -92,7 +110,7 @@ ALTER TABLE swot_analyses
   ALTER COLUMN threats       TYPE jsonb USING parse_bullet_to_jsonb(threats);
 
 ALTER TABLE swot_analyses
-  ALTER COLUMN strengths     SET DEFAULT '[]',
-  ALTER COLUMN weaknesses    SET DEFAULT '[]',
-  ALTER COLUMN opportunities SET DEFAULT '[]',
-  ALTER COLUMN threats       SET DEFAULT '[]';
+  ALTER COLUMN strengths     SET DEFAULT '[]'::jsonb,
+  ALTER COLUMN weaknesses    SET DEFAULT '[]'::jsonb,
+  ALTER COLUMN opportunities SET DEFAULT '[]'::jsonb,
+  ALTER COLUMN threats       SET DEFAULT '[]'::jsonb;

--- a/types.ts
+++ b/types.ts
@@ -98,24 +98,24 @@ export interface CompanyProfile {
 }
 
 export interface SustainabilityBusinessModel {
-  keyPartners: string;
-  keyActivities: string;
-  keyResources: string;
-  valueProposition: string;
-  customerRelationships: string;
-  channels: string;
-  customerSegments: string;
-  costStructure: string;
-  revenueStreams: string;
-  ecoSocialCosts: string; // Negative impacts
-  ecoSocialBenefits: string; // Positive impacts
+  keyPartners: string[];
+  keyActivities: string[];
+  keyResources: string[];
+  valueProposition: string[];
+  customerRelationships: string[];
+  channels: string[];
+  customerSegments: string[];
+  costStructure: string[];
+  revenueStreams: string[];
+  ecoSocialCosts: string[];
+  ecoSocialBenefits: string[];
 }
 
 export interface SwotAnalysis {
-  strengths: string;
-  weaknesses: string;
-  opportunities: string;
-  threats: string;
+  strengths: string[];
+  weaknesses: string[];
+  opportunities: string[];
+  threats: string[];
 }
 
 // --- Performance Management Types ---


### PR DESCRIPTION
## Summary

- Migrates 11 BMC + 4 SWOT text columns to `jsonb` arrays in Supabase via `006_bmc_swot_jsonb.sql` (includes rollback plan)
- Updates `types.ts`: `SustainabilityBusinessModel` and `SwotAnalysis` all fields `string` → `string[]`
- Updates `dbService.ts`: `toStringArray()` helper handles both new jsonb and legacy text format during transition
- Rewrites `BusinessModelCanvas.tsx`: replaces textareas with item-list UI (`ArrayFieldEditor` in wizard, `CanvasCard` in grid view); AI suggest merges new items without duplicates
- Rewrites `SwotAnalysisWizard.tsx`: replaces textareas with `ArrayFieldEditor` for all four SWOT fields; matrix view renders structured bullet lists
- Updates AI functions (`api.ts`, `geminiService.ts`): `generateCanvasSuggestion` and `generateSwotInternal` use JSON schema to return arrays; `generateSwotExternal` parses grounded search text (Google Search grounding is incompatible with JSON schema mode)

## Test plan

- [x] BMC wizard: add/remove items in each field; verify saved to DB as jsonb array
- [x] BMC grid: add/remove items in each canvas card; verify correct display
- [x] BMC AI suggest: click "AI Suggest" — new items appear in list without duplicating existing ones
- [x] SWOT step 1: "Auto-Analyze Internal" populates Strengths + Weaknesses as arrays
- [x] SWOT step 2: "Search News" for Opportunities/Threats populates as arrays
- [x] SWOT step 3 matrix: all four quadrants render as bullet lists
- [x] Run `006_bmc_swot_jsonb.sql` on staging — verify existing text data migrates cleanly
- [x] Legacy data: verify `toStringArray()` correctly parses old bullet-text rows

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)