### PR TITLE
feat(issue-05): DMA Insight Hub — analyzeDMAQuality backend action

### DIFF
--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -224,6 +224,8 @@ async function runAction(
       return generateKPISuggestions(ai, model, params);
     case "generateSustainabilityStatement":
       return generateSustainabilityStatement(ai, model, params);
+    case "analyzeDMAQuality":
+      return analyzeDMAQuality(ai, model, params);
     default:
       throw new Error(`Unknown action: ${action}`);
   }
@@ -772,6 +774,207 @@ async function generateSustainabilityStatement(
     },
     inputTokens,
     outputTokens,
+  };
+}
+
+async function analyzeDMAQuality(
+  ai: GoogleGenAI,
+  model: string,
+  { assessments, bmcItems, swotItems, profile }: any
+) {
+  if (!assessments || assessments.length === 0) {
+    return {
+      result: { qualityChecks: [], strategicInsight: { summary: "", keyRisks: [], opportunities: [], bottomLine: "" }, recommendedActions: [] },
+      inputTokens: 0,
+      outputTokens: 0,
+    };
+  }
+
+  const companyCtx = profile ? buildCompanyContext(profile) : "";
+
+  const assessmentSummary = assessments
+    .map((a: any) => {
+      const impactScore = a.impactMaterialityValue ?? a.impact_score ?? 0;
+      const financialScore = a.financialMaterialityValue ?? a.financial_score ?? 0;
+      const material = a.isMaterial ?? a.is_material ?? false;
+      const impactDesc = a.impactDescription ?? a.impact_description ?? "";
+      const financialDesc = a.financialDescription ?? a.financial_description ?? "";
+      const scores = a.impactScore ?? {};
+      return [
+        `Topic: ${a.topic} (${a.topicTitle || ""})`,
+        `  Material: ${material ? "Yes" : "No"}`,
+        `  Impact score: ${impactScore}/100 — ${impactDesc}`,
+        `  Financial score: ${financialScore}/100 — ${financialDesc}`,
+        scores.scale ? `  Scores: scale=${scores.scale} scope=${scores.scope} irremediability=${scores.irremediability} likelihood=${scores.likelihood}` : "",
+      ].filter(Boolean).join("\n");
+    })
+    .join("\n\n");
+
+  const bmcContext = bmcItems
+    ? [
+        bmcItems.key_activities?.length ? `Key activities: ${joinField(bmcItems.key_activities)}` : "",
+        bmcItems.eco_social_costs?.length ? `Eco-social costs: ${joinField(bmcItems.eco_social_costs)}` : "",
+        bmcItems.eco_social_benefits?.length ? `Eco-social benefits: ${joinField(bmcItems.eco_social_benefits)}` : "",
+      ].filter(Boolean).join("\n")
+    : "";
+
+  const swotContext = swotItems
+    ? [
+        swotItems.threats?.length ? `Threats: ${joinField(swotItems.threats)}` : "",
+        swotItems.opportunities?.length ? `Opportunities: ${joinField(swotItems.opportunities)}` : "",
+      ].filter(Boolean).join("\n")
+    : "";
+
+  const prompt = `
+You are a senior ESRS/CSRD sustainability advisor performing a quality review of a Double Materiality Assessment (DMA) for an SME.
+
+${companyCtx}
+
+${bmcContext ? `Business context:\n${bmcContext}` : ""}
+${swotContext ? `Strategic context:\n${swotContext}` : ""}
+
+DMA Assessment Results:
+${assessmentSummary}
+
+Your task: Analyse the quality and completeness of this DMA and provide:
+
+1. QUALITY CHECKS — For each assessed topic, flag issues a CSRD auditor would raise.
+   - "needs_fix": critical gaps that would fail compliance review
+   - "review": concerns worth reviewing but not blocking
+   - "ok": meets minimum ESRS requirements
+   Focus on: missing coverage of required sub-topics, scores that seem inconsistent with the company context, descriptions too vague for disclosure, and material topics with suspiciously low scores.
+
+2. STRATEGIC INSIGHT — CEO-level summary in plain language (no ESRS jargon). What does this DMA mean for the business? What must they act on urgently?
+
+3. RECOMMENDED ACTIONS — Prioritised list of concrete next steps.
+   - "fix": correct an incomplete or inconsistent assessment (source_type: "dma")
+   - "comply": meet a specific ESRS requirement for a material topic
+   - "improve": strategic opportunity beyond compliance
+
+Return ONLY valid JSON matching this exact structure:
+{
+  "qualityChecks": [
+    {
+      "topic": "E1",
+      "topicTitle": "Climate Change",
+      "status": "needs_fix",
+      "issues": [
+        {
+          "severity": "high",
+          "title": "Missing transition risk analysis",
+          "description": "...",
+          "esrs_ref": "ESRS E1-6",
+          "fix_suggestion": "..."
+        }
+      ]
+    }
+  ],
+  "strategicInsight": {
+    "summary": "...",
+    "keyRisks": ["...", "..."],
+    "opportunities": ["...", "..."],
+    "bottomLine": "..."
+  },
+  "recommendedActions": [
+    {
+      "id": "action-1",
+      "type": "fix",
+      "priority": "high",
+      "title": "...",
+      "description": "...",
+      "esrs_ref": "ESRS E1-6",
+      "source_type": "dma",
+      "source_id": "uuid-or-topic-code",
+      "estimated_time": "2 hours"
+    }
+  ]
+}
+
+No markdown, no backticks, no explanation outside the JSON.
+  `;
+
+  const issueSchema = {
+    type: Type.OBJECT,
+    required: ["severity", "title", "description", "esrs_ref", "fix_suggestion"],
+    properties: {
+      severity:       { type: Type.STRING },
+      title:          { type: Type.STRING },
+      description:    { type: Type.STRING },
+      esrs_ref:       { type: Type.STRING },
+      fix_suggestion: { type: Type.STRING },
+    },
+  };
+
+  const response = await ai.models.generateContent({
+    model,
+    contents: prompt,
+    config: {
+      responseMimeType: "application/json",
+      responseSchema: {
+        type: Type.OBJECT,
+        required: ["qualityChecks", "strategicInsight", "recommendedActions"],
+        properties: {
+          qualityChecks: {
+            type: Type.ARRAY,
+            items: {
+              type: Type.OBJECT,
+              required: ["topic", "topicTitle", "status", "issues"],
+              properties: {
+                topic:      { type: Type.STRING },
+                topicTitle: { type: Type.STRING },
+                status:     { type: Type.STRING },
+                issues:     { type: Type.ARRAY, items: issueSchema },
+              },
+            },
+          },
+          strategicInsight: {
+            type: Type.OBJECT,
+            required: ["summary", "keyRisks", "opportunities", "bottomLine"],
+            properties: {
+              summary:       { type: Type.STRING },
+              keyRisks:      { type: Type.ARRAY, items: { type: Type.STRING } },
+              opportunities: { type: Type.ARRAY, items: { type: Type.STRING } },
+              bottomLine:    { type: Type.STRING },
+            },
+          },
+          recommendedActions: {
+            type: Type.ARRAY,
+            items: {
+              type: Type.OBJECT,
+              required: ["id", "type", "priority", "title", "description", "esrs_ref", "source_type", "source_id", "estimated_time"],
+              properties: {
+                id:             { type: Type.STRING },
+                type:           { type: Type.STRING },
+                priority:       { type: Type.STRING },
+                title:          { type: Type.STRING },
+                description:    { type: Type.STRING },
+                esrs_ref:       { type: Type.STRING },
+                source_type:    { type: Type.STRING },
+                source_id:      { type: Type.STRING },
+                estimated_time: { type: Type.STRING },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const fallback = {
+    qualityChecks: [],
+    strategicInsight: { summary: "", keyRisks: [], opportunities: [], bottomLine: "" },
+    recommendedActions: [],
+  };
+
+  const parsed = parseAIJson(response.text, fallback);
+
+  return {
+    result: {
+      qualityChecks:      Array.isArray(parsed?.qualityChecks) ? parsed.qualityChecks : [],
+      strategicInsight:   parsed?.strategicInsight ?? fallback.strategicInsight,
+      recommendedActions: Array.isArray(parsed?.recommendedActions) ? parsed.recommendedActions : [],
+    },
+    ...extractTokens(response),
   };
 }
 

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -1,4 +1,4 @@
-import { ESRSTopic, SustainabilityBusinessModel, SwotAnalysis, BSCPerspective, AssessmentData, CompanyProfile, AssessmentScoring } from "../types";
+import { ESRSTopic, SustainabilityBusinessModel, SwotAnalysis, BSCPerspective, AssessmentData, CompanyProfile, AssessmentScoring, InsightHubResponse } from "../types";
 import { supabase } from "../lib/supabaseClient";
 
 const API_ENDPOINT = "/.netlify/functions/api";
@@ -143,4 +143,23 @@ export const generateSustainabilityStatement = async (
 ): Promise<GeneratedStatement> => {
   // Re-throws so the caller can show a real error message instead of a silent null.
   return await callApi("generateSustainabilityStatement", { profile, materialAssessments });
+};
+
+export const generateDMAInsight = async (
+  assessments: AssessmentData[],
+  bmcData: SustainabilityBusinessModel,
+  swotData: SwotAnalysis,
+  profile: CompanyProfile,
+): Promise<InsightHubResponse> => {
+  const bmcItems = {
+    key_activities: bmcData.keyActivities,
+    eco_social_costs: bmcData.ecoSocialCosts,
+    eco_social_benefits: bmcData.ecoSocialBenefits,
+  };
+  const swotItems = {
+    threats: swotData.threats,
+    opportunities: swotData.opportunities,
+  };
+  // Re-throws so the caller can show a meaningful error.
+  return await callApi("analyzeDMAQuality", { assessments, bmcItems, swotItems, profile });
 };

--- a/types.ts
+++ b/types.ts
@@ -280,6 +280,52 @@ export interface EvidenceAttachment {
   uploaded_at: string;
 }
 
+// --- DMA Insight Hub ---
+
+export type QualityCheckStatus = 'needs_fix' | 'review' | 'ok';
+export type InsightActionType = 'fix' | 'comply' | 'improve';
+export type InsightActionPriority = 'high' | 'medium' | 'low';
+
+export interface QualityIssue {
+  severity: 'high' | 'medium' | 'low';
+  title: string;
+  description: string;
+  esrs_ref: string;
+  fix_suggestion: string;
+}
+
+export interface QualityCheck {
+  topic: string;
+  topicTitle: string;
+  status: QualityCheckStatus;
+  issues: QualityIssue[];
+}
+
+export interface StrategicInsight {
+  summary: string;
+  keyRisks: string[];
+  opportunities: string[];
+  bottomLine: string;
+}
+
+export interface RecommendedAction {
+  id: string;
+  type: InsightActionType;
+  priority: InsightActionPriority;
+  title: string;
+  description: string;
+  esrs_ref: string;
+  source_type: string;
+  source_id: string;
+  estimated_time: string;
+}
+
+export interface InsightHubResponse {
+  qualityChecks: QualityCheck[];
+  strategicInsight: StrategicInsight;
+  recommendedActions: RecommendedAction[];
+}
+
 // --- Notifications ---
 
 export type NotificationChannelType = 'in_app' | 'email' | 'line' | 'slack' | 'webhook';


### PR DESCRIPTION
Closes #32

## Summary
- New `analyzeDMAQuality` action in `netlify/functions/api.ts` that calls Gemini with all DMA assessment data and returns quality checks, strategic insight, and recommended actions
- New `InsightHubResponse`, `QualityCheck`, `StrategicInsight`, `RecommendedAction` types in `types.ts`
- New `generateDMAInsight()` export in `services/geminiService.ts` (re-throws so caller can display errors)

## What the API returns
- **qualityChecks[]** — per-topic traffic light (`needs_fix` / `review` / `ok`) with ESRS-referenced issues and fix suggestions
- **strategicInsight** — CEO-level summary, key risks, opportunities, bottom line in plain language
- **recommendedActions[]** — prioritised `fix | comply | improve` actions with ESRS refs and source links

## Test plan
- [ ] Call `analyzeDMAQuality` from browser console with mock assessment data and verify JSON shape
- [ ] Empty `assessments[]` returns empty result without calling Gemini
- [ ] AI usage logged to `ai_usage_log` after a successful call
- [ ] Type errors: run `npx tsc --noEmit` — must be clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)