### PR TITLE
feat(issue-06): DMA Insight Hub UI

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -513,10 +513,10 @@ const App: React.FC = () => {
                     onQualityCheckReady={(assessmentId, check) => {
                       if (orgId) saveQualityCheck(assessmentId, orgId, check);
                     }}
-                    onEditTopic={(topicCode, qualityCheck) => {
-                      const match = assessments.find(a =>
-                        String(a.topic).startsWith(topicCode)
-                      );
+                    onEditTopic={(topicCode, assessmentId, qualityCheck) => {
+                      // Prefer the exact record that was analyzed (by ID); fall back to topic code match.
+                      const match = assessments.find(a => a.id === assessmentId)
+                        ?? assessments.find(a => String(a.topic).startsWith(topicCode));
                       setEditingAssessment(match ?? null);
                       setHubQualityCheck(qualityCheck ?? null);
                       setIsFormOpen(true);

--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { AssessmentData, ESRSTopic, SustainabilityBusinessModel, SwotAnalysis, CompanyProfile, KPI, BSCPerspective } from './types';
 import AssessmentForm from './components/AssessmentForm';
+import DMAInsightHub from './components/DMAInsightHub';
 import MaterialityMatrix from './components/MaterialityMatrix';
 import BusinessModelCanvas from './components/BusinessModelCanvas';
 import SwotAnalysisWizard from './components/SwotAnalysisWizard';
@@ -66,7 +67,7 @@ const App: React.FC = () => {
   };
 
   // UI state
-  const [view, setView] = useState<'overview' | 'profile' | 'dm_dashboard' | 'canvas' | 'swot' | 'kpi' | 'assess' | 'report'>('overview');
+  const [view, setView] = useState<'overview' | 'profile' | 'dm_dashboard' | 'canvas' | 'swot' | 'kpi' | 'assess' | 'report' | 'insight_hub'>('overview');
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
   const [editingAssessment, setEditingAssessment] = useState<AssessmentData | null>(null);
@@ -290,7 +291,7 @@ const App: React.FC = () => {
                 <span className="font-medium text-slate-800 dark:text-white hidden sm:inline">
                   {view === 'overview' && 'Overview'}
                   {(view === 'profile' || view === 'canvas' || view === 'swot' || view === 'kpi') && 'My Business'}
-                  {(view === 'dm_dashboard' || view === 'assess' || view === 'report') && 'Double Materiality'}
+                  {(view === 'dm_dashboard' || view === 'assess' || view === 'report' || view === 'insight_hub') && 'Double Materiality'}
                 </span>
                 <ChevronRight className="w-4 h-4 hidden sm:block" />
                 <span className="truncate">
@@ -302,6 +303,7 @@ const App: React.FC = () => {
                   {view === 'dm_dashboard' && 'Materiality Dashboard'}
                   {view === 'assess' && 'Materiality Assessments'}
                   {view === 'report' && 'Sustainability Statement'}
+                  {view === 'insight_hub' && 'DMA Insight Hub'}
                 </span>
               </div>
             </div>
@@ -426,6 +428,15 @@ const App: React.FC = () => {
                         <div className="mt-12 text-left w-full">
                           <div className="flex justify-between items-center border-b border-slate-200 dark:border-slate-700 pb-4 mb-4">
                             <h3 className="font-bold text-slate-800 dark:text-white">Assessment History</h3>
+                            {assessments.length > 0 && (
+                              <button
+                                onClick={() => setView('insight_hub')}
+                                className="flex items-center gap-2 bg-esg-600 text-white px-4 py-2 rounded-lg text-sm font-medium hover:bg-esg-700 transition-colors"
+                              >
+                                Review &amp; Continue
+                                <ChevronRight className="w-4 h-4" />
+                              </button>
+                            )}
                           </div>
                           {assessments.length === 0 ? (
                             <div className="p-8 text-center border border-dashed border-slate-300 dark:border-slate-700 rounded-lg bg-slate-50 dark:bg-slate-800/50 text-slate-400">No assessments recorded yet.</div>
@@ -453,6 +464,17 @@ const App: React.FC = () => {
 
                 {view === 'report' && (
                   <SustainabilityStatement profile={profile.data} assessments={assessments} canvas={canvas.data} organizationId={organization.id} />
+                )}
+
+                {view === 'insight_hub' && (
+                  <DMAInsightHub
+                    assessments={assessments}
+                    profile={profile.data}
+                    bmcData={canvas.data}
+                    swotData={swot.data}
+                    onBack={() => setView('assess')}
+                    onContinue={() => setView('kpi')}
+                  />
                 )}
               </>
             )}

--- a/App.tsx
+++ b/App.tsx
@@ -474,6 +474,14 @@ const App: React.FC = () => {
                     swotData={swot.data}
                     onBack={() => setView('assess')}
                     onContinue={() => setView('kpi')}
+                    onEditTopic={(topicCode) => {
+                      const match = assessments.find(a =>
+                        String(a.topic).startsWith(topicCode)
+                      );
+                      setEditingAssessment(match ?? null);
+                      setIsFormOpen(true);
+                      setView('assess');
+                    }}
                   />
                 )}
               </>

--- a/App.tsx
+++ b/App.tsx
@@ -24,7 +24,7 @@ import {
 } from './services/dbService';
 import { setOrganizationContext } from './services/geminiService';
 import { Plus, FileText, BarChart3, CheckCircle, AlertTriangle, Grid, Moon, Sun, Target, Home, ChevronRight, Building2, Menu, X, TrendingUp, ChevronsLeft, ChevronsRight, LogOut, Loader2 } from 'lucide-react';
-import type { InsightHubResponse } from './types';
+import type { InsightHubResponse, QualityCheck } from './types';
 
 const DEFAULT_PROFILE: CompanyProfile = {
   name: '', taxId: '', industry: '', isicCode: '', foundingYear: '',
@@ -76,6 +76,9 @@ const App: React.FC = () => {
   const [cachedInsight, setCachedInsight] = useState<InsightHubResponse | null>(null);
   // Whether the assessment form was opened from the insight hub (to enable "back to hub" navigation)
   const [editFromHub, setEditFromHub] = useState(false);
+  // Quality check context for the topic being edited from the hub — passed to AssessmentForm
+  // so AI auto-fill knows which issues to address
+  const [hubQualityCheck, setHubQualityCheck] = useState<QualityCheck | null>(null);
 
   // DB-backed singleton data (auto-save + manual save)
   const orgId = organization?.id ?? null;
@@ -136,6 +139,7 @@ const App: React.FC = () => {
       setCachedInsight(null);
       if (editFromHub) {
         setEditFromHub(false);
+        setHubQualityCheck(null);
         setView('insight_hub');
       } else {
         setView('dm_dashboard');
@@ -469,9 +473,14 @@ const App: React.FC = () => {
                           onCancel={() => {
                             setIsFormOpen(false);
                             setEditingAssessment(null);
-                            if (editFromHub) { setEditFromHub(false); setView('insight_hub'); }
+                            if (editFromHub) {
+                              setEditFromHub(false);
+                              setHubQualityCheck(null);
+                              setView('insight_hub');
+                            }
                           }}
                           initialData={editingAssessment}
+                          qualityCheckContext={editFromHub ? hubQualityCheck : null}
                         />
                       </div>
                     )}
@@ -492,11 +501,12 @@ const App: React.FC = () => {
                     onContinue={() => setView('kpi')}
                     cachedInsight={cachedInsight}
                     onInsightReady={setCachedInsight}
-                    onEditTopic={(topicCode) => {
+                    onEditTopic={(topicCode, qualityCheck) => {
                       const match = assessments.find(a =>
                         String(a.topic).startsWith(topicCode)
                       );
                       setEditingAssessment(match ?? null);
+                      setHubQualityCheck(qualityCheck ?? null);
                       setIsFormOpen(true);
                       setEditFromHub(true);
                       setView('assess');

--- a/App.tsx
+++ b/App.tsx
@@ -21,6 +21,7 @@ import {
   fromDbSwot, toDbSwot,
   fetchAssessments, upsertAssessment, deleteAssessment,
   fetchKpis, upsertKpi, deleteKpi,
+  saveQualityCheck, saveDMAInsight, clearDMAInsight, loadDMAInsight, saveDMASuggestedTasks,
 } from './services/dbService';
 import { setOrganizationContext } from './services/geminiService';
 import { Plus, FileText, BarChart3, CheckCircle, AlertTriangle, Grid, Moon, Sun, Target, Home, ChevronRight, Building2, Menu, X, TrendingUp, ChevronsLeft, ChevronsRight, LogOut, Loader2 } from 'lucide-react';
@@ -104,11 +105,12 @@ const App: React.FC = () => {
     if (!orgId) { setArrayLoading(false); return; }
     let cancelled = false;
     setArrayLoading(true);
-    Promise.all([fetchAssessments(orgId), fetchKpis(orgId)])
-      .then(([a, k]) => {
+    Promise.all([fetchAssessments(orgId), fetchKpis(orgId), loadDMAInsight(orgId)])
+      .then(([a, k, insight]) => {
         if (cancelled) return;
         setAssessments(a);
         setKpis(k);
+        setCachedInsight(insight);
       })
       .catch(err => {
         // eslint-disable-next-line no-console
@@ -135,8 +137,9 @@ const App: React.FC = () => {
         setAssessments(prev => [saved, ...prev]);
       }
       setIsFormOpen(false);
-      // Assessments changed — clear cached insight so hub re-analyses next visit
+      // Assessments changed — clear cached insight so hub re-analyses fresh on next visit.
       setCachedInsight(null);
+      if (orgId) clearDMAInsight(orgId);
       if (editFromHub) {
         setEditFromHub(false);
         setHubQualityCheck(null);
@@ -500,7 +503,16 @@ const App: React.FC = () => {
                     onBack={() => setView('assess')}
                     onContinue={() => setView('kpi')}
                     cachedInsight={cachedInsight}
-                    onInsightReady={setCachedInsight}
+                    onInsightReady={(result) => {
+                      setCachedInsight(result);
+                      if (orgId) {
+                        saveDMAInsight(orgId, result.strategicInsight, result.recommendedActions);
+                        saveDMASuggestedTasks(orgId, result.recommendedActions, assessments);
+                      }
+                    }}
+                    onQualityCheckReady={(assessmentId, check) => {
+                      if (orgId) saveQualityCheck(assessmentId, orgId, check);
+                    }}
                     onEditTopic={(topicCode, qualityCheck) => {
                       const match = assessments.find(a =>
                         String(a.topic).startsWith(topicCode)

--- a/App.tsx
+++ b/App.tsx
@@ -24,6 +24,7 @@ import {
 } from './services/dbService';
 import { setOrganizationContext } from './services/geminiService';
 import { Plus, FileText, BarChart3, CheckCircle, AlertTriangle, Grid, Moon, Sun, Target, Home, ChevronRight, Building2, Menu, X, TrendingUp, ChevronsLeft, ChevronsRight, LogOut, Loader2 } from 'lucide-react';
+import type { InsightHubResponse } from './types';
 
 const DEFAULT_PROFILE: CompanyProfile = {
   name: '', taxId: '', industry: '', isicCode: '', foundingYear: '',
@@ -71,6 +72,10 @@ const App: React.FC = () => {
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
   const [editingAssessment, setEditingAssessment] = useState<AssessmentData | null>(null);
+  // Cached insight hub result — cleared when user explicitly re-analyses or assessments change
+  const [cachedInsight, setCachedInsight] = useState<InsightHubResponse | null>(null);
+  // Whether the assessment form was opened from the insight hub (to enable "back to hub" navigation)
+  const [editFromHub, setEditFromHub] = useState(false);
 
   // DB-backed singleton data (auto-save + manual save)
   const orgId = organization?.id ?? null;
@@ -127,7 +132,14 @@ const App: React.FC = () => {
         setAssessments(prev => [saved, ...prev]);
       }
       setIsFormOpen(false);
-      setView('dm_dashboard');
+      // Assessments changed — clear cached insight so hub re-analyses next visit
+      setCachedInsight(null);
+      if (editFromHub) {
+        setEditFromHub(false);
+        setView('insight_hub');
+      } else {
+        setView('dm_dashboard');
+      }
     } catch (e: any) {
       alert(`Failed to save assessment: ${e?.message ?? 'Unknown error'}`);
     }
@@ -454,7 +466,11 @@ const App: React.FC = () => {
                           bmcData={canvas.data}
                           swotData={swot.data}
                           onSave={handleSaveAssessment}
-                          onCancel={() => { setIsFormOpen(false); setEditingAssessment(null); }}
+                          onCancel={() => {
+                            setIsFormOpen(false);
+                            setEditingAssessment(null);
+                            if (editFromHub) { setEditFromHub(false); setView('insight_hub'); }
+                          }}
                           initialData={editingAssessment}
                         />
                       </div>
@@ -474,12 +490,15 @@ const App: React.FC = () => {
                     swotData={swot.data}
                     onBack={() => setView('assess')}
                     onContinue={() => setView('kpi')}
+                    cachedInsight={cachedInsight}
+                    onInsightReady={setCachedInsight}
                     onEditTopic={(topicCode) => {
                       const match = assessments.find(a =>
                         String(a.topic).startsWith(topicCode)
                       );
                       setEditingAssessment(match ?? null);
                       setIsFormOpen(true);
+                      setEditFromHub(true);
                       setView('assess');
                     }}
                   />

--- a/components/AssessmentForm.tsx
+++ b/components/AssessmentForm.tsx
@@ -90,15 +90,34 @@ const AssessmentForm: React.FC<Props> = ({ profile, bmcData, swotData, onSave, o
     setLoadingScoring(false);
   };
 
-  // AI Auto-Fill: generate descriptions then immediately score based on them
+  const [autoFillError, setAutoFillError] = useState<string | null>(null);
+
+  // AI Auto-Fill: generate descriptions then auto-save so data is persisted immediately.
+  // Scoring is NOT triggered automatically — user can request it manually after reviewing.
   const handleAutoFill = async () => {
     setLoadingAI(true);
-    const suggestions = await generateAssessmentSuggestions(profile, topic);
-    setImpactDesc(suggestions.impactSuggestion);
-    setFinancialDesc(suggestions.financialSuggestion);
-    setLoadingAI(false);
-    // Trigger scoring with the freshly generated descriptions
-    await runAIScoring(suggestions.impactSuggestion, suggestions.financialSuggestion, topic);
+    setAutoFillError(null);
+    try {
+      const suggestions = await generateAssessmentSuggestions(profile, topic);
+      const imValue = calculateImpactMateriality(impactScore);
+      const fmValue = calculateFinancialMateriality(financialScore);
+      onSave({
+        id: initialData?.id || Math.random().toString(36).substr(2, 9),
+        topic,
+        impactDescription: suggestions.impactSuggestion,
+        financialDescription: suggestions.financialSuggestion,
+        impactScore,
+        financialScore,
+        impactMaterialityValue: imValue,
+        financialMaterialityValue: fmValue,
+        isMaterial: imValue > 40 || fmValue > 40,
+        aiScoringSuggestion: initialData?.aiScoringSuggestion ?? null,
+      });
+    } catch (err: any) {
+      setAutoFillError(err?.message ?? "AI auto-fill failed. Please try again.");
+    } finally {
+      setLoadingAI(false);
+    }
   };
 
   // Manual trigger: user typed their own descriptions and wants AI score suggestions
@@ -179,7 +198,7 @@ const AssessmentForm: React.FC<Props> = ({ profile, bmcData, swotData, onSave, o
             onClick={handleAutoFill}
             disabled={loadingAI || loadingScoring}
             className="flex items-center gap-1.5 bg-indigo-50 text-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300 px-3 py-1.5 rounded-lg hover:bg-indigo-100 dark:hover:bg-indigo-900/50 transition-colors text-sm font-medium disabled:opacity-50 shrink-0"
-            title="AI writes descriptions then immediately suggests scores"
+            title="AI writes descriptions and auto-saves. Request AI scores separately."
           >
             {loadingAI ? <Loader2 className="w-4 h-4 animate-spin" /> : <Cpu className="w-4 h-4" />}
             AI Auto-Fill
@@ -244,6 +263,17 @@ const AssessmentForm: React.FC<Props> = ({ profile, bmcData, swotData, onSave, o
           <X className="w-6 h-6" />
         </button>
       </div>
+
+      {/* ── Auto-fill error banner ── */}
+      {autoFillError && (
+        <div className="flex items-center gap-2 px-4 py-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg text-sm text-red-700 dark:text-red-400">
+          <AlertTriangle className="w-4 h-4 shrink-0" />
+          <span>{autoFillError}</span>
+          <button type="button" onClick={() => setAutoFillError(null)} className="ml-auto text-red-400 hover:text-red-600">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+      )}
 
       {/* ── Topic selector ── */}
       <div className="max-w-sm space-y-1.5">

--- a/components/AssessmentForm.tsx
+++ b/components/AssessmentForm.tsx
@@ -92,27 +92,20 @@ const AssessmentForm: React.FC<Props> = ({ profile, bmcData, swotData, onSave, o
 
   const [autoFillError, setAutoFillError] = useState<string | null>(null);
 
-  // AI Auto-Fill: generate descriptions then auto-save so data is persisted immediately.
-  // Scoring is NOT triggered automatically — user can request it manually after reviewing.
+  // AI Auto-Fill: populate description fields and keep the form open for review.
+  // Scoring is NOT triggered — the "Get Suggestions" button becomes available once
+  // descriptions are present; user can click it manually after reviewing.
   const handleAutoFill = async () => {
     setLoadingAI(true);
     setAutoFillError(null);
     try {
       const suggestions = await generateAssessmentSuggestions(profile, topic);
-      const imValue = calculateImpactMateriality(impactScore);
-      const fmValue = calculateFinancialMateriality(financialScore);
-      onSave({
-        id: initialData?.id || Math.random().toString(36).substr(2, 9),
-        topic,
-        impactDescription: suggestions.impactSuggestion,
-        financialDescription: suggestions.financialSuggestion,
-        impactScore,
-        financialScore,
-        impactMaterialityValue: imValue,
-        financialMaterialityValue: fmValue,
-        isMaterial: imValue > 40 || fmValue > 40,
-        aiScoringSuggestion: initialData?.aiScoringSuggestion ?? null,
-      });
+      setImpactDesc(suggestions.impactSuggestion);
+      setFinancialDesc(suggestions.financialSuggestion);
+      // Reset any prior scoring so "Get Suggestions" button reappears
+      setAiScoring(null);
+      setScoringError(false);
+      setOverrides(new Set());
     } catch (err: any) {
       setAutoFillError(err?.message ?? "AI auto-fill failed. Please try again.");
     } finally {

--- a/components/AssessmentForm.tsx
+++ b/components/AssessmentForm.tsx
@@ -1,7 +1,7 @@
 
 import React, { useState, useEffect, useRef } from 'react';
 import { createPortal } from 'react-dom';
-import { AssessmentData, ESRSTopic, ImpactScore, FinancialScore, CompanyProfile, SustainabilityBusinessModel, SwotAnalysis, AssessmentScoring } from '../types';
+import { AssessmentData, ESRSTopic, ImpactScore, FinancialScore, CompanyProfile, SustainabilityBusinessModel, SwotAnalysis, AssessmentScoring, QualityCheck } from '../types';
 import { SCALE_OPTIONS, LIKELIHOOD_OPTIONS, calculateImpactMateriality, calculateFinancialMateriality, TOPICS } from '../constants';
 import { generateAssessmentSuggestions, generateAssessmentScoring } from '../services/geminiService';
 import { AlertCircle, TrendingUp, Cpu, Loader2, Save, X, Sparkles, RotateCcw, AlertTriangle } from 'lucide-react';
@@ -13,11 +13,12 @@ interface Props {
   onSave: (data: AssessmentData) => void;
   onCancel: () => void;
   initialData?: AssessmentData | null;
+  qualityCheckContext?: QualityCheck | null;
 }
 
 type OverrideKey = 'impact.scale' | 'impact.scope' | 'impact.irremediability' | 'impact.likelihood' | 'financial.magnitude' | 'financial.likelihood';
 
-const AssessmentForm: React.FC<Props> = ({ profile, bmcData, swotData, onSave, onCancel, initialData }) => {
+const AssessmentForm: React.FC<Props> = ({ profile, bmcData, swotData, onSave, onCancel, initialData, qualityCheckContext }) => {
   const [topic, setTopic] = useState<ESRSTopic>(ESRSTopic.E1);
   const [impactDesc, setImpactDesc] = useState('');
   const [financialDesc, setFinancialDesc] = useState('');
@@ -99,7 +100,7 @@ const AssessmentForm: React.FC<Props> = ({ profile, bmcData, swotData, onSave, o
     setLoadingAI(true);
     setAutoFillError(null);
     try {
-      const suggestions = await generateAssessmentSuggestions(profile, topic);
+      const suggestions = await generateAssessmentSuggestions(profile, topic, qualityCheckContext ?? undefined);
       setImpactDesc(suggestions.impactSuggestion);
       setFinancialDesc(suggestions.financialSuggestion);
       // Reset any prior scoring so "Get Suggestions" button reappears
@@ -256,6 +257,18 @@ const AssessmentForm: React.FC<Props> = ({ profile, bmcData, swotData, onSave, o
           <X className="w-6 h-6" />
         </button>
       </div>
+
+      {/* ── Quality check context banner ── */}
+      {qualityCheckContext && qualityCheckContext.issues.length > 0 && (
+        <div className="flex items-start gap-2 px-4 py-3 bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 rounded-lg text-sm text-amber-800 dark:text-amber-300">
+          <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" />
+          <div>
+            <span className="font-semibold">Quality check context loaded — </span>
+            {qualityCheckContext.issues.length} issue{qualityCheckContext.issues.length > 1 ? 's' : ''} found for {qualityCheckContext.topic}.
+            {' '}AI Auto-Fill will address these when regenerating descriptions.
+          </div>
+        </div>
+      )}
 
       {/* ── Auto-fill error banner ── */}
       {autoFillError && (

--- a/components/DMAInsightHub.tsx
+++ b/components/DMAInsightHub.tsx
@@ -37,6 +37,8 @@ interface Props {
   onBack: () => void;
   onContinue: () => void;
   onEditTopic: (topicCode: string) => void;
+  cachedInsight?: InsightHubResponse | null;
+  onInsightReady?: (result: InsightHubResponse) => void;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -51,20 +53,24 @@ const DMAInsightHub: React.FC<Props> = ({
   onBack,
   onContinue,
   onEditTopic,
+  cachedInsight,
+  onInsightReady,
 }) => {
-  const [loading, setLoading] = useState(true);
+  const [loading, setLoading] = useState(!cachedInsight);
   const [error, setError] = useState<string | null>(null);
-  const [insight, setInsight] = useState<InsightHubResponse | null>(null);
+  const [insight, setInsight] = useState<InsightHubResponse | null>(cachedInsight ?? null);
 
-  useEffect(() => {
+  const runAnalysis = React.useCallback(() => {
     let cancelled = false;
     setLoading(true);
     setError(null);
+    setInsight(null);
 
     generateDMAInsight(assessments, bmcData, swotData, profile)
       .then((result) => {
         if (!cancelled) {
           setInsight(result);
+          onInsightReady?.(result);
           setLoading(false);
         }
       })
@@ -76,6 +82,11 @@ const DMAInsightHub: React.FC<Props> = ({
       });
 
     return () => { cancelled = true; };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [assessments, bmcData, swotData, profile]);
+
+  useEffect(() => {
+    if (!cachedInsight) return runAnalysis();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
@@ -90,11 +101,7 @@ const DMAInsightHub: React.FC<Props> = ({
         <h2 className="text-xl font-bold text-slate-800 dark:text-white mb-2">Analysis Failed</h2>
         <p className="text-slate-500 dark:text-slate-400 max-w-md mb-6">{error}</p>
         <button
-          onClick={() => { setError(null); setLoading(true); setInsight(null);
-            generateDMAInsight(assessments, bmcData, swotData, profile)
-              .then(setInsight).catch((e) => setError(e instanceof Error ? e.message : "Error"))
-              .finally(() => setLoading(false));
-          }}
+          onClick={runAnalysis}
           className="px-6 py-2.5 bg-esg-600 text-white rounded-lg hover:bg-esg-700 transition-colors font-medium"
         >
           Retry Analysis
@@ -106,11 +113,20 @@ const DMAInsightHub: React.FC<Props> = ({
   return (
     <div className="max-w-5xl mx-auto px-4 py-8 space-y-8 animate-in fade-in duration-500">
       {/* Header */}
-      <div>
-        <h1 className="text-2xl font-bold text-slate-800 dark:text-white">DMA Insight Hub</h1>
-        <p className="text-slate-500 dark:text-slate-400 mt-1 text-sm">
-          AI-powered quality review of your Double Materiality Assessment
-        </p>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-800 dark:text-white">DMA Insight Hub</h1>
+          <p className="text-slate-500 dark:text-slate-400 mt-1 text-sm">
+            AI-powered quality review of your Double Materiality Assessment
+          </p>
+        </div>
+        <button
+          onClick={runAnalysis}
+          className="flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400 hover:text-esg-600 dark:hover:text-esg-400 border border-slate-300 dark:border-slate-600 rounded-lg px-3 py-1.5 transition-colors flex-shrink-0"
+        >
+          <Loader2 className="w-3 h-3" />
+          Re-analyse
+        </button>
       </div>
 
       {/* Score banner */}

--- a/components/DMAInsightHub.tsx
+++ b/components/DMAInsightHub.tsx
@@ -60,7 +60,7 @@ type SynthesisPhase =
 // ─────────────────────────────────────────────────────────────────────────────
 
 const DMAInsightHub: React.FC<Props> = ({
-  assessments,
+  assessments: rawAssessments,
   profile,
   bmcData,
   swotData,
@@ -70,9 +70,32 @@ const DMAInsightHub: React.FC<Props> = ({
   cachedInsight,
   onInsightReady,
 }) => {
+  // Deduplicate by topic code — keep the highest-scored row per topic.
+  // Duplicate DB rows happen when a user saves the same ESRS topic more than once.
+  const assessments = React.useMemo(() => {
+    const seen = new Map<string, AssessmentData>();
+    for (const a of rawAssessments) {
+      const code = String(a.topic).split(" ")[0];
+      const existing = seen.get(code);
+      const score = (a.impactMaterialityValue ?? 0) + (a.financialMaterialityValue ?? 0);
+      const existingScore = existing ? (existing.impactMaterialityValue ?? 0) + (existing.financialMaterialityValue ?? 0) : -1;
+      if (!existing || score > existingScore) seen.set(code, a);
+    }
+    return [...seen.values()];
+  }, [rawAssessments]);
+
   const [topicStates, setTopicStates] = useState<Map<string, TopicPhase>>(() => {
     if (cachedInsight) {
-      return new Map(cachedInsight.qualityChecks.map((c) => [c.topic, { phase: "done", check: c } as TopicPhase]));
+      const map = new Map(cachedInsight.qualityChecks.map((c) => [c.topic, { phase: "done", check: c } as TopicPhase]));
+      // Topics that timed out in a previous run are absent from the cache.
+      // Show them as an error so the user can Re-analyse instead of spinning forever.
+      assessments.forEach((a) => {
+        const code = String(a.topic).split(" ")[0];
+        if (!map.has(code)) {
+          map.set(code, { phase: "error", message: "Previous check timed out — click Re-analyse to retry." });
+        }
+      });
+      return map;
     }
     return new Map(assessments.map((a) => [String(a.topic).split(" ")[0], { phase: "loading" } as TopicPhase]));
   });

--- a/components/DMAInsightHub.tsx
+++ b/components/DMAInsightHub.tsx
@@ -37,7 +37,8 @@ interface Props {
   swotData: SwotAnalysis;
   onBack: () => void;
   onContinue: () => void;
-  onEditTopic: (topicCode: string, qualityCheck?: QualityCheck) => void;
+  /** assessmentId is the UUID of the specific record that was analyzed (deduplicated). */
+  onEditTopic: (topicCode: string, assessmentId: string, qualityCheck?: QualityCheck) => void;
   cachedInsight?: InsightHubResponse | null;
   onInsightReady?: (result: InsightHubResponse) => void;
   /** Called as each per-topic quality check resolves — used to persist results to DB. */
@@ -176,11 +177,18 @@ const DMAInsightHub: React.FC<Props> = ({
   const hasFixIssues = completedChecks.some((c) => c.status === "needs_fix");
   const isAnalysing = [...topicStates.values()].some((s) => s.phase === "loading");
 
+  // Map topicCode → assessmentId for the deduplicated record — used by edit links.
+  const topicToAssessmentId = React.useMemo(
+    () => new Map(assessments.map((a) => [String(a.topic).split(" ")[0], a.id])),
+    [assessments],
+  );
+
   const handleEditTopic = React.useCallback((topicCode: string, qualityCheck?: QualityCheck) => {
     const state = topicStates.get(topicCode);
     const qc = qualityCheck ?? (state?.phase === "done" ? state.check : undefined);
-    onEditTopic(topicCode, qc);
-  }, [topicStates, onEditTopic]);
+    const assessmentId = topicToAssessmentId.get(topicCode) ?? "";
+    onEditTopic(topicCode, assessmentId, qc);
+  }, [topicStates, topicToAssessmentId, onEditTopic]);
 
   return (
     <div className="max-w-5xl mx-auto px-4 py-8 space-y-8">
@@ -203,7 +211,7 @@ const DMAInsightHub: React.FC<Props> = ({
       </div>
 
       {/* Score banner — updates as topic cards arrive */}
-      <ScoreBanner assessments={assessments} checks={completedChecks} />
+      <ScoreBanner assessments={assessments} rawCount={rawAssessments.length} checks={completedChecks} />
 
       {/* Quality checks — each card appears as its topic call resolves */}
       {assessments.length > 0 && (
@@ -301,12 +309,13 @@ const SynthesisSection: React.FC<{
 // Score banner
 // ─────────────────────────────────────────────────────────────────────────────
 
-const ScoreBanner: React.FC<{ assessments: AssessmentData[]; checks: QualityCheck[] }> = ({
-  assessments,
-  checks,
-}) => {
+const ScoreBanner: React.FC<{
+  assessments: AssessmentData[];
+  rawCount: number;
+  checks: QualityCheck[];
+}> = ({ assessments, rawCount, checks }) => {
+  const uniqueTopics = assessments.length;
   const materialCount = assessments.filter((a) => a.isMaterial).length;
-  const completionPct = assessments.length === 0 ? 0 : Math.round((assessments.length / 10) * 100);
   const fixCount = checks.filter((c) => c.status === "needs_fix").length;
   const reviewCount = checks.filter((c) => c.status === "review").length;
   const okCount = checks.filter((c) => c.status === "ok").length;
@@ -322,24 +331,31 @@ const ScoreBanner: React.FC<{ assessments: AssessmentData[]; checks: QualityChec
       ? "text-emerald-500"
       : "text-slate-400";
 
+  // Sub-label shown when there are duplicate records for the same topic
+  const topicsLabel = rawCount > uniqueTopics
+    ? `${rawCount} records · ${uniqueTopics} unique`
+    : "ESRS Topics";
+
   return (
     <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
       {[
-        { label: "Material Topics", value: `${materialCount}/10`, color: "text-esg-600 dark:text-esg-400" },
-        { label: "Assessments Done", value: `${completionPct}%`, color: "text-blue-600 dark:text-blue-400" },
+        { label: "Material Topics", value: `${materialCount}/10`, color: "text-esg-600 dark:text-esg-400", sub: null },
+        { label: "Topics Covered", value: `${uniqueTopics}/10`, color: "text-blue-600 dark:text-blue-400", sub: topicsLabel },
         {
           label: "Quality Status",
           value: `${fixCount > 0 ? `${fixCount} fix` : reviewCount > 0 ? `${reviewCount} review` : `${okCount} ok`}`,
           color: fixCount > 0 ? "text-red-500" : reviewCount > 0 ? "text-amber-500" : "text-emerald-500",
+          sub: null,
         },
-        { label: "Statement Ready", value: readiness, color: readinessColor },
-      ].map(({ label, value, color }) => (
+        { label: "Statement Ready", value: readiness, color: readinessColor, sub: null },
+      ].map(({ label, value, color, sub }) => (
         <div
           key={label}
           className="bg-white dark:bg-slate-800 rounded-xl p-5 border border-slate-200 dark:border-slate-700 shadow-sm text-center"
         >
           <div className={`text-2xl font-bold ${color}`}>{value}</div>
           <div className="text-xs text-slate-500 dark:text-slate-400 mt-1">{label}</div>
+          {sub && <div className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">{sub}</div>}
         </div>
       ))}
     </div>

--- a/components/DMAInsightHub.tsx
+++ b/components/DMAInsightHub.tsx
@@ -1,0 +1,521 @@
+import React, { useEffect, useState } from "react";
+import {
+  AlertTriangle,
+  ArrowLeft,
+  ArrowRight,
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+  Clock,
+  Lightbulb,
+  Loader2,
+  TrendingUp,
+  XCircle,
+  Zap,
+} from "lucide-react";
+import { generateDMAInsight } from "../services/geminiService";
+import type {
+  AssessmentData,
+  CompanyProfile,
+  InsightHubResponse,
+  QualityCheck,
+  RecommendedAction,
+  StrategicInsight,
+  SustainabilityBusinessModel,
+  SwotAnalysis,
+} from "../types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Types
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface Props {
+  assessments: AssessmentData[];
+  profile: CompanyProfile;
+  bmcData: SustainabilityBusinessModel;
+  swotData: SwotAnalysis;
+  onBack: () => void;
+  onContinue: () => void;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main component
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DMAInsightHub: React.FC<Props> = ({
+  assessments,
+  profile,
+  bmcData,
+  swotData,
+  onBack,
+  onContinue,
+}) => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [insight, setInsight] = useState<InsightHubResponse | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    generateDMAInsight(assessments, bmcData, swotData, profile)
+      .then((result) => {
+        if (!cancelled) {
+          setInsight(result);
+          setLoading(false);
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : "Failed to analyse assessments. Please try again.");
+          setLoading(false);
+        }
+      });
+
+    return () => { cancelled = true; };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const hasFixIssues = insight?.qualityChecks.some((c) => c.status === "needs_fix") ?? false;
+
+  if (loading) return <LoadingState />;
+
+  if (error) {
+    return (
+      <div className="flex flex-col items-center justify-center py-24 px-4 text-center">
+        <XCircle className="w-12 h-12 text-red-500 mb-4" />
+        <h2 className="text-xl font-bold text-slate-800 dark:text-white mb-2">Analysis Failed</h2>
+        <p className="text-slate-500 dark:text-slate-400 max-w-md mb-6">{error}</p>
+        <button
+          onClick={() => { setError(null); setLoading(true); setInsight(null);
+            generateDMAInsight(assessments, bmcData, swotData, profile)
+              .then(setInsight).catch((e) => setError(e instanceof Error ? e.message : "Error"))
+              .finally(() => setLoading(false));
+          }}
+          className="px-6 py-2.5 bg-esg-600 text-white rounded-lg hover:bg-esg-700 transition-colors font-medium"
+        >
+          Retry Analysis
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-8 space-y-8 animate-in fade-in duration-500">
+      {/* Header */}
+      <div>
+        <h1 className="text-2xl font-bold text-slate-800 dark:text-white">DMA Insight Hub</h1>
+        <p className="text-slate-500 dark:text-slate-400 mt-1 text-sm">
+          AI-powered quality review of your Double Materiality Assessment
+        </p>
+      </div>
+
+      {/* Score banner */}
+      <ScoreBanner assessments={assessments} checks={insight?.qualityChecks ?? []} />
+
+      {/* Quality checks */}
+      {insight && insight.qualityChecks.length > 0 && (
+        <QualityCheckSection checks={insight.qualityChecks} onFixTopic={onBack} />
+      )}
+
+      {/* Strategic insight */}
+      {insight?.strategicInsight && (
+        <StrategicInsightPanel insight={insight.strategicInsight} />
+      )}
+
+      {/* Recommended actions */}
+      {insight && insight.recommendedActions.length > 0 && (
+        <RecommendedActionsSection actions={insight.recommendedActions} onFixSource={onBack} />
+      )}
+
+      {/* Navigation */}
+      <div className="flex flex-col sm:flex-row items-center justify-between gap-4 pt-4 border-t border-slate-200 dark:border-slate-700">
+        <button
+          onClick={onBack}
+          className="flex items-center gap-2 px-5 py-2.5 rounded-lg border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors font-medium w-full sm:w-auto justify-center"
+        >
+          <ArrowLeft className="w-4 h-4" />
+          Back to Assessments
+        </button>
+
+        <div className="flex flex-col items-center gap-1 text-center">
+          {hasFixIssues && (
+            <p className="text-xs text-amber-600 dark:text-amber-400 flex items-center gap-1">
+              <AlertTriangle className="w-3 h-3" />
+              Some topics need attention before continuing
+            </p>
+          )}
+        </div>
+
+        <button
+          onClick={onContinue}
+          className="flex items-center gap-2 px-5 py-2.5 rounded-lg bg-esg-600 text-white hover:bg-esg-700 transition-colors font-medium w-full sm:w-auto justify-center"
+        >
+          Continue to KPI Dashboard
+          <ArrowRight className="w-4 h-4" />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Loading state
+// ─────────────────────────────────────────────────────────────────────────────
+
+const LoadingState: React.FC = () => (
+  <div className="flex flex-col items-center justify-center py-32 px-4 text-center">
+    <div className="relative mb-6">
+      <div className="w-16 h-16 rounded-full border-2 border-esg-200 dark:border-esg-900 flex items-center justify-center">
+        <Loader2 className="w-8 h-8 text-esg-600 animate-spin" />
+      </div>
+    </div>
+    <h2 className="text-xl font-bold text-slate-800 dark:text-white mb-2">Analysing your assessments…</h2>
+    <p className="text-slate-500 dark:text-slate-400 max-w-sm text-sm">
+      Reviewing quality, identifying gaps, and generating strategic insights from your DMA data.
+    </p>
+    <div className="mt-8 space-y-2 text-sm text-slate-400 dark:text-slate-500">
+      {["Checking ESRS coverage…", "Analysing materiality patterns…", "Building strategic insights…"].map((step) => (
+        <div key={step} className="flex items-center gap-2 justify-center">
+          <div className="w-1.5 h-1.5 rounded-full bg-esg-400 animate-pulse" />
+          {step}
+        </div>
+      ))}
+    </div>
+  </div>
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Score banner
+// ─────────────────────────────────────────────────────────────────────────────
+
+const ScoreBanner: React.FC<{ assessments: AssessmentData[]; checks: QualityCheck[] }> = ({
+  assessments,
+  checks,
+}) => {
+  const materialCount = assessments.filter((a) => a.isMaterial).length;
+  const completionPct = assessments.length === 0 ? 0 : Math.round((assessments.length / 10) * 100);
+  const fixCount = checks.filter((c) => c.status === "needs_fix").length;
+  const reviewCount = checks.filter((c) => c.status === "review").length;
+  const okCount = checks.filter((c) => c.status === "ok").length;
+
+  const readiness =
+    fixCount > 0 ? "Not Ready" : reviewCount > 0 ? "Needs Review" : materialCount > 0 ? "Ready" : "Incomplete";
+  const readinessColor =
+    fixCount > 0
+      ? "text-red-500"
+      : reviewCount > 0
+      ? "text-amber-500"
+      : materialCount > 0
+      ? "text-emerald-500"
+      : "text-slate-400";
+
+  return (
+    <div className="grid grid-cols-2 sm:grid-cols-4 gap-4">
+      {[
+        { label: "Material Topics", value: `${materialCount}/10`, color: "text-esg-600 dark:text-esg-400" },
+        { label: "Assessments Done", value: `${completionPct}%`, color: "text-blue-600 dark:text-blue-400" },
+        {
+          label: "Quality Status",
+          value: `${fixCount > 0 ? `${fixCount} fix` : reviewCount > 0 ? `${reviewCount} review` : `${okCount} ok`}`,
+          color: fixCount > 0 ? "text-red-500" : reviewCount > 0 ? "text-amber-500" : "text-emerald-500",
+        },
+        { label: "Statement Ready", value: readiness, color: readinessColor },
+      ].map(({ label, value, color }) => (
+        <div
+          key={label}
+          className="bg-white dark:bg-slate-800 rounded-xl p-5 border border-slate-200 dark:border-slate-700 shadow-sm text-center"
+        >
+          <div className={`text-2xl font-bold ${color}`}>{value}</div>
+          <div className="text-xs text-slate-500 dark:text-slate-400 mt-1">{label}</div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Quality check section
+// ─────────────────────────────────────────────────────────────────────────────
+
+const statusConfig = {
+  needs_fix: {
+    icon: <XCircle className="w-4 h-4 text-red-500" />,
+    label: "Must Fix",
+    border: "border-l-red-500",
+    bg: "bg-red-50 dark:bg-red-950/30",
+  },
+  review: {
+    icon: <AlertTriangle className="w-4 h-4 text-amber-500" />,
+    label: "Should Review",
+    border: "border-l-amber-500",
+    bg: "bg-amber-50 dark:bg-amber-950/30",
+  },
+  ok: {
+    icon: <CheckCircle2 className="w-4 h-4 text-emerald-500" />,
+    label: "Complete",
+    border: "border-l-emerald-500",
+    bg: "bg-emerald-50 dark:bg-emerald-950/30",
+  },
+};
+
+const QualityCheckSection: React.FC<{
+  checks: QualityCheck[];
+  onFixTopic: () => void;
+}> = ({ checks }) => {
+  const sorted = [...checks].sort((a, b) => {
+    const order = { needs_fix: 0, review: 1, ok: 2 };
+    return order[a.status] - order[b.status];
+  });
+
+  return (
+    <section>
+      <h2 className="text-lg font-semibold text-slate-800 dark:text-white mb-4 flex items-center gap-2">
+        <CheckCircle2 className="w-5 h-5 text-esg-500" />
+        Quality Check
+      </h2>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        {sorted.map((check) => (
+          <QualityCheckCard key={check.topic} check={check} />
+        ))}
+      </div>
+    </section>
+  );
+};
+
+const QualityCheckCard: React.FC<{ check: QualityCheck }> = ({ check }) => {
+  const [expanded, setExpanded] = useState(check.status === "needs_fix");
+  const cfg = statusConfig[check.status] ?? statusConfig.ok;
+
+  return (
+    <div
+      className={`rounded-xl border border-l-4 ${cfg.border} ${cfg.bg} border-slate-200 dark:border-slate-700 overflow-hidden`}
+    >
+      <button
+        className="w-full flex items-center justify-between px-4 py-3 text-left"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          <span aria-label={cfg.label}>{cfg.icon}</span>
+          <span className="font-semibold text-slate-800 dark:text-white text-sm truncate">
+            {check.topic} — {check.topicTitle}
+          </span>
+        </div>
+        <div className="flex items-center gap-2 flex-shrink-0 ml-2">
+          <span
+            className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+              check.status === "needs_fix"
+                ? "bg-red-100 dark:bg-red-900/50 text-red-700 dark:text-red-300"
+                : check.status === "review"
+                ? "bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-300"
+                : "bg-emerald-100 dark:bg-emerald-900/50 text-emerald-700 dark:text-emerald-300"
+            }`}
+          >
+            {cfg.label}
+          </span>
+          {expanded ? (
+            <ChevronUp className="w-4 h-4 text-slate-400" />
+          ) : (
+            <ChevronDown className="w-4 h-4 text-slate-400" />
+          )}
+        </div>
+      </button>
+
+      {expanded && check.issues.length > 0 && (
+        <div className="px-4 pb-4 space-y-3 border-t border-slate-200 dark:border-slate-700 pt-3">
+          {check.issues.map((issue, idx) => (
+            <div key={idx} className="space-y-1">
+              <div className="flex items-start gap-1.5">
+                <span
+                  className={`mt-0.5 w-1.5 h-1.5 rounded-full flex-shrink-0 ${
+                    issue.severity === "high"
+                      ? "bg-red-500"
+                      : issue.severity === "medium"
+                      ? "bg-amber-500"
+                      : "bg-slate-400"
+                  }`}
+                />
+                <p className="text-sm font-medium text-slate-800 dark:text-white">{issue.title}</p>
+              </div>
+              <p className="text-xs text-slate-600 dark:text-slate-300 pl-3">{issue.description}</p>
+              {issue.fix_suggestion && (
+                <p className="text-xs text-slate-500 dark:text-slate-400 pl-3">
+                  <span className="font-medium">Fix: </span>
+                  {issue.fix_suggestion}
+                </p>
+              )}
+              <p className="text-xs text-esg-600 dark:text-esg-400 font-mono pl-3">{issue.esrs_ref}</p>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {expanded && check.issues.length === 0 && (
+        <p className="px-4 pb-3 text-xs text-emerald-600 dark:text-emerald-400 border-t border-slate-200 dark:border-slate-700 pt-3">
+          No issues found — this topic meets minimum ESRS requirements.
+        </p>
+      )}
+    </div>
+  );
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Strategic insight panel
+// ─────────────────────────────────────────────────────────────────────────────
+
+const StrategicInsightPanel: React.FC<{ insight: StrategicInsight }> = ({ insight }) => (
+  <section>
+    <h2 className="text-lg font-semibold text-slate-800 dark:text-white mb-4 flex items-center gap-2">
+      <Lightbulb className="w-5 h-5 text-amber-500" />
+      Strategic Insight
+    </h2>
+    <div className="rounded-xl bg-gradient-to-br from-blue-600 to-blue-800 dark:from-blue-800 dark:to-blue-950 p-6 text-white space-y-5">
+      <p className="text-base leading-relaxed">{insight.summary}</p>
+
+      <div className="grid sm:grid-cols-2 gap-4">
+        <div>
+          <h3 className="text-xs font-semibold uppercase tracking-widest text-blue-200 mb-2 flex items-center gap-1">
+            <AlertTriangle className="w-3 h-3" /> Key Risks
+          </h3>
+          <ul className="space-y-1.5">
+            {insight.keyRisks.map((r, i) => (
+              <li key={i} className="text-sm text-blue-100 flex items-start gap-1.5">
+                <span className="mt-1.5 w-1 h-1 rounded-full bg-blue-300 flex-shrink-0" />
+                {r}
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3 className="text-xs font-semibold uppercase tracking-widest text-blue-200 mb-2 flex items-center gap-1">
+            <TrendingUp className="w-3 h-3" /> Opportunities
+          </h3>
+          <ul className="space-y-1.5">
+            {insight.opportunities.map((o, i) => (
+              <li key={i} className="text-sm text-blue-100 flex items-start gap-1.5">
+                <span className="mt-1.5 w-1 h-1 rounded-full bg-emerald-300 flex-shrink-0" />
+                {o}
+              </li>
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      {insight.bottomLine && (
+        <div className="border-t border-blue-500/40 pt-4">
+          <p className="text-sm font-semibold text-blue-100 flex items-center gap-1.5 mb-1">
+            <Zap className="w-4 h-4 text-yellow-300" /> Bottom Line
+          </p>
+          <p className="text-sm text-blue-50">{insight.bottomLine}</p>
+        </div>
+      )}
+    </div>
+  </section>
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Recommended actions
+// ─────────────────────────────────────────────────────────────────────────────
+
+const actionTypeConfig = {
+  fix: {
+    label: "Fix",
+    icon: <XCircle className="w-4 h-4 text-red-500" />,
+    description: "Correct incomplete or inconsistent assessments",
+  },
+  comply: {
+    label: "Comply",
+    icon: <CheckCircle2 className="w-4 h-4 text-blue-500" />,
+    description: "Meet specific ESRS requirements",
+  },
+  improve: {
+    label: "Improve",
+    icon: <TrendingUp className="w-4 h-4 text-emerald-500" />,
+    description: "Strategic opportunities beyond compliance",
+  },
+};
+
+const priorityStyle = {
+  high: "border-l-red-500",
+  medium: "border-l-amber-500",
+  low: "border-l-emerald-500",
+};
+
+const RecommendedActionsSection: React.FC<{
+  actions: RecommendedAction[];
+  onFixSource: () => void;
+}> = ({ actions }) => {
+  const groups = (["fix", "comply", "improve"] as const).map((type) => ({
+    type,
+    items: actions.filter((a) => a.type === type),
+  })).filter((g) => g.items.length > 0);
+
+  return (
+    <section>
+      <h2 className="text-lg font-semibold text-slate-800 dark:text-white mb-4 flex items-center gap-2">
+        <Zap className="w-5 h-5 text-esg-500" />
+        Recommended Actions
+      </h2>
+      <div className="space-y-6">
+        {groups.map(({ type, items }) => {
+          const cfg = actionTypeConfig[type];
+          return (
+            <div key={type}>
+              <div className="flex items-center gap-2 mb-3">
+                {cfg.icon}
+                <span className="font-semibold text-slate-700 dark:text-slate-200 text-sm">
+                  {cfg.label}
+                </span>
+                <span className="text-xs text-slate-400 dark:text-slate-500">— {cfg.description}</span>
+              </div>
+              <div className="space-y-3">
+                {items.map((action) => (
+                  <ActionCard key={action.id} action={action} />
+                ))}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+};
+
+const ActionCard: React.FC<{ action: RecommendedAction }> = ({ action }) => (
+  <div
+    className={`bg-white dark:bg-slate-800 rounded-xl border border-l-4 ${priorityStyle[action.priority] ?? priorityStyle.low} border-slate-200 dark:border-slate-700 p-4`}
+  >
+    <div className="flex items-start justify-between gap-2">
+      <div className="min-w-0">
+        <p className="font-medium text-slate-800 dark:text-white text-sm">{action.title}</p>
+        <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">{action.description}</p>
+      </div>
+      <div className="flex flex-col items-end gap-1 flex-shrink-0">
+        <span
+          className={`text-xs font-medium px-2 py-0.5 rounded-full ${
+            action.priority === "high"
+              ? "bg-red-100 dark:bg-red-900/50 text-red-700 dark:text-red-300"
+              : action.priority === "medium"
+              ? "bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-300"
+              : "bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300"
+          }`}
+        >
+          {action.priority}
+        </span>
+      </div>
+    </div>
+    <div className="flex items-center gap-3 mt-2 text-xs text-slate-400 dark:text-slate-500">
+      <span className="font-mono text-esg-600 dark:text-esg-400">{action.esrs_ref}</span>
+      {action.estimated_time && (
+        <span className="flex items-center gap-1">
+          <Clock className="w-3 h-3" />
+          {action.estimated_time}
+        </span>
+      )}
+    </div>
+  </div>
+);
+
+export default DMAInsightHub;

--- a/components/DMAInsightHub.tsx
+++ b/components/DMAInsightHub.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import {
   AlertTriangle,
   ArrowLeft,
@@ -9,11 +9,12 @@ import {
   Clock,
   Lightbulb,
   Loader2,
+  RotateCcw,
   TrendingUp,
   XCircle,
   Zap,
 } from "lucide-react";
-import { generateDMAInsight } from "../services/geminiService";
+import { analyzeTopicQuality, analyzeDMASynthesis } from "../services/geminiService";
 import type {
   AssessmentData,
   CompanyProfile,
@@ -41,6 +42,19 @@ interface Props {
   onInsightReady?: (result: InsightHubResponse) => void;
 }
 
+// Per-topic loading phase — one per assessment, updated independently
+type TopicPhase =
+  | { phase: "loading" }
+  | { phase: "done"; check: QualityCheck }
+  | { phase: "error"; message: string };
+
+// Synthesis (Pass 2) phase — starts after all topics settle
+type SynthesisPhase =
+  | { phase: "idle" }
+  | { phase: "loading" }
+  | { phase: "done"; insight: StrategicInsight; actions: RecommendedAction[] }
+  | { phase: "error"; message: string };
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Main component
 // ─────────────────────────────────────────────────────────────────────────────
@@ -56,70 +70,93 @@ const DMAInsightHub: React.FC<Props> = ({
   cachedInsight,
   onInsightReady,
 }) => {
-  const [loading, setLoading] = useState(!cachedInsight);
-  const [error, setError] = useState<string | null>(null);
-  const [insight, setInsight] = useState<InsightHubResponse | null>(cachedInsight ?? null);
+  const [topicStates, setTopicStates] = useState<Map<string, TopicPhase>>(() => {
+    if (cachedInsight) {
+      return new Map(cachedInsight.qualityChecks.map((c) => [c.topic, { phase: "done", check: c } as TopicPhase]));
+    }
+    return new Map(assessments.map((a) => [String(a.topic).split(" ")[0], { phase: "loading" } as TopicPhase]));
+  });
+
+  const [synthesisState, setSynthesisState] = useState<SynthesisPhase>(() =>
+    cachedInsight
+      ? { phase: "done", insight: cachedInsight.strategicInsight, actions: cachedInsight.recommendedActions }
+      : { phase: "idle" }
+  );
+
+  // Incremented on each Re-analyse so stale async callbacks self-cancel
+  const runIdRef = useRef(0);
 
   const runAnalysis = React.useCallback(() => {
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-    setInsight(null);
+    const runId = ++runIdRef.current;
 
-    generateDMAInsight(assessments, bmcData, swotData, profile)
-      .then((result) => {
-        if (!cancelled) {
-          setInsight(result);
-          onInsightReady?.(result);
-          setLoading(false);
-        }
-      })
-      .catch((err) => {
-        if (!cancelled) {
-          setError(err instanceof Error ? err.message : "Failed to analyse assessments. Please try again.");
-          setLoading(false);
-        }
-      });
+    setTopicStates(new Map(assessments.map((a) => [String(a.topic).split(" ")[0], { phase: "loading" } as TopicPhase])));
+    setSynthesisState({ phase: "idle" });
 
-    return () => { cancelled = true; };
+    const doneChecks: QualityCheck[] = [];
+    let settledCount = 0;
+
+    const onTopicSettle = async () => {
+      settledCount++;
+      if (settledCount < assessments.length) return;
+      if (runId !== runIdRef.current) return;
+
+      if (doneChecks.length === 0) {
+        setSynthesisState({ phase: "error", message: "All topic checks failed — unable to synthesise." });
+        return;
+      }
+
+      setSynthesisState({ phase: "loading" });
+      try {
+        const synth = await analyzeDMASynthesis(doneChecks, assessments, profile, bmcData, swotData);
+        if (runId !== runIdRef.current) return;
+        setSynthesisState({ phase: "done", insight: synth.strategicInsight, actions: synth.recommendedActions });
+        onInsightReady?.({ qualityChecks: doneChecks, strategicInsight: synth.strategicInsight, recommendedActions: synth.recommendedActions });
+      } catch (err) {
+        if (runId !== runIdRef.current) return;
+        setSynthesisState({ phase: "error", message: err instanceof Error ? err.message : "Strategic analysis failed." });
+      }
+    };
+
+    assessments.forEach(async (assessment) => {
+      const topicCode = String(assessment.topic).split(" ")[0];
+      try {
+        const check = await analyzeTopicQuality(assessment, profile, bmcData, swotData);
+        if (runId !== runIdRef.current) return;
+        doneChecks.push(check);
+        setTopicStates((prev) => new Map(prev).set(topicCode, { phase: "done", check }));
+      } catch (err) {
+        if (runId !== runIdRef.current) return;
+        setTopicStates((prev) =>
+          new Map(prev).set(topicCode, { phase: "error", message: err instanceof Error ? err.message : "Check failed" })
+        );
+      }
+      await onTopicSettle();
+    });
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [assessments, bmcData, swotData, profile]);
+  }, [assessments, profile, bmcData, swotData]);
 
   useEffect(() => {
-    if (!cachedInsight) return runAnalysis();
+    if (!cachedInsight) runAnalysis();
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  // Wrap onEditTopic so sub-components don't need access to the full checks list.
-  // QualityCheckCard passes its own check explicitly; ActionCard passes just topicCode
-  // and the lookup happens here.
+  // Derived
+  const completedChecks = assessments
+    .map((a) => topicStates.get(String(a.topic).split(" ")[0]))
+    .filter((s): s is { phase: "done"; check: QualityCheck } => s?.phase === "done")
+    .map((s) => s.check);
+
+  const hasFixIssues = completedChecks.some((c) => c.status === "needs_fix");
+  const isAnalysing = [...topicStates.values()].some((s) => s.phase === "loading");
+
   const handleEditTopic = React.useCallback((topicCode: string, qualityCheck?: QualityCheck) => {
-    const qc = qualityCheck ?? insight?.qualityChecks.find((c) => c.topic === topicCode);
+    const state = topicStates.get(topicCode);
+    const qc = qualityCheck ?? (state?.phase === "done" ? state.check : undefined);
     onEditTopic(topicCode, qc);
-  }, [insight, onEditTopic]);
-
-  const hasFixIssues = insight?.qualityChecks.some((c) => c.status === "needs_fix") ?? false;
-
-  if (loading) return <LoadingState />;
-
-  if (error) {
-    return (
-      <div className="flex flex-col items-center justify-center py-24 px-4 text-center">
-        <XCircle className="w-12 h-12 text-red-500 mb-4" />
-        <h2 className="text-xl font-bold text-slate-800 dark:text-white mb-2">Analysis Failed</h2>
-        <p className="text-slate-500 dark:text-slate-400 max-w-md mb-6">{error}</p>
-        <button
-          onClick={runAnalysis}
-          className="px-6 py-2.5 bg-esg-600 text-white rounded-lg hover:bg-esg-700 transition-colors font-medium"
-        >
-          Retry Analysis
-        </button>
-      </div>
-    );
-  }
+  }, [topicStates, onEditTopic]);
 
   return (
-    <div className="max-w-5xl mx-auto px-4 py-8 space-y-8 animate-in fade-in duration-500">
+    <div className="max-w-5xl mx-auto px-4 py-8 space-y-8">
       {/* Header */}
       <div className="flex items-start justify-between gap-4">
         <div>
@@ -130,30 +167,39 @@ const DMAInsightHub: React.FC<Props> = ({
         </div>
         <button
           onClick={runAnalysis}
-          className="flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400 hover:text-esg-600 dark:hover:text-esg-400 border border-slate-300 dark:border-slate-600 rounded-lg px-3 py-1.5 transition-colors flex-shrink-0"
+          disabled={isAnalysing || synthesisState.phase === "loading"}
+          className="flex items-center gap-1.5 text-xs text-slate-500 dark:text-slate-400 hover:text-esg-600 dark:hover:text-esg-400 border border-slate-300 dark:border-slate-600 rounded-lg px-3 py-1.5 transition-colors flex-shrink-0 disabled:opacity-40"
         >
-          <Loader2 className="w-3 h-3" />
+          <RotateCcw className="w-3 h-3" />
           Re-analyse
         </button>
       </div>
 
-      {/* Score banner */}
-      <ScoreBanner assessments={assessments} checks={insight?.qualityChecks ?? []} />
+      {/* Score banner — updates as topic cards arrive */}
+      <ScoreBanner assessments={assessments} checks={completedChecks} />
 
-      {/* Quality checks */}
-      {insight && insight.qualityChecks.length > 0 && (
-        <QualityCheckSection checks={insight.qualityChecks} onEditTopic={handleEditTopic} />
+      {/* Quality checks — each card appears as its topic call resolves */}
+      {assessments.length > 0 && (
+        <QualityCheckSection
+          assessments={assessments}
+          topicStates={topicStates}
+          onEditTopic={handleEditTopic}
+        />
       )}
 
-      {/* Strategic insight */}
-      {insight?.strategicInsight && (
-        <StrategicInsightPanel insight={insight.strategicInsight} />
-      )}
-
-      {/* Recommended actions */}
-      {insight && (
-        <RecommendedActionsSection actions={insight.recommendedActions} onEditTopic={handleEditTopic} />
-      )}
+      {/* Synthesis — shown once all topics settle */}
+      <SynthesisSection
+        state={synthesisState}
+        onRetry={() => {
+          if (completedChecks.length > 0) {
+            setSynthesisState({ phase: "loading" });
+            analyzeDMASynthesis(completedChecks, assessments, profile, bmcData, swotData)
+              .then((s) => setSynthesisState({ phase: "done", insight: s.strategicInsight, actions: s.recommendedActions }))
+              .catch((e) => setSynthesisState({ phase: "error", message: e instanceof Error ? e.message : "Retry failed" }));
+          }
+        }}
+        onEditTopic={handleEditTopic}
+      />
 
       {/* Navigation */}
       <div className="flex flex-col sm:flex-row items-center justify-between gap-4 pt-4 border-t border-slate-200 dark:border-slate-700">
@@ -187,30 +233,42 @@ const DMAInsightHub: React.FC<Props> = ({
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Loading state
+// Synthesis section — appears after all topic calls settle
 // ─────────────────────────────────────────────────────────────────────────────
 
-const LoadingState: React.FC = () => (
-  <div className="flex flex-col items-center justify-center py-32 px-4 text-center">
-    <div className="relative mb-6">
-      <div className="w-16 h-16 rounded-full border-2 border-esg-200 dark:border-esg-900 flex items-center justify-center">
-        <Loader2 className="w-8 h-8 text-esg-600 animate-spin" />
+const SynthesisSection: React.FC<{
+  state: SynthesisPhase;
+  onRetry: () => void;
+  onEditTopic: (topicCode: string, qualityCheck?: QualityCheck) => void;
+}> = ({ state, onRetry, onEditTopic }) => {
+  if (state.phase === "idle") return null;
+
+  if (state.phase === "loading") {
+    return (
+      <div className="flex items-center gap-3 py-8 text-slate-500 dark:text-slate-400 text-sm">
+        <Loader2 className="w-4 h-4 animate-spin flex-shrink-0 text-esg-500" />
+        Analysing strategic context across all topics…
       </div>
-    </div>
-    <h2 className="text-xl font-bold text-slate-800 dark:text-white mb-2">Analysing your assessments…</h2>
-    <p className="text-slate-500 dark:text-slate-400 max-w-sm text-sm">
-      Reviewing quality, identifying gaps, and generating strategic insights from your DMA data.
-    </p>
-    <div className="mt-8 space-y-2 text-sm text-slate-400 dark:text-slate-500">
-      {["Checking ESRS coverage…", "Analysing materiality patterns…", "Building strategic insights…"].map((step) => (
-        <div key={step} className="flex items-center gap-2 justify-center">
-          <div className="w-1.5 h-1.5 rounded-full bg-esg-400 animate-pulse" />
-          {step}
-        </div>
-      ))}
-    </div>
-  </div>
-);
+    );
+  }
+
+  if (state.phase === "error") {
+    return (
+      <div className="flex items-center gap-3 py-6 text-sm text-red-600 dark:text-red-400">
+        <XCircle className="w-4 h-4 flex-shrink-0" />
+        <span>{state.message}</span>
+        <button onClick={onRetry} className="ml-2 underline hover:no-underline flex-shrink-0">Retry</button>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <StrategicInsightPanel insight={state.insight} />
+      <RecommendedActionsSection actions={state.actions} onEditTopic={onEditTopic} />
+    </>
+  );
+};
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Score banner
@@ -287,12 +345,21 @@ const statusConfig = {
 };
 
 const QualityCheckSection: React.FC<{
-  checks: QualityCheck[];
+  assessments: AssessmentData[];
+  topicStates: Map<string, TopicPhase>;
   onEditTopic: (topicCode: string, qualityCheck?: QualityCheck) => void;
-}> = ({ checks, onEditTopic }) => {
-  const sorted = [...checks].sort((a, b) => {
-    const order = { needs_fix: 0, review: 1, ok: 2 };
-    return order[a.status] - order[b.status];
+}> = ({ assessments, topicStates, onEditTopic }) => {
+  // Sort: done (needs_fix first) → loading → error
+  const sorted = [...assessments].sort((a, b) => {
+    const sa = topicStates.get(String(a.topic).split(" ")[0]);
+    const sb = topicStates.get(String(b.topic).split(" ")[0]);
+    const rank = (s: TopicPhase | undefined) => {
+      if (!s || s.phase === "loading") return 3;
+      if (s.phase === "error") return 4;
+      const order = { needs_fix: 0, review: 1, ok: 2 };
+      return order[s.check.status] ?? 2;
+    };
+    return rank(sa) - rank(sb);
   });
 
   return (
@@ -302,13 +369,43 @@ const QualityCheckSection: React.FC<{
         Quality Check
       </h2>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-        {sorted.map((check) => (
-          <QualityCheckCard key={check.topic} check={check} onEditTopic={onEditTopic} />
-        ))}
+        {sorted.map((assessment) => {
+          const topicCode = String(assessment.topic).split(" ")[0];
+          const topicTitle = String(assessment.topic).replace(/^[A-Z0-9]+ /, "");
+          const state = topicStates.get(topicCode);
+
+          if (!state || state.phase === "loading") {
+            return <TopicSkeletonCard key={topicCode} topicCode={topicCode} topicTitle={topicTitle} />;
+          }
+          if (state.phase === "error") {
+            return <TopicErrorCard key={topicCode} topicCode={topicCode} topicTitle={topicTitle} message={state.message} />;
+          }
+          return <QualityCheckCard key={topicCode} check={state.check} onEditTopic={onEditTopic} />;
+        })}
       </div>
     </section>
   );
 };
+
+const TopicSkeletonCard: React.FC<{ topicCode: string; topicTitle: string }> = ({ topicCode, topicTitle }) => (
+  <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-800 p-4 flex items-center gap-3 animate-pulse">
+    <Loader2 className="w-4 h-4 text-esg-400 animate-spin flex-shrink-0" />
+    <div className="min-w-0">
+      <p className="text-sm font-semibold text-slate-500 dark:text-slate-400">{topicCode} — {topicTitle}</p>
+      <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">Checking quality…</p>
+    </div>
+  </div>
+);
+
+const TopicErrorCard: React.FC<{ topicCode: string; topicTitle: string; message: string }> = ({ topicCode, topicTitle, message }) => (
+  <div className="rounded-xl border border-l-4 border-l-slate-400 border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/30 p-4 flex items-center gap-3">
+    <XCircle className="w-4 h-4 text-slate-400 flex-shrink-0" />
+    <div className="min-w-0">
+      <p className="text-sm font-semibold text-slate-600 dark:text-slate-400">{topicCode} — {topicTitle}</p>
+      <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5 truncate">{message}</p>
+    </div>
+  </div>
+);
 
 const QualityCheckCard: React.FC<{
   check: QualityCheck;

--- a/components/DMAInsightHub.tsx
+++ b/components/DMAInsightHub.tsx
@@ -36,6 +36,7 @@ interface Props {
   swotData: SwotAnalysis;
   onBack: () => void;
   onContinue: () => void;
+  onEditTopic: (topicCode: string) => void;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -49,6 +50,7 @@ const DMAInsightHub: React.FC<Props> = ({
   swotData,
   onBack,
   onContinue,
+  onEditTopic,
 }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -116,7 +118,7 @@ const DMAInsightHub: React.FC<Props> = ({
 
       {/* Quality checks */}
       {insight && insight.qualityChecks.length > 0 && (
-        <QualityCheckSection checks={insight.qualityChecks} onFixTopic={onBack} />
+        <QualityCheckSection checks={insight.qualityChecks} onEditTopic={onEditTopic} />
       )}
 
       {/* Strategic insight */}
@@ -125,8 +127,8 @@ const DMAInsightHub: React.FC<Props> = ({
       )}
 
       {/* Recommended actions */}
-      {insight && insight.recommendedActions.length > 0 && (
-        <RecommendedActionsSection actions={insight.recommendedActions} onFixSource={onBack} />
+      {insight && (
+        <RecommendedActionsSection actions={insight.recommendedActions} onEditTopic={onEditTopic} />
       )}
 
       {/* Navigation */}
@@ -262,8 +264,8 @@ const statusConfig = {
 
 const QualityCheckSection: React.FC<{
   checks: QualityCheck[];
-  onFixTopic: () => void;
-}> = ({ checks }) => {
+  onEditTopic: (topicCode: string) => void;
+}> = ({ checks, onEditTopic }) => {
   const sorted = [...checks].sort((a, b) => {
     const order = { needs_fix: 0, review: 1, ok: 2 };
     return order[a.status] - order[b.status];
@@ -277,14 +279,17 @@ const QualityCheckSection: React.FC<{
       </h2>
       <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
         {sorted.map((check) => (
-          <QualityCheckCard key={check.topic} check={check} />
+          <QualityCheckCard key={check.topic} check={check} onEditTopic={onEditTopic} />
         ))}
       </div>
     </section>
   );
 };
 
-const QualityCheckCard: React.FC<{ check: QualityCheck }> = ({ check }) => {
+const QualityCheckCard: React.FC<{
+  check: QualityCheck;
+  onEditTopic: (topicCode: string) => void;
+}> = ({ check, onEditTopic }) => {
   const [expanded, setExpanded] = useState(check.status === "needs_fix");
   const cfg = statusConfig[check.status] ?? statusConfig.ok;
 
@@ -356,6 +361,18 @@ const QualityCheckCard: React.FC<{ check: QualityCheck }> = ({ check }) => {
         <p className="px-4 pb-3 text-xs text-emerald-600 dark:text-emerald-400 border-t border-slate-200 dark:border-slate-700 pt-3">
           No issues found — this topic meets minimum ESRS requirements.
         </p>
+      )}
+
+      {/* Edit link — always visible in footer */}
+      {expanded && (
+        <div className="px-4 pb-3 flex justify-end border-t border-slate-200/60 dark:border-slate-700/60 pt-2">
+          <button
+            onClick={() => onEditTopic(check.topic)}
+            className="text-xs font-medium text-esg-600 dark:text-esg-400 hover:underline flex items-center gap-1"
+          >
+            Edit {check.topic} assessment →
+          </button>
+        </div>
       )}
     </div>
   );
@@ -445,8 +462,20 @@ const priorityStyle = {
 
 const RecommendedActionsSection: React.FC<{
   actions: RecommendedAction[];
-  onFixSource: () => void;
-}> = ({ actions }) => {
+  onEditTopic: (topicCode: string) => void;
+}> = ({ actions, onEditTopic }) => {
+  if (actions.length === 0) {
+    return (
+      <section>
+        <h2 className="text-lg font-semibold text-slate-800 dark:text-white mb-4 flex items-center gap-2">
+          <Zap className="w-5 h-5 text-esg-500" />
+          Recommended Actions
+        </h2>
+        <p className="text-sm text-slate-400 dark:text-slate-500 italic">No actions generated.</p>
+      </section>
+    );
+  }
+
   const groups = (["fix", "comply", "improve"] as const).map((type) => ({
     type,
     items: actions.filter((a) => a.type === type),
@@ -472,7 +501,7 @@ const RecommendedActionsSection: React.FC<{
               </div>
               <div className="space-y-3">
                 {items.map((action) => (
-                  <ActionCard key={action.id} action={action} />
+                  <ActionCard key={action.id} action={action} onEditTopic={onEditTopic} />
                 ))}
               </div>
             </div>
@@ -483,7 +512,10 @@ const RecommendedActionsSection: React.FC<{
   );
 };
 
-const ActionCard: React.FC<{ action: RecommendedAction }> = ({ action }) => (
+const ActionCard: React.FC<{
+  action: RecommendedAction;
+  onEditTopic: (topicCode: string) => void;
+}> = ({ action, onEditTopic }) => (
   <div
     className={`bg-white dark:bg-slate-800 rounded-xl border border-l-4 ${priorityStyle[action.priority] ?? priorityStyle.low} border-slate-200 dark:border-slate-700 p-4`}
   >
@@ -492,27 +524,35 @@ const ActionCard: React.FC<{ action: RecommendedAction }> = ({ action }) => (
         <p className="font-medium text-slate-800 dark:text-white text-sm">{action.title}</p>
         <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5">{action.description}</p>
       </div>
-      <div className="flex flex-col items-end gap-1 flex-shrink-0">
-        <span
-          className={`text-xs font-medium px-2 py-0.5 rounded-full ${
-            action.priority === "high"
-              ? "bg-red-100 dark:bg-red-900/50 text-red-700 dark:text-red-300"
-              : action.priority === "medium"
-              ? "bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-300"
-              : "bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300"
-          }`}
-        >
-          {action.priority}
-        </span>
-      </div>
+      <span
+        className={`text-xs font-medium px-2 py-0.5 rounded-full flex-shrink-0 ${
+          action.priority === "high"
+            ? "bg-red-100 dark:bg-red-900/50 text-red-700 dark:text-red-300"
+            : action.priority === "medium"
+            ? "bg-amber-100 dark:bg-amber-900/50 text-amber-700 dark:text-amber-300"
+            : "bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300"
+        }`}
+      >
+        {action.priority}
+      </span>
     </div>
-    <div className="flex items-center gap-3 mt-2 text-xs text-slate-400 dark:text-slate-500">
-      <span className="font-mono text-esg-600 dark:text-esg-400">{action.esrs_ref}</span>
-      {action.estimated_time && (
-        <span className="flex items-center gap-1">
-          <Clock className="w-3 h-3" />
-          {action.estimated_time}
-        </span>
+    <div className="flex items-center justify-between mt-2">
+      <div className="flex items-center gap-3 text-xs text-slate-400 dark:text-slate-500">
+        <span className="font-mono text-esg-600 dark:text-esg-400">{action.esrs_ref}</span>
+        {action.estimated_time && (
+          <span className="flex items-center gap-1">
+            <Clock className="w-3 h-3" />
+            {action.estimated_time}
+          </span>
+        )}
+      </div>
+      {action.source_id && (
+        <button
+          onClick={() => onEditTopic(action.source_id)}
+          className="text-xs text-esg-600 dark:text-esg-400 hover:underline font-medium"
+        >
+          Edit {action.source_id} →
+        </button>
       )}
     </div>
   </div>

--- a/components/DMAInsightHub.tsx
+++ b/components/DMAInsightHub.tsx
@@ -74,16 +74,27 @@ const DMAInsightHub: React.FC<Props> = ({
   onInsightReady,
   onQualityCheckReady,
 }) => {
-  // Deduplicate by topic code — keep the highest-scored row per topic.
-  // Duplicate DB rows happen when a user saves the same ESRS topic more than once.
+  // Deduplicate by topic code — one record per ESRS topic for quality check.
+  // Pick priority: (1) record with descriptions written > (2) most recently updated.
+  // Score is NOT used — it represents materiality significance, not completeness.
   const assessments = React.useMemo(() => {
+    const hasContent = (a: AssessmentData) =>
+      (a.impactDescription?.trim().length ?? 0) > 0 ||
+      (a.financialDescription?.trim().length ?? 0) > 0;
+    const updatedTime = (a: AssessmentData) =>
+      a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
+
     const seen = new Map<string, AssessmentData>();
     for (const a of rawAssessments) {
       const code = String(a.topic).split(" ")[0];
       const existing = seen.get(code);
-      const score = (a.impactMaterialityValue ?? 0) + (a.financialMaterialityValue ?? 0);
-      const existingScore = existing ? (existing.impactMaterialityValue ?? 0) + (existing.financialMaterialityValue ?? 0) : -1;
-      if (!existing || score > existingScore) seen.set(code, a);
+      if (!existing) { seen.set(code, a); continue; }
+      const aContent = hasContent(a);
+      const existContent = hasContent(existing);
+      if (aContent && !existContent) { seen.set(code, a); continue; }
+      if (aContent === existContent && updatedTime(a) > updatedTime(existing)) {
+        seen.set(code, a);
+      }
     }
     return [...seen.values()];
   }, [rawAssessments]);

--- a/components/DMAInsightHub.tsx
+++ b/components/DMAInsightHub.tsx
@@ -36,7 +36,7 @@ interface Props {
   swotData: SwotAnalysis;
   onBack: () => void;
   onContinue: () => void;
-  onEditTopic: (topicCode: string) => void;
+  onEditTopic: (topicCode: string, qualityCheck?: QualityCheck) => void;
   cachedInsight?: InsightHubResponse | null;
   onInsightReady?: (result: InsightHubResponse) => void;
 }
@@ -90,6 +90,14 @@ const DMAInsightHub: React.FC<Props> = ({
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // Wrap onEditTopic so sub-components don't need access to the full checks list.
+  // QualityCheckCard passes its own check explicitly; ActionCard passes just topicCode
+  // and the lookup happens here.
+  const handleEditTopic = React.useCallback((topicCode: string, qualityCheck?: QualityCheck) => {
+    const qc = qualityCheck ?? insight?.qualityChecks.find((c) => c.topic === topicCode);
+    onEditTopic(topicCode, qc);
+  }, [insight, onEditTopic]);
+
   const hasFixIssues = insight?.qualityChecks.some((c) => c.status === "needs_fix") ?? false;
 
   if (loading) return <LoadingState />;
@@ -134,7 +142,7 @@ const DMAInsightHub: React.FC<Props> = ({
 
       {/* Quality checks */}
       {insight && insight.qualityChecks.length > 0 && (
-        <QualityCheckSection checks={insight.qualityChecks} onEditTopic={onEditTopic} />
+        <QualityCheckSection checks={insight.qualityChecks} onEditTopic={handleEditTopic} />
       )}
 
       {/* Strategic insight */}
@@ -144,7 +152,7 @@ const DMAInsightHub: React.FC<Props> = ({
 
       {/* Recommended actions */}
       {insight && (
-        <RecommendedActionsSection actions={insight.recommendedActions} onEditTopic={onEditTopic} />
+        <RecommendedActionsSection actions={insight.recommendedActions} onEditTopic={handleEditTopic} />
       )}
 
       {/* Navigation */}
@@ -280,7 +288,7 @@ const statusConfig = {
 
 const QualityCheckSection: React.FC<{
   checks: QualityCheck[];
-  onEditTopic: (topicCode: string) => void;
+  onEditTopic: (topicCode: string, qualityCheck?: QualityCheck) => void;
 }> = ({ checks, onEditTopic }) => {
   const sorted = [...checks].sort((a, b) => {
     const order = { needs_fix: 0, review: 1, ok: 2 };
@@ -304,7 +312,7 @@ const QualityCheckSection: React.FC<{
 
 const QualityCheckCard: React.FC<{
   check: QualityCheck;
-  onEditTopic: (topicCode: string) => void;
+  onEditTopic: (topicCode: string, qualityCheck?: QualityCheck) => void;
 }> = ({ check, onEditTopic }) => {
   const [expanded, setExpanded] = useState(check.status === "needs_fix");
   const cfg = statusConfig[check.status] ?? statusConfig.ok;
@@ -383,7 +391,7 @@ const QualityCheckCard: React.FC<{
       {expanded && (
         <div className="px-4 pb-3 flex justify-end border-t border-slate-200/60 dark:border-slate-700/60 pt-2">
           <button
-            onClick={() => onEditTopic(check.topic)}
+            onClick={() => onEditTopic(check.topic, check)}
             className="text-xs font-medium text-esg-600 dark:text-esg-400 hover:underline flex items-center gap-1"
           >
             Edit {check.topic} assessment →

--- a/components/DMAInsightHub.tsx
+++ b/components/DMAInsightHub.tsx
@@ -40,6 +40,8 @@ interface Props {
   onEditTopic: (topicCode: string, qualityCheck?: QualityCheck) => void;
   cachedInsight?: InsightHubResponse | null;
   onInsightReady?: (result: InsightHubResponse) => void;
+  /** Called as each per-topic quality check resolves — used to persist results to DB. */
+  onQualityCheckReady?: (assessmentId: string, check: QualityCheck) => void;
 }
 
 // Per-topic loading phase — one per assessment, updated independently
@@ -69,6 +71,7 @@ const DMAInsightHub: React.FC<Props> = ({
   onEditTopic,
   cachedInsight,
   onInsightReady,
+  onQualityCheckReady,
 }) => {
   // Deduplicate by topic code — keep the highest-scored row per topic.
   // Duplicate DB rows happen when a user saves the same ESRS topic more than once.
@@ -147,6 +150,7 @@ const DMAInsightHub: React.FC<Props> = ({
         if (runId !== runIdRef.current) return;
         doneChecks.push(check);
         setTopicStates((prev) => new Map(prev).set(topicCode, { phase: "done", check }));
+        onQualityCheckReady?.(assessment.id, check);
       } catch (err) {
         if (runId !== runIdRef.current) return;
         setTopicStates((prev) =>

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,6 +3,9 @@
   publish = "dist"
   functions = "netlify/functions"
 
+[functions]
+  timeout = 26
+
 [dev]
   command = "npm run dev"
   port = 8888

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,9 +3,6 @@
   publish = "dist"
   functions = "netlify/functions"
 
-[functions]
-  timeout = 26
-
 [dev]
   command = "npm run dev"
   port = 8888

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -257,6 +257,12 @@ async function runAction(
   }
 }
 
+// thinkingBudget: 0 disables extended thinking on Flash models, keeping latency under 9s.
+// Pro models do not support budget=0 (minimum is 128) — return empty config for them.
+function noThinkingConfig(model: string): object {
+  return model.includes("flash") ? { thinkingConfig: { thinkingBudget: 0 } } : {};
+}
+
 // Pull token counts out of Gemini's response in a tolerant way.
 function extractTokens(response: any): { inputTokens: number; outputTokens: number } {
   const u = response?.usageMetadata ?? {};
@@ -419,11 +425,9 @@ ${(qualityCheckContext.issues as any[]).map((i: any) =>
   `;
 
   // Run both descriptions in parallel — halves latency vs a single combined call.
-  // thinkingBudget: 0 disables extended thinking on 2.5-flash to keep latency under 9s.
-  const noThinking = { thinkingConfig: { thinkingBudget: 0 } };
   const [impactResp, financialResp] = await Promise.all([
-    ai.models.generateContent({ model, contents: impactPrompt, config: noThinking }),
-    ai.models.generateContent({ model, contents: financialPrompt, config: noThinking }),
+    ai.models.generateContent({ model, contents: impactPrompt, config: noThinkingConfig(model) }),
+    ai.models.generateContent({ model, contents: financialPrompt, config: noThinkingConfig(model) }),
   ]);
 
   const impactTokens = extractTokens(impactResp);
@@ -683,6 +687,7 @@ Return ONLY valid JSON, no markdown:
       model,
       contents: prompt,
       config: {
+        ...noThinkingConfig(model),
         responseMimeType: "application/json",
         responseSchema: {
           type: Type.OBJECT,
@@ -967,8 +972,7 @@ Return ONLY valid JSON — no markdown, no backticks.
     model,
     contents: prompt,
     config: {
-      // thinkingBudget: 0 disables extended thinking — keeps each per-topic call under 9s.
-      thinkingConfig: { thinkingBudget: 0 },
+      ...noThinkingConfig(model),
       responseMimeType: "application/json",
       responseSchema: {
         type: Type.OBJECT,
@@ -1053,8 +1057,7 @@ Return ONLY valid JSON — no markdown, no backticks.
     model,
     contents: prompt,
     config: {
-      // thinkingBudget: 0 disables extended thinking to stay within the 9s fence.
-      thinkingConfig: { thinkingBudget: 0 },
+      ...noThinkingConfig(model),
       responseMimeType: "application/json",
       responseSchema: {
         type: Type.OBJECT,

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -330,13 +330,24 @@ const ESRS_TOPIC_GUIDANCE: Record<string, { impactAreas: string; financialAreas:
 async function generateAssessmentSuggestions(
   ai: GoogleGenAI,
   model: string,
-  { profile, topic }: any
+  { profile, topic, qualityCheckContext }: any
 ) {
   const topicCode = String(topic).split(" ")[0];
   const guidance = ESRS_TOPIC_GUIDANCE[topicCode];
   const companyName = profile.name || "this company";
   const industryCtx = [profile.industry, profile.isicCode].filter(Boolean).join(", ISIC: ");
   const companyCtx = buildCompanyContext(profile);
+
+  // If quality check issues are provided, convert them to explicit AI instructions
+  const qualityFixBlock = qualityCheckContext?.issues?.length
+    ? `
+QUALITY CHECK FEEDBACK — the previous description failed review on these points.
+Your new description MUST explicitly address each one:
+${(qualityCheckContext.issues as any[]).map((i: any) =>
+  `• [${(i.severity ?? "").toUpperCase()}] ${i.title}: ${i.description} — Fix: ${i.fix_suggestion} (${i.esrs_ref})`
+).join('\n')}
+`.trim()
+    : "";
 
   const sharedRules = `
     Ground every sentence in ${companyName}'s actual industry (${industryCtx}), business model,
@@ -357,6 +368,7 @@ async function generateAssessmentSuggestions(
     Write the IMPACT DESCRIPTION (Inside-out / Impact Materiality):
     Describe how ${companyName} impacts people and the environment on this topic.
     ${guidance ? `ESRS disclosure areas to address (select relevant ones): ${guidance.impactAreas}` : "Cover key environmental and social impact pathways."}
+    ${qualityFixBlock ? `\n${qualityFixBlock}` : ""}
 
     ${sharedRules}
     Return ONLY the plain text description. No JSON, no markdown, no label.
@@ -374,6 +386,7 @@ async function generateAssessmentSuggestions(
     Describe how this sustainability topic creates financial risks or opportunities for ${companyName}.
     Name regulatory frameworks, cost lines, or market mechanisms relevant to its industry.
     ${guidance ? `ESRS financial exposure areas to address (select relevant ones): ${guidance.financialAreas}` : "Cover key financial risks and opportunities."}
+    ${qualityFixBlock ? `\n${qualityFixBlock}` : ""}
 
     ${sharedRules}
     Return ONLY the plain text description. No JSON, no markdown, no label.

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -246,6 +246,10 @@ async function runAction(
       return generateKPISuggestions(ai, model, params);
     case "generateSustainabilityStatement":
       return generateSustainabilityStatement(ai, model, params);
+    case "analyzeTopicQuality":
+      return analyzeTopicQuality(ai, model, params);
+    case "analyzeDMASynthesis":
+      return analyzeDMASynthesis(ai, model, params);
     case "analyzeDMAQuality":
       return analyzeDMAQuality(ai, model, params);
     default:
@@ -889,6 +893,215 @@ async function generateSustainabilityStatement(
   };
 }
 
+// ── Shared helpers for DMA analysis ──────────────────────────────────────────
+
+function buildDMACompanySection(profile: any, bmcItems: any, swotItems: any): string {
+  const companyCtx = profile ? buildCompanyContext(profile) : "";
+  const bmcContext = bmcItems
+    ? [
+        bmcItems.key_activities?.length ? `Key activities: ${joinField(bmcItems.key_activities)}` : "",
+        bmcItems.eco_social_costs?.length ? `Eco-social costs: ${joinField(bmcItems.eco_social_costs)}` : "",
+        bmcItems.eco_social_benefits?.length ? `Eco-social benefits: ${joinField(bmcItems.eco_social_benefits)}` : "",
+      ].filter(Boolean).join("\n")
+    : "";
+  const swotContext = swotItems
+    ? [
+        swotItems.threats?.length ? `Threats: ${joinField(swotItems.threats)}` : "",
+        swotItems.opportunities?.length ? `Opportunities: ${joinField(swotItems.opportunities)}` : "",
+      ].filter(Boolean).join("\n")
+    : "";
+  return [
+    companyCtx,
+    bmcContext ? `Business context:\n${bmcContext}` : "",
+    swotContext ? `Strategic context:\n${swotContext}` : "",
+  ].filter(Boolean).join("\n\n");
+}
+
+// Pass 1 — single topic quality check. One call per topic from the frontend.
+async function analyzeTopicQuality(
+  ai: GoogleGenAI,
+  model: string,
+  { assessment, profile, bmcItems, swotItems }: any
+) {
+  const a = assessment;
+  const topicCode  = String(a.topic).split(" ")[0];
+  const topicTitle = String(a.topic).replace(/^[A-Z0-9]+ /, "");
+  const companySection = buildDMACompanySection(profile, bmcItems, swotItems);
+  const scores = a.impactScore ?? {};
+
+  const prompt = `
+You are a senior ESRS/CSRD auditor reviewing one topic in a Double Materiality Assessment.
+
+${companySection}
+
+Topic under review: ${a.topic}
+Material: ${(a.isMaterial ?? false) ? "Yes" : "No"}
+Impact score: ${a.impactMaterialityValue ?? 0}/100 — "${a.impactDescription || "No description provided"}"
+Financial score: ${a.financialMaterialityValue ?? 0}/100 — "${a.financialDescription || "No description provided"}"
+${scores.scale ? `Sub-scores: scale=${scores.scale} scope=${scores.scope} irremediability=${scores.irremediability} likelihood=${scores.likelihood}` : ""}
+
+Assess quality:
+- "needs_fix": critical gap that would fail a CSRD compliance review
+- "review": minor concern worth addressing, not blocking
+- "ok": meets minimum ESRS requirements for this topic
+
+Flag issues only if genuinely present. Return at most 2 issues. Keep descriptions concise (under 30 words each).
+Return ONLY valid JSON — no markdown, no backticks.
+  `.trim();
+
+  const issueSchema = {
+    type: Type.OBJECT,
+    required: ["severity", "title", "description", "esrs_ref", "fix_suggestion"],
+    properties: {
+      severity:       { type: Type.STRING },
+      title:          { type: Type.STRING },
+      description:    { type: Type.STRING },
+      esrs_ref:       { type: Type.STRING },
+      fix_suggestion: { type: Type.STRING },
+    },
+  };
+
+  const response = await ai.models.generateContent({
+    model,
+    contents: prompt,
+    config: {
+      responseMimeType: "application/json",
+      responseSchema: {
+        type: Type.OBJECT,
+        required: ["topic", "topicTitle", "status", "issues"],
+        properties: {
+          topic:      { type: Type.STRING },
+          topicTitle: { type: Type.STRING },
+          status:     { type: Type.STRING },
+          issues:     { type: Type.ARRAY, items: issueSchema },
+        },
+      },
+    },
+  });
+
+  const parsed = parseAIJson<any>(response.text, { topic: topicCode, topicTitle, status: "ok", issues: [] });
+  // Always override topic/topicTitle from source data to prevent AI drift
+  return {
+    result: { ...parsed, topic: topicCode, topicTitle },
+    ...extractTokens(response),
+  };
+}
+
+// Pass 2 — holistic synthesis. Fired once after all topic calls complete.
+async function analyzeDMASynthesis(
+  ai: GoogleGenAI,
+  model: string,
+  { qualityChecks, assessments, profile, bmcItems, swotItems }: any
+) {
+  const companySection = buildDMACompanySection(profile, bmcItems, swotItems);
+
+  const allTopicsSummary = (assessments ?? []).map((a: any) =>
+    `${a.topic}: material=${(a.isMaterial ?? false) ? "yes" : "no"} impact=${a.impactMaterialityValue ?? 0}/100 financial=${a.financialMaterialityValue ?? 0}/100`
+  ).join(" | ");
+
+  const materialTopics = (assessments ?? [])
+    .filter((a: any) => a.isMaterial ?? false)
+    .map((a: any) => String(a.topic).split(" ")[0])
+    .join(", ") || "none identified";
+
+  // Summarise quality check results for the synthesis prompt
+  const qualitySummary = (qualityChecks ?? []).map((c: any) =>
+    `${c.topic} (${c.status})${c.issues?.length ? ": " + c.issues.map((i: any) => i.title).join("; ") : ""}`
+  ).join("\n");
+
+  const prompt = `
+You are a senior sustainability strategy advisor briefing a CEO on their completed Double Materiality Assessment (DMA).
+
+${companySection}
+
+All ESRS topics summary (topic: material? impact/100 financial/100):
+${allTopicsSummary}
+
+Material topics: ${materialTopics}
+
+Quality check results per topic:
+${qualitySummary}
+
+TASK 1 — STRATEGIC INSIGHT (plain language, no ESRS jargon):
+- summary: 2-3 sentences on what this DMA reveals about the business
+- keyRisks: exactly 3-5 strings, each describing a specific material risk with business impact
+- opportunities: exactly 3-5 strings, each describing a concrete strategic opportunity
+- bottomLine: one sentence — the single most important thing this company must do now
+
+TASK 2 — RECOMMENDED ACTIONS: Generate exactly 5 to 8 actions covering all three types.
+Each action MUST have ALL of these fields:
+- id: "action-1", "action-2", etc.
+- type: "fix" (correct an incomplete assessment), "comply" (meet ESRS requirement for material topic), or "improve" (strategic opportunity)
+- priority: "high", "medium", or "low"
+- title: short action title (under 10 words)
+- description: what to do and why (under 25 words)
+- esrs_ref: relevant ESRS standard (e.g. "ESRS E1-6", "ESRS S1-1")
+- source_type: "dma"
+- source_id: the ESRS topic code this action relates to (e.g. "E1", "S1")
+- estimated_time: realistic estimate (e.g. "2 hours", "1 day", "1 week")
+
+Distribute actions: at least 1 "fix", 2 "comply", 1 "improve". Prioritise material topics and topics with needs_fix status.
+
+Return ONLY valid JSON — no markdown, no backticks.
+  `.trim();
+
+  const response = await ai.models.generateContent({
+    model,
+    contents: prompt,
+    config: {
+      responseMimeType: "application/json",
+      responseSchema: {
+        type: Type.OBJECT,
+        required: ["strategicInsight", "recommendedActions"],
+        properties: {
+          strategicInsight: {
+            type: Type.OBJECT,
+            required: ["summary", "keyRisks", "opportunities", "bottomLine"],
+            properties: {
+              summary:       { type: Type.STRING },
+              keyRisks:      { type: Type.ARRAY, items: { type: Type.STRING } },
+              opportunities: { type: Type.ARRAY, items: { type: Type.STRING } },
+              bottomLine:    { type: Type.STRING },
+            },
+          },
+          recommendedActions: {
+            type: Type.ARRAY,
+            items: {
+              type: Type.OBJECT,
+              required: ["id", "type", "priority", "title", "description", "esrs_ref", "source_type", "source_id", "estimated_time"],
+              properties: {
+                id:             { type: Type.STRING },
+                type:           { type: Type.STRING },
+                priority:       { type: Type.STRING },
+                title:          { type: Type.STRING },
+                description:    { type: Type.STRING },
+                esrs_ref:       { type: Type.STRING },
+                source_type:    { type: Type.STRING },
+                source_id:      { type: Type.STRING },
+                estimated_time: { type: Type.STRING },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+
+  const parsed = parseAIJson(response.text, {
+    strategicInsight: { summary: "", keyRisks: [], opportunities: [], bottomLine: "" },
+    recommendedActions: [],
+  });
+
+  return {
+    result: {
+      strategicInsight:   parsed?.strategicInsight  ?? { summary: "", keyRisks: [], opportunities: [], bottomLine: "" },
+      recommendedActions: Array.isArray(parsed?.recommendedActions) ? parsed.recommendedActions : [],
+    },
+    ...extractTokens(response),
+  };
+}
+
+// Legacy single-call version — kept for backward compat but no longer called by the UI.
 async function analyzeDMAQuality(
   ai: GoogleGenAI,
   model: string,

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -893,14 +893,41 @@ Return ONLY valid JSON — no markdown, no backticks.
   });
 
   // ── Insight + actions call (fires in parallel with topic calls) ───────────
+  const materialTopics = assessments
+    .filter((a: any) => a.isMaterial ?? false)
+    .map((a: any) => String(a.topic).split(" ")[0])
+    .join(", ") || "none identified";
+
   const insightPrompt = `
-You are a senior sustainability strategy advisor briefing a CEO on their completed DMA.
+You are a senior sustainability strategy advisor briefing a CEO on their completed Double Materiality Assessment (DMA).
 
 ${companySection}
 
-All topics summary: ${allTopicsSummary}
+All 10 ESRS topics summary (topic: material? impact/100 financial/100):
+${allTopicsSummary}
 
-Write a CEO-level briefing in plain language (no ESRS jargon) and a short action list.
+Material topics: ${materialTopics}
+
+TASK 1 — STRATEGIC INSIGHT (plain language, no ESRS jargon):
+- summary: 2-3 sentences on what this DMA reveals about the business
+- keyRisks: exactly 3-5 strings, each describing a specific material risk with business impact
+- opportunities: exactly 3-5 strings, each describing a concrete strategic opportunity
+- bottomLine: one sentence — the single most important thing this company must do now
+
+TASK 2 — RECOMMENDED ACTIONS: Generate exactly 5 to 8 actions covering all three types.
+Each action MUST have ALL of these fields:
+- id: "action-1", "action-2", etc.
+- type: one of "fix" (correct an incomplete assessment), "comply" (meet an ESRS requirement for a material topic), or "improve" (strategic opportunity)
+- priority: "high", "medium", or "low"
+- title: short action title (under 10 words)
+- description: what to do and why (under 25 words)
+- esrs_ref: relevant ESRS standard (e.g. "ESRS E1-6", "ESRS S1-1")
+- source_type: "dma"
+- source_id: the ESRS topic code this action relates to (e.g. "E1", "S1")
+- estimated_time: realistic estimate (e.g. "2 hours", "1 day", "1 week")
+
+Distribute actions: include at least 1 "fix", 2 "comply", and 1 "improve".
+Prioritise material topics.
 
 Return ONLY valid JSON — no markdown, no backticks.
   `.trim();

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -283,21 +283,89 @@ const joinField = (v: string | string[]): string =>
 // Action implementations
 // =============================================================
 
+// ESRS topic-specific required disclosure areas (used in auto-fill prompt to ensure quality-check compliance)
+const ESRS_TOPIC_GUIDANCE: Record<string, { impactAreas: string; financialAreas: string }> = {
+  "E1": {
+    impactAreas: "GHG emissions (Scope 1, 2, 3), energy consumption mix, climate transition plan, carbon reduction targets, physical climate risks to operations and value chain",
+    financialAreas: "carbon pricing exposure, stranded asset risk, energy cost volatility, regulatory compliance costs (EU ETS, carbon border adjustment), green financing opportunities",
+  },
+  "E2": {
+    impactAreas: "air pollutants (NOx, SOx, PM), water and soil contamination, hazardous substance releases, impact on human health and ecosystems near operations",
+    financialAreas: "regulatory fines and cleanup liability, licence-to-operate risk, pollution insurance costs, market access restrictions for polluting products",
+  },
+  "E3": {
+    impactAreas: "water withdrawal volumes and sources, wastewater quality and discharge, impact on water-stressed catchments, effects on marine ecosystems",
+    financialAreas: "water scarcity risk to production continuity, regulatory permit costs, water treatment capex, reputational risk in water-stressed regions",
+  },
+  "E4": {
+    impactAreas: "land use change, habitat fragmentation, use of threatened species, impacts on ecosystem services (pollination, soil health, carbon sequestration)",
+    financialAreas: "deforestation-linked supply chain disruptions, biodiversity regulation compliance costs (EU Nature Restoration Law), ecosystem service dependency risk",
+  },
+  "E5": {
+    impactAreas: "primary material consumption, product end-of-life (landfill vs. recyclable), packaging waste, waste generation rates, circular design adoption",
+    financialAreas: "raw material price volatility, extended producer responsibility (EPR) costs, waste disposal costs, circular revenue models, resource efficiency savings",
+  },
+  "S1": {
+    impactAreas: "employee health & safety (injury rates, occupational diseases), fair wages and living wage alignment, diversity & inclusion metrics, training hours per employee, freedom of association",
+    financialAreas: "talent attraction and retention costs, absenteeism and turnover impact, legal exposure from labour violations, productivity link to workforce wellbeing",
+  },
+  "S2": {
+    impactAreas: "supplier labour conditions (forced/child labour risk), safety in Tier-1 and Tier-2 supply chain, supplier audit coverage, remediation mechanisms",
+    financialAreas: "supply chain disruption from supplier non-compliance, reputational risk from negative supplier incidents, cost of supplier audits vs. sourcing risk reduction",
+  },
+  "S3": {
+    impactAreas: "community consultation processes, land rights and displacement risk, local economic contribution vs. harm, access to essential services affected by operations",
+    financialAreas: "social licence-to-operate risk, community litigation or protest costs, local partnership opportunities, impact on permits and expansion plans",
+  },
+  "S4": {
+    impactAreas: "product safety and recall history, data privacy and user rights, accessibility for vulnerable consumers, transparent marketing practices, responsible use of AI or data",
+    financialAreas: "product liability and recall costs, consumer protection regulatory fines (GDPR, etc.), brand value erosion from safety incidents, customer loyalty linked to trust",
+  },
+  "G1": {
+    impactAreas: "anti-corruption policies and training coverage, lobbying transparency, whistleblower protection mechanisms, supplier code of conduct compliance, political contributions",
+    financialAreas: "corruption investigation and penalty exposure, governance-linked cost of capital, contract exclusion risk from procurement rules, ESG rating impact on investor access",
+  },
+};
+
 async function generateAssessmentSuggestions(
   ai: GoogleGenAI,
   model: string,
   { profile, topic }: any
 ) {
+  // Extract topic code (e.g. "E1" from "E1 Climate Change")
+  const topicCode = String(topic).split(" ")[0];
+  const guidance = ESRS_TOPIC_GUIDANCE[topicCode];
+  const impactGuidance = guidance
+    ? `Cover these ESRS-required disclosure areas: ${guidance.impactAreas}.`
+    : "Cover the key environmental or social impacts relevant to this topic.";
+  const financialGuidance = guidance
+    ? `Cover these ESRS-required financial exposure areas: ${guidance.financialAreas}.`
+    : "Cover key financial risks and opportunities linked to this topic.";
+
   const prompt = `
-    Act as a senior sustainability consultant specializing in ESRS (European Sustainability Reporting Standards).
+    You are a senior sustainability consultant writing a Double Materiality Assessment for a CSRD/ESRS report.
 
     ${buildCompanyContext(profile)}
 
-    For the ESRS Topic: "${topic}", provide:
-    1. A summary of potential "Impacts" (Inside-out): How the company impacts people and the environment regarding this topic.
-    2. A summary of potential "Risks & Opportunities" (Outside-in): How this sustainability matter triggers financial effects on the company.
+    ESRS Topic: "${topic}"
 
-    Keep descriptions concise (under 50 words each) and specific to the company's industry and products/services.
+    Write two descriptions that will PASS an ESRS quality review:
+
+    1. Impact Description (Inside-out / Impact Materiality):
+    Describe how ${profile.name || "this company"} impacts people and the environment on this topic.
+    ${impactGuidance}
+    Be concrete: name specific activities, processes, or products. Reference actual impact pathways.
+    Do NOT use vague language like "may have impacts" or "could affect". State what the company does and what impact that has.
+    Length: 80–120 words.
+
+    2. Financial Description (Outside-in / Financial Materiality):
+    Describe how this sustainability topic creates financial risks or opportunities for ${profile.name || "this company"}.
+    ${financialGuidance}
+    Be concrete: name regulatory frameworks, market mechanisms, cost/revenue lines, or time horizons.
+    Do NOT use vague language. Quantify where possible (e.g. "energy costs represent X% of OPEX" if known).
+    Length: 80–120 words.
+
+    Return ONLY a JSON object. No markdown, no backticks, no explanation.
   `;
 
   const response = await ai.models.generateContent({

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -342,28 +342,37 @@ async function generateAssessmentSuggestions(
     ? `Cover these ESRS-required financial exposure areas: ${guidance.financialAreas}.`
     : "Cover key financial risks and opportunities linked to this topic.";
 
+  const companyName = profile.name || "this company";
+  const industryCtx = [profile.industry, profile.isicCode].filter(Boolean).join(", ISIC: ");
+
   const prompt = `
     You are a senior sustainability consultant writing a Double Materiality Assessment for a CSRD/ESRS report.
 
+    --- COMPANY CONTEXT ---
     ${buildCompanyContext(profile)}
+    -----------------------
 
     ESRS Topic: "${topic}"
 
-    Write two descriptions that will PASS an ESRS quality review:
+    Your task: write two descriptions that are SPECIFIC TO THIS COMPANY and will PASS an ESRS quality review.
+
+    Critical rules:
+    - Ground every sentence in ${companyName}'s actual industry (${industryCtx}), business model, products/services, and operations as described above.
+    - From the ESRS disclosure areas listed below, SELECT only the ones that are genuinely material for a company of this type — do NOT list areas that are irrelevant to this industry.
+    - Name the company's specific activities, processes, or products. Do not write generic statements that could apply to any company.
+    - Do NOT use vague hedging like "may have", "could affect", or "might result in". Be direct.
+
+    ESRS disclosure areas to consider for the Impact Description:
+    ${impactGuidance}
+
+    ESRS disclosure areas to consider for the Financial Description:
+    ${financialGuidance}
 
     1. Impact Description (Inside-out / Impact Materiality):
-    Describe how ${profile.name || "this company"} impacts people and the environment on this topic.
-    ${impactGuidance}
-    Be concrete: name specific activities, processes, or products. Reference actual impact pathways.
-    Do NOT use vague language like "may have impacts" or "could affect". State what the company does and what impact that has.
-    Length: 80–120 words.
+    Describe how ${companyName} actually impacts people and the environment on this topic, referencing its specific operations and value chain. Length: 80–120 words.
 
     2. Financial Description (Outside-in / Financial Materiality):
-    Describe how this sustainability topic creates financial risks or opportunities for ${profile.name || "this company"}.
-    ${financialGuidance}
-    Be concrete: name regulatory frameworks, market mechanisms, cost/revenue lines, or time horizons.
-    Do NOT use vague language. Quantify where possible (e.g. "energy costs represent X% of OPEX" if known).
-    Length: 80–120 words.
+    Describe how this sustainability topic creates concrete financial risks or opportunities for ${companyName}, naming regulatory frameworks, cost lines, or market mechanisms relevant to its industry. Length: 80–120 words.
 
     Return ONLY a JSON object. No markdown, no backticks, no explanation.
   `;

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -418,10 +418,12 @@ ${(qualityCheckContext.issues as any[]).map((i: any) =>
     Return ONLY the plain text description. No JSON, no markdown, no label.
   `;
 
-  // Run both descriptions in parallel — halves latency vs a single combined call
+  // Run both descriptions in parallel — halves latency vs a single combined call.
+  // thinkingBudget: 0 disables extended thinking on 2.5-flash to keep latency under 9s.
+  const noThinking = { thinkingConfig: { thinkingBudget: 0 } };
   const [impactResp, financialResp] = await Promise.all([
-    ai.models.generateContent({ model, contents: impactPrompt }),
-    ai.models.generateContent({ model, contents: financialPrompt }),
+    ai.models.generateContent({ model, contents: impactPrompt, config: noThinking }),
+    ai.models.generateContent({ model, contents: financialPrompt, config: noThinking }),
   ]);
 
   const impactTokens = extractTokens(impactResp);
@@ -965,6 +967,8 @@ Return ONLY valid JSON — no markdown, no backticks.
     model,
     contents: prompt,
     config: {
+      // thinkingBudget: 0 disables extended thinking — keeps each per-topic call under 9s.
+      thinkingConfig: { thinkingBudget: 0 },
       responseMimeType: "application/json",
       responseSchema: {
         type: Type.OBJECT,
@@ -1049,6 +1053,8 @@ Return ONLY valid JSON — no markdown, no backticks.
     model,
     contents: prompt,
     config: {
+      // thinkingBudget: 0 disables extended thinking to stay within the 9s fence.
+      thinkingConfig: { thinkingBudget: 0 },
       responseMimeType: "application/json",
       responseSchema: {
         type: Type.OBJECT,

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -803,8 +803,8 @@ async function analyzeDMAQuality(
       return [
         `Topic: ${a.topic} (${a.topicTitle || ""})`,
         `  Material: ${material ? "Yes" : "No"}`,
-        `  Impact score: ${impactScore}/100 — ${impactDesc}`,
-        `  Financial score: ${financialScore}/100 — ${financialDesc}`,
+        `  Impact score: ${impactScore}/100 — ${impactDesc || "No description"}`,
+        `  Financial score: ${financialScore}/100 — ${financialDesc || "No description"}`,
         scores.scale ? `  Scores: scale=${scores.scale} scope=${scores.scope} irremediability=${scores.irremediability} likelihood=${scores.likelihood}` : "",
       ].filter(Boolean).join("\n");
     })
@@ -825,72 +825,29 @@ async function analyzeDMAQuality(
       ].filter(Boolean).join("\n")
     : "";
 
-  const prompt = `
-You are a senior ESRS/CSRD sustainability advisor performing a quality review of a Double Materiality Assessment (DMA) for an SME.
-
+  const sharedContext = `
 ${companyCtx}
-
-${bmcContext ? `Business context:\n${bmcContext}` : ""}
-${swotContext ? `Strategic context:\n${swotContext}` : ""}
+${bmcContext ? `\nBusiness context:\n${bmcContext}` : ""}
+${swotContext ? `\nStrategic context:\n${swotContext}` : ""}
 
 DMA Assessment Results:
 ${assessmentSummary}
+  `.trim();
 
-Your task: Analyse the quality and completeness of this DMA and provide:
+  // ── Call 1: Quality checks per topic ──────────────────────────────────────
+  const qualityPrompt = `
+You are a senior ESRS/CSRD sustainability advisor reviewing a Double Materiality Assessment (DMA).
 
-1. QUALITY CHECKS — For each assessed topic, flag issues a CSRD auditor would raise.
-   - "needs_fix": critical gaps that would fail compliance review
-   - "review": concerns worth reviewing but not blocking
-   - "ok": meets minimum ESRS requirements
-   Focus on: missing coverage of required sub-topics, scores that seem inconsistent with the company context, descriptions too vague for disclosure, and material topics with suspiciously low scores.
+${sharedContext}
 
-2. STRATEGIC INSIGHT — CEO-level summary in plain language (no ESRS jargon). What does this DMA mean for the business? What must they act on urgently?
+Task: For EACH topic listed above, determine the quality of the assessment.
+- "needs_fix": critical gap that would fail a CSRD compliance review
+- "review": worth reviewing but not blocking
+- "ok": meets minimum ESRS requirements
 
-3. RECOMMENDED ACTIONS — Prioritised list of concrete next steps.
-   - "fix": correct an incomplete or inconsistent assessment (source_type: "dma")
-   - "comply": meet a specific ESRS requirement for a material topic
-   - "improve": strategic opportunity beyond compliance
-
-Return ONLY valid JSON matching this exact structure:
-{
-  "qualityChecks": [
-    {
-      "topic": "E1",
-      "topicTitle": "Climate Change",
-      "status": "needs_fix",
-      "issues": [
-        {
-          "severity": "high",
-          "title": "Missing transition risk analysis",
-          "description": "...",
-          "esrs_ref": "ESRS E1-6",
-          "fix_suggestion": "..."
-        }
-      ]
-    }
-  ],
-  "strategicInsight": {
-    "summary": "...",
-    "keyRisks": ["...", "..."],
-    "opportunities": ["...", "..."],
-    "bottomLine": "..."
-  },
-  "recommendedActions": [
-    {
-      "id": "action-1",
-      "type": "fix",
-      "priority": "high",
-      "title": "...",
-      "description": "...",
-      "esrs_ref": "ESRS E1-6",
-      "source_type": "dma",
-      "source_id": "uuid-or-topic-code",
-      "estimated_time": "2 hours"
-    }
-  ]
-}
-
-No markdown, no backticks, no explanation outside the JSON.
+Flag issues like: missing coverage of required sub-topics, descriptions too vague for disclosure, scores inconsistent with the company context.
+Return one entry per topic from the assessment results above.
+Return ONLY valid JSON — no markdown, no backticks.
   `;
 
   const issueSchema = {
@@ -905,76 +862,113 @@ No markdown, no backticks, no explanation outside the JSON.
     },
   };
 
-  const response = await ai.models.generateContent({
-    model,
-    contents: prompt,
-    config: {
-      responseMimeType: "application/json",
-      responseSchema: {
-        type: Type.OBJECT,
-        required: ["qualityChecks", "strategicInsight", "recommendedActions"],
-        properties: {
-          qualityChecks: {
-            type: Type.ARRAY,
-            items: {
+  // ── Call 2: Strategic insight + recommended actions ────────────────────────
+  const insightPrompt = `
+You are a senior sustainability strategy advisor providing an executive briefing on a completed DMA.
+
+${sharedContext}
+
+Task 1 — STRATEGIC INSIGHT: Write a CEO-level summary in plain language (no ESRS jargon).
+  - summary: What this DMA reveals about the business (2-3 sentences)
+  - keyRisks: 3-5 material risks with potential business impact
+  - opportunities: 3-5 strategic opportunities identified
+  - bottomLine: One-sentence priority recommendation
+
+Task 2 — RECOMMENDED ACTIONS: List 5-8 concrete next steps.
+  - type "fix": correct an incomplete assessment (source_type: "dma")
+  - type "comply": meet a specific ESRS requirement for a material topic
+  - type "improve": strategic opportunity beyond compliance
+  - priority: "high", "medium", or "low"
+  - estimated_time: realistic time estimate (e.g. "2 hours", "1 day")
+
+Return ONLY valid JSON — no markdown, no backticks.
+  `;
+
+  const [qualityResp, insightResp] = await Promise.all([
+    ai.models.generateContent({
+      model,
+      contents: qualityPrompt,
+      config: {
+        responseMimeType: "application/json",
+        responseSchema: {
+          type: Type.ARRAY,
+          items: {
+            type: Type.OBJECT,
+            required: ["topic", "topicTitle", "status", "issues"],
+            properties: {
+              topic:      { type: Type.STRING },
+              topicTitle: { type: Type.STRING },
+              status:     { type: Type.STRING },
+              issues:     { type: Type.ARRAY, items: issueSchema },
+            },
+          },
+        },
+      },
+    }),
+    ai.models.generateContent({
+      model,
+      contents: insightPrompt,
+      config: {
+        responseMimeType: "application/json",
+        responseSchema: {
+          type: Type.OBJECT,
+          required: ["strategicInsight", "recommendedActions"],
+          properties: {
+            strategicInsight: {
               type: Type.OBJECT,
-              required: ["topic", "topicTitle", "status", "issues"],
+              required: ["summary", "keyRisks", "opportunities", "bottomLine"],
               properties: {
-                topic:      { type: Type.STRING },
-                topicTitle: { type: Type.STRING },
-                status:     { type: Type.STRING },
-                issues:     { type: Type.ARRAY, items: issueSchema },
+                summary:       { type: Type.STRING },
+                keyRisks:      { type: Type.ARRAY, items: { type: Type.STRING } },
+                opportunities: { type: Type.ARRAY, items: { type: Type.STRING } },
+                bottomLine:    { type: Type.STRING },
               },
             },
-          },
-          strategicInsight: {
-            type: Type.OBJECT,
-            required: ["summary", "keyRisks", "opportunities", "bottomLine"],
-            properties: {
-              summary:       { type: Type.STRING },
-              keyRisks:      { type: Type.ARRAY, items: { type: Type.STRING } },
-              opportunities: { type: Type.ARRAY, items: { type: Type.STRING } },
-              bottomLine:    { type: Type.STRING },
-            },
-          },
-          recommendedActions: {
-            type: Type.ARRAY,
-            items: {
-              type: Type.OBJECT,
-              required: ["id", "type", "priority", "title", "description", "esrs_ref", "source_type", "source_id", "estimated_time"],
-              properties: {
-                id:             { type: Type.STRING },
-                type:           { type: Type.STRING },
-                priority:       { type: Type.STRING },
-                title:          { type: Type.STRING },
-                description:    { type: Type.STRING },
-                esrs_ref:       { type: Type.STRING },
-                source_type:    { type: Type.STRING },
-                source_id:      { type: Type.STRING },
-                estimated_time: { type: Type.STRING },
+            recommendedActions: {
+              type: Type.ARRAY,
+              items: {
+                type: Type.OBJECT,
+                required: ["id", "type", "priority", "title", "description", "esrs_ref", "source_type", "source_id", "estimated_time"],
+                properties: {
+                  id:             { type: Type.STRING },
+                  type:           { type: Type.STRING },
+                  priority:       { type: Type.STRING },
+                  title:          { type: Type.STRING },
+                  description:    { type: Type.STRING },
+                  esrs_ref:       { type: Type.STRING },
+                  source_type:    { type: Type.STRING },
+                  source_id:      { type: Type.STRING },
+                  estimated_time: { type: Type.STRING },
+                },
               },
             },
           },
         },
       },
-    },
-  });
+    }),
+  ]);
 
-  const fallback = {
-    qualityChecks: [],
+  const qualityChecks = parseAIJson<any[]>(qualityResp.text, []);
+  const insightParsed = parseAIJson(insightResp.text, {
     strategicInsight: { summary: "", keyRisks: [], opportunities: [], bottomLine: "" },
     recommendedActions: [],
-  };
+  });
 
-  const parsed = parseAIJson(response.text, fallback);
+  const inputTokens =
+    Number(qualityResp.usageMetadata?.promptTokenCount ?? 0) +
+    Number(insightResp.usageMetadata?.promptTokenCount ?? 0);
+  const outputTokens =
+    Number(qualityResp.usageMetadata?.candidatesTokenCount ?? 0) +
+    Number(insightResp.usageMetadata?.candidatesTokenCount ?? 0);
 
   return {
     result: {
-      qualityChecks:      Array.isArray(parsed?.qualityChecks) ? parsed.qualityChecks : [],
-      strategicInsight:   parsed?.strategicInsight ?? fallback.strategicInsight,
-      recommendedActions: Array.isArray(parsed?.recommendedActions) ? parsed.recommendedActions : [],
+      qualityChecks:      Array.isArray(qualityChecks) ? qualityChecks : [],
+      strategicInsight:   insightParsed?.strategicInsight ?? { summary: "", keyRisks: [], opportunities: [], bottomLine: "" },
+      recommendedActions: Array.isArray(insightParsed?.recommendedActions) ? insightParsed.recommendedActions : [],
     },
-    ...extractTokens(response),
+    inputTokens,
+    outputTokens,
   };
 }
 

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -792,24 +792,6 @@ async function analyzeDMAQuality(
 
   const companyCtx = profile ? buildCompanyContext(profile) : "";
 
-  const assessmentSummary = assessments
-    .map((a: any) => {
-      const impactScore = a.impactMaterialityValue ?? a.impact_score ?? 0;
-      const financialScore = a.financialMaterialityValue ?? a.financial_score ?? 0;
-      const material = a.isMaterial ?? a.is_material ?? false;
-      const impactDesc = a.impactDescription ?? a.impact_description ?? "";
-      const financialDesc = a.financialDescription ?? a.financial_description ?? "";
-      const scores = a.impactScore ?? {};
-      return [
-        `Topic: ${a.topic} (${a.topicTitle || ""})`,
-        `  Material: ${material ? "Yes" : "No"}`,
-        `  Impact score: ${impactScore}/100 — ${impactDesc || "No description"}`,
-        `  Financial score: ${financialScore}/100 — ${financialDesc || "No description"}`,
-        scores.scale ? `  Scores: scale=${scores.scale} scope=${scores.scope} irremediability=${scores.irremediability} likelihood=${scores.likelihood}` : "",
-      ].filter(Boolean).join("\n");
-    })
-    .join("\n\n");
-
   const bmcContext = bmcItems
     ? [
         bmcItems.key_activities?.length ? `Key activities: ${joinField(bmcItems.key_activities)}` : "",
@@ -825,30 +807,19 @@ async function analyzeDMAQuality(
       ].filter(Boolean).join("\n")
     : "";
 
-  const sharedContext = `
-${companyCtx}
-${bmcContext ? `\nBusiness context:\n${bmcContext}` : ""}
-${swotContext ? `\nStrategic context:\n${swotContext}` : ""}
+  const companySection = [
+    companyCtx,
+    bmcContext ? `Business context:\n${bmcContext}` : "",
+    swotContext ? `Strategic context:\n${swotContext}` : "",
+  ].filter(Boolean).join("\n\n");
 
-DMA Assessment Results:
-${assessmentSummary}
-  `.trim();
-
-  // ── Call 1: Quality checks per topic ──────────────────────────────────────
-  const qualityPrompt = `
-You are a senior ESRS/CSRD sustainability advisor reviewing a Double Materiality Assessment (DMA).
-
-${sharedContext}
-
-Task: For EACH topic listed above, determine the quality of the assessment.
-- "needs_fix": critical gap that would fail a CSRD compliance review
-- "review": worth reviewing but not blocking
-- "ok": meets minimum ESRS requirements
-
-Flag issues like: missing coverage of required sub-topics, descriptions too vague for disclosure, scores inconsistent with the company context.
-Return one entry per topic from the assessment results above.
-Return ONLY valid JSON — no markdown, no backticks.
-  `;
+  // ── Build a mini-summary of ALL topics (for the insight call context) ──────
+  const allTopicsSummary = assessments.map((a: any) => {
+    const impactScore = a.impactMaterialityValue ?? 0;
+    const financialScore = a.financialMaterialityValue ?? 0;
+    const material = a.isMaterial ?? false;
+    return `${a.topic}: material=${material ? "yes" : "no"} impact=${impactScore}/100 financial=${financialScore}/100`;
+  }).join(" | ");
 
   const issueSchema = {
     type: Type.OBJECT,
@@ -862,108 +833,145 @@ Return ONLY valid JSON — no markdown, no backticks.
     },
   };
 
-  // ── Call 2: Strategic insight + recommended actions ────────────────────────
+  const qualityCheckSchema = {
+    type: Type.OBJECT,
+    required: ["topic", "topicTitle", "status", "issues"],
+    properties: {
+      topic:      { type: Type.STRING },
+      topicTitle: { type: Type.STRING },
+      status:     { type: Type.STRING },
+      issues:     { type: Type.ARRAY, items: issueSchema },
+    },
+  };
+
+  // ── One tiny call per topic (all in parallel) ─────────────────────────────
+  const topicQualityCalls = assessments.map((a: any) => {
+    const impactScore = a.impactMaterialityValue ?? 0;
+    const financialScore = a.financialMaterialityValue ?? 0;
+    const material = a.isMaterial ?? false;
+    const impactDesc = a.impactDescription ?? "";
+    const financialDesc = a.financialDescription ?? "";
+    const topicCode = String(a.topic).split(" ")[0];
+    const topicTitle = String(a.topic).replace(/^[A-Z0-9]+ /, "");
+    const scores = a.impactScore ?? {};
+
+    const prompt = `
+You are a senior ESRS/CSRD auditor reviewing one topic in a Double Materiality Assessment.
+
+${companySection}
+
+Topic under review: ${a.topic}
+Material: ${material ? "Yes" : "No"}
+Impact score: ${impactScore}/100 — "${impactDesc || "No description provided"}"
+Financial score: ${financialScore}/100 — "${financialDesc || "No description provided"}"
+${scores.scale ? `Sub-scores: scale=${scores.scale} scope=${scores.scope} irremediability=${scores.irremediability} likelihood=${scores.likelihood}` : ""}
+
+Assess quality:
+- "needs_fix": critical gap that would fail a CSRD compliance review
+- "review": minor concern worth addressing, not blocking
+- "ok": meets minimum ESRS requirements for this topic
+
+Flag issues only if genuinely present. Return at most 2 issues. Keep descriptions concise (under 30 words each).
+Return ONLY valid JSON — no markdown, no backticks.
+    `.trim();
+
+    return ai.models.generateContent({
+      model,
+      contents: prompt,
+      config: {
+        responseMimeType: "application/json",
+        responseSchema: {
+          ...qualityCheckSchema,
+          properties: {
+            ...qualityCheckSchema.properties,
+            topic:      { type: Type.STRING, description: topicCode },
+            topicTitle: { type: Type.STRING, description: topicTitle },
+          },
+        },
+      },
+    });
+  });
+
+  // ── Insight + actions call (fires in parallel with topic calls) ───────────
   const insightPrompt = `
-You are a senior sustainability strategy advisor providing an executive briefing on a completed DMA.
+You are a senior sustainability strategy advisor briefing a CEO on their completed DMA.
 
-${sharedContext}
+${companySection}
 
-Task 1 — STRATEGIC INSIGHT: Write a CEO-level summary in plain language (no ESRS jargon).
-  - summary: What this DMA reveals about the business (2-3 sentences)
-  - keyRisks: 3-5 material risks with potential business impact
-  - opportunities: 3-5 strategic opportunities identified
-  - bottomLine: One-sentence priority recommendation
+All topics summary: ${allTopicsSummary}
 
-Task 2 — RECOMMENDED ACTIONS: List 5-8 concrete next steps.
-  - type "fix": correct an incomplete assessment (source_type: "dma")
-  - type "comply": meet a specific ESRS requirement for a material topic
-  - type "improve": strategic opportunity beyond compliance
-  - priority: "high", "medium", or "low"
-  - estimated_time: realistic time estimate (e.g. "2 hours", "1 day")
+Write a CEO-level briefing in plain language (no ESRS jargon) and a short action list.
 
 Return ONLY valid JSON — no markdown, no backticks.
-  `;
+  `.trim();
 
-  const [qualityResp, insightResp] = await Promise.all([
-    ai.models.generateContent({
-      model,
-      contents: qualityPrompt,
-      config: {
-        responseMimeType: "application/json",
-        responseSchema: {
-          type: Type.ARRAY,
-          items: {
+  const insightCall = ai.models.generateContent({
+    model,
+    contents: insightPrompt,
+    config: {
+      responseMimeType: "application/json",
+      responseSchema: {
+        type: Type.OBJECT,
+        required: ["strategicInsight", "recommendedActions"],
+        properties: {
+          strategicInsight: {
             type: Type.OBJECT,
-            required: ["topic", "topicTitle", "status", "issues"],
+            required: ["summary", "keyRisks", "opportunities", "bottomLine"],
             properties: {
-              topic:      { type: Type.STRING },
-              topicTitle: { type: Type.STRING },
-              status:     { type: Type.STRING },
-              issues:     { type: Type.ARRAY, items: issueSchema },
+              summary:       { type: Type.STRING },
+              keyRisks:      { type: Type.ARRAY, items: { type: Type.STRING } },
+              opportunities: { type: Type.ARRAY, items: { type: Type.STRING } },
+              bottomLine:    { type: Type.STRING },
             },
           },
-        },
-      },
-    }),
-    ai.models.generateContent({
-      model,
-      contents: insightPrompt,
-      config: {
-        responseMimeType: "application/json",
-        responseSchema: {
-          type: Type.OBJECT,
-          required: ["strategicInsight", "recommendedActions"],
-          properties: {
-            strategicInsight: {
+          recommendedActions: {
+            type: Type.ARRAY,
+            items: {
               type: Type.OBJECT,
-              required: ["summary", "keyRisks", "opportunities", "bottomLine"],
+              required: ["id", "type", "priority", "title", "description", "esrs_ref", "source_type", "source_id", "estimated_time"],
               properties: {
-                summary:       { type: Type.STRING },
-                keyRisks:      { type: Type.ARRAY, items: { type: Type.STRING } },
-                opportunities: { type: Type.ARRAY, items: { type: Type.STRING } },
-                bottomLine:    { type: Type.STRING },
-              },
-            },
-            recommendedActions: {
-              type: Type.ARRAY,
-              items: {
-                type: Type.OBJECT,
-                required: ["id", "type", "priority", "title", "description", "esrs_ref", "source_type", "source_id", "estimated_time"],
-                properties: {
-                  id:             { type: Type.STRING },
-                  type:           { type: Type.STRING },
-                  priority:       { type: Type.STRING },
-                  title:          { type: Type.STRING },
-                  description:    { type: Type.STRING },
-                  esrs_ref:       { type: Type.STRING },
-                  source_type:    { type: Type.STRING },
-                  source_id:      { type: Type.STRING },
-                  estimated_time: { type: Type.STRING },
-                },
+                id:             { type: Type.STRING },
+                type:           { type: Type.STRING },
+                priority:       { type: Type.STRING },
+                title:          { type: Type.STRING },
+                description:    { type: Type.STRING },
+                esrs_ref:       { type: Type.STRING },
+                source_type:    { type: Type.STRING },
+                source_id:      { type: Type.STRING },
+                estimated_time: { type: Type.STRING },
               },
             },
           },
         },
       },
-    }),
-  ]);
+    },
+  });
 
-  const qualityChecks = parseAIJson<any[]>(qualityResp.text, []);
+  // Fire all calls in parallel
+  const allResps = await Promise.all([...topicQualityCalls, insightCall]);
+  const topicResps = allResps.slice(0, assessments.length);
+  const insightResp = allResps[assessments.length];
+
+  const qualityChecks = topicResps.map((r, i) => {
+    const a = assessments[i];
+    const topicCode = String(a.topic).split(" ")[0];
+    const topicTitle = String(a.topic).replace(/^[A-Z0-9]+ /, "");
+    const parsed = parseAIJson<any>(r.text, { topic: topicCode, topicTitle, status: "ok", issues: [] });
+    // Ensure topic/topicTitle are always correct regardless of AI output
+    return { ...parsed, topic: topicCode, topicTitle };
+  });
+
   const insightParsed = parseAIJson(insightResp.text, {
     strategicInsight: { summary: "", keyRisks: [], opportunities: [], bottomLine: "" },
     recommendedActions: [],
   });
 
-  const inputTokens =
-    Number(qualityResp.usageMetadata?.promptTokenCount ?? 0) +
-    Number(insightResp.usageMetadata?.promptTokenCount ?? 0);
-  const outputTokens =
-    Number(qualityResp.usageMetadata?.candidatesTokenCount ?? 0) +
-    Number(insightResp.usageMetadata?.candidatesTokenCount ?? 0);
+  const inputTokens = allResps.reduce((s, r) => s + Number(r.usageMetadata?.promptTokenCount ?? 0), 0);
+  const outputTokens = allResps.reduce((s, r) => s + Number(r.usageMetadata?.candidatesTokenCount ?? 0), 0);
 
   return {
     result: {
-      qualityChecks:      Array.isArray(qualityChecks) ? qualityChecks : [],
+      qualityChecks,
       strategicInsight:   insightParsed?.strategicInsight ?? { summary: "", keyRisks: [], opportunities: [], bottomLine: "" },
       recommendedActions: Array.isArray(insightParsed?.recommendedActions) ? insightParsed.recommendedActions : [],
     },

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -332,69 +332,69 @@ async function generateAssessmentSuggestions(
   model: string,
   { profile, topic }: any
 ) {
-  // Extract topic code (e.g. "E1" from "E1 Climate Change")
   const topicCode = String(topic).split(" ")[0];
   const guidance = ESRS_TOPIC_GUIDANCE[topicCode];
-  const impactGuidance = guidance
-    ? `Cover these ESRS-required disclosure areas: ${guidance.impactAreas}.`
-    : "Cover the key environmental or social impacts relevant to this topic.";
-  const financialGuidance = guidance
-    ? `Cover these ESRS-required financial exposure areas: ${guidance.financialAreas}.`
-    : "Cover key financial risks and opportunities linked to this topic.";
-
   const companyName = profile.name || "this company";
   const industryCtx = [profile.industry, profile.isicCode].filter(Boolean).join(", ISIC: ");
+  const companyCtx = buildCompanyContext(profile);
 
-  const prompt = `
-    You are a senior sustainability consultant writing a Double Materiality Assessment for a CSRD/ESRS report.
+  const sharedRules = `
+    Ground every sentence in ${companyName}'s actual industry (${industryCtx}), business model,
+    products/services, and operations described above.
+    Select only the ESRS areas genuinely material for a company of this type — skip irrelevant ones.
+    Name specific activities, processes, or products. Do not write generic statements.
+    Do NOT use vague hedging ("may have", "could affect"). Be direct. Length: 80–120 words.
+  `.trim();
+
+  const impactPrompt = `
+    You are a senior sustainability consultant writing a CSRD/ESRS Double Materiality Assessment.
 
     --- COMPANY CONTEXT ---
-    ${buildCompanyContext(profile)}
+    ${companyCtx}
     -----------------------
-
     ESRS Topic: "${topic}"
 
-    Your task: write two descriptions that are SPECIFIC TO THIS COMPANY and will PASS an ESRS quality review.
+    Write the IMPACT DESCRIPTION (Inside-out / Impact Materiality):
+    Describe how ${companyName} impacts people and the environment on this topic.
+    ${guidance ? `ESRS disclosure areas to address (select relevant ones): ${guidance.impactAreas}` : "Cover key environmental and social impact pathways."}
 
-    Critical rules:
-    - Ground every sentence in ${companyName}'s actual industry (${industryCtx}), business model, products/services, and operations as described above.
-    - From the ESRS disclosure areas listed below, SELECT only the ones that are genuinely material for a company of this type — do NOT list areas that are irrelevant to this industry.
-    - Name the company's specific activities, processes, or products. Do not write generic statements that could apply to any company.
-    - Do NOT use vague hedging like "may have", "could affect", or "might result in". Be direct.
-
-    ESRS disclosure areas to consider for the Impact Description:
-    ${impactGuidance}
-
-    ESRS disclosure areas to consider for the Financial Description:
-    ${financialGuidance}
-
-    1. Impact Description (Inside-out / Impact Materiality):
-    Describe how ${companyName} actually impacts people and the environment on this topic, referencing its specific operations and value chain. Length: 80–120 words.
-
-    2. Financial Description (Outside-in / Financial Materiality):
-    Describe how this sustainability topic creates concrete financial risks or opportunities for ${companyName}, naming regulatory frameworks, cost lines, or market mechanisms relevant to its industry. Length: 80–120 words.
-
-    Return ONLY a JSON object. No markdown, no backticks, no explanation.
+    ${sharedRules}
+    Return ONLY the plain text description. No JSON, no markdown, no label.
   `;
 
-  const response = await ai.models.generateContent({
-    model,
-    contents: prompt,
-    config: {
-      responseMimeType: "application/json",
-      responseSchema: {
-        type: Type.OBJECT,
-        properties: {
-          impactSuggestion: { type: Type.STRING },
-          financialSuggestion: { type: Type.STRING },
-        },
-      },
-    },
-  });
+  const financialPrompt = `
+    You are a senior sustainability consultant writing a CSRD/ESRS Double Materiality Assessment.
+
+    --- COMPANY CONTEXT ---
+    ${companyCtx}
+    -----------------------
+    ESRS Topic: "${topic}"
+
+    Write the FINANCIAL DESCRIPTION (Outside-in / Financial Materiality):
+    Describe how this sustainability topic creates financial risks or opportunities for ${companyName}.
+    Name regulatory frameworks, cost lines, or market mechanisms relevant to its industry.
+    ${guidance ? `ESRS financial exposure areas to address (select relevant ones): ${guidance.financialAreas}` : "Cover key financial risks and opportunities."}
+
+    ${sharedRules}
+    Return ONLY the plain text description. No JSON, no markdown, no label.
+  `;
+
+  // Run both descriptions in parallel — halves latency vs a single combined call
+  const [impactResp, financialResp] = await Promise.all([
+    ai.models.generateContent({ model, contents: impactPrompt }),
+    ai.models.generateContent({ model, contents: financialPrompt }),
+  ]);
+
+  const impactTokens = extractTokens(impactResp);
+  const financialTokens = extractTokens(financialResp);
 
   return {
-    result: parseAIJson(response.text, { impactSuggestion: "", financialSuggestion: "" }),
-    ...extractTokens(response),
+    result: {
+      impactSuggestion: impactResp.text?.trim() ?? "",
+      financialSuggestion: financialResp.text?.trim() ?? "",
+    },
+    inputTokens: impactTokens.inputTokens + financialTokens.inputTokens,
+    outputTokens: impactTokens.outputTokens + financialTokens.outputTokens,
   };
 }
 

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -7,16 +7,19 @@ const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
 const DEFAULT_MODEL = "gemini-2.5-flash";
 
-// Approximate Gemini pricing per 1M tokens (USD).
-// Source: https://ai.google.dev/pricing
-const PRICING: Record<string, { input: number; output: number }> = {
-  "gemini-2.5-flash-lite": { input: 0.10, output: 0.40 },
-  "gemini-2.5-flash":      { input: 0.30, output: 2.50 },
-  "gemini-2.5-pro":        { input: 1.25, output: 10.00 },
+// Per-model capabilities and pricing.
+// Update this table whenever a new model is added to the admin model picker.
+// canDisableThinking: true  → thinkingBudget:0 is valid (Flash family)
+// canDisableThinking: false → model always thinks; don't pass thinkingConfig (Pro family)
+// canDisableThinking: null  → unknown/BYOK model; falls back to name heuristic below
+const MODEL_REGISTRY: Record<string, { input: number; output: number; canDisableThinking: boolean }> = {
+  "gemini-2.5-flash-lite": { input: 0.10, output: 0.40,  canDisableThinking: true  },
+  "gemini-2.5-flash":      { input: 0.30, output: 2.50,  canDisableThinking: true  },
+  "gemini-2.5-pro":        { input: 1.25, output: 10.00, canDisableThinking: false },
 };
 
 function estimateCost(model: string, inputTokens: number, outputTokens: number): number {
-  const p = PRICING[model];
+  const p = MODEL_REGISTRY[model];
   if (!p) return 0;
   return (inputTokens * p.input + outputTokens * p.output) / 1_000_000;
 }
@@ -257,10 +260,13 @@ async function runAction(
   }
 }
 
-// thinkingBudget: 0 disables extended thinking on Flash models, keeping latency under 9s.
-// Pro models do not support budget=0 (minimum is 128) — return empty config for them.
+// Returns { thinkingConfig: { thinkingBudget: 0 } } for models that support disabling thinking,
+// or {} for models that don't (Pro) or are unknown (BYOK).
+// Prefer MODEL_REGISTRY lookup; fall back to name heuristic for unknown future models.
 function noThinkingConfig(model: string): object {
-  return model.includes("flash") ? { thinkingConfig: { thinkingBudget: 0 } } : {};
+  const entry = MODEL_REGISTRY[model];
+  const canDisable = entry != null ? entry.canDisableThinking : model.includes("flash");
+  return canDisable ? { thinkingConfig: { thinkingBudget: 0 } } : {};
 }
 
 // Pull token counts out of Gemini's response in a tolerant way.

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -117,22 +117,44 @@ const handler = async (event: any) => {
   let upstreamStatus: number | null = null;
   let userFacingMessage = "Something went wrong while contacting the AI service.";
 
+  // Internal fence at 9 s — Netlify kills the process at 10 s with no chance to log.
+  // Rejecting one second early lets the catch block write to ai_usage_log + error_log
+  // before the hard deadline hits.
+  const FENCE_MS = 9_000;
+  let fenceId: ReturnType<typeof setTimeout>;
+  const fencePromise = new Promise<never>((_, reject) => {
+    fenceId = setTimeout(() => {
+      const err = new Error(`Action '${action}' exceeded the ${FENCE_MS / 1000}s timeout`);
+      (err as any).isTimeout = true;
+      reject(err);
+    }, FENCE_MS);
+  });
+
   try {
-    const outcome = await runAction(ai, model, action, params);
+    const outcome = await Promise.race([
+      runAction(ai, model, action, params),
+      fencePromise,
+    ]);
+    clearTimeout(fenceId!);
     result = outcome.result;
     inputTokens = outcome.inputTokens;
     outputTokens = outcome.outputTokens;
   } catch (error: any) {
+    clearTimeout(fenceId!);
     console.error("API Error:", error);
     success = false;
     rawAiResponse = error?.rawAiResponse ?? null;
     upstreamStatus =
-      (typeof error?.status === "number" && error.status) ||
-      (typeof error?.error?.code === "number" && error.error.code) ||
-      null;
+      error?.isTimeout
+        ? 504
+        : (typeof error?.status === "number" && error.status) ||
+          (typeof error?.error?.code === "number" && error.error.code) ||
+          null;
     errorMessage = error?.error?.message || (error instanceof Error ? error.message : String(error));
     userFacingMessage =
-      upstreamStatus === 503
+      error?.isTimeout
+        ? "The AI request timed out. Please try again — complex topics occasionally need a second attempt."
+        : upstreamStatus === 503
         ? "The AI service is temporarily overloaded. Please try again in a moment."
         : upstreamStatus === 429
         ? "AI rate limit reached. Please wait a minute and try again."

--- a/services/dbService.ts
+++ b/services/dbService.ts
@@ -11,6 +11,10 @@ import type {
   Organization,
   OrgMember,
   OrgRole,
+  QualityCheck,
+  StrategicInsight,
+  RecommendedAction,
+  InsightHubResponse,
 } from "../types";
 
 // =================================================================
@@ -343,6 +347,113 @@ export async function upsertAssessment(orgId: string, assessment: AssessmentData
 export async function deleteAssessment(id: string): Promise<void> {
   const { error } = await supabase.from("assessments").delete().eq("id", id);
   if (error) throw error;
+}
+
+// =================================================================
+// DMA INSIGHTS  (quality checks, strategic insight, suggested tasks)
+// =================================================================
+
+// Save quality check result for one topic onto its assessment row.
+export async function saveQualityCheck(
+  assessmentId: string,
+  orgId: string,
+  check: QualityCheck,
+): Promise<void> {
+  const { error } = await supabase
+    .from("assessments")
+    .update({
+      quality_check_status: check.status,
+      quality_check_issues: check.issues,
+    })
+    .eq("id", assessmentId)
+    .eq("organization_id", orgId);
+  if (error) console.warn("saveQualityCheck failed:", error.message);
+}
+
+// Upsert the org's strategic insight and recommended actions.
+export async function saveDMAInsight(
+  orgId: string,
+  strategicInsight: StrategicInsight,
+  recommendedActions: RecommendedAction[],
+): Promise<void> {
+  const { error } = await supabase
+    .from("dma_insights")
+    .upsert(
+      { organization_id: orgId, strategic_insight: strategicInsight, recommended_actions: recommendedActions },
+      { onConflict: "organization_id" },
+    );
+  if (error) console.warn("saveDMAInsight failed:", error.message);
+}
+
+// Load the cached DMA insight from DB. Returns null if the org has never run analysis.
+export async function loadDMAInsight(orgId: string): Promise<InsightHubResponse | null> {
+  const [insightResp, checksResp] = await Promise.all([
+    supabase
+      .from("dma_insights")
+      .select("strategic_insight, recommended_actions")
+      .eq("organization_id", orgId)
+      .maybeSingle(),
+    supabase
+      .from("assessments")
+      .select("topic, quality_check_status, quality_check_issues")
+      .eq("organization_id", orgId)
+      .not("quality_check_status", "is", null),
+  ]);
+
+  if (!insightResp.data) return null;
+
+  const qualityChecks: QualityCheck[] = (checksResp.data ?? []).map((row) => ({
+    topic: String(row.topic).split(" ")[0],
+    topicTitle: String(row.topic).replace(/^[A-Z0-9]+ /, ""),
+    status: row.quality_check_status as QualityCheck["status"],
+    issues: (row.quality_check_issues as QualityCheck["issues"]) ?? [],
+  }));
+
+  return {
+    qualityChecks,
+    strategicInsight: insightResp.data.strategic_insight as StrategicInsight,
+    recommendedActions: insightResp.data.recommended_actions as RecommendedAction[],
+  };
+}
+
+// Delete the org's strategic insight row so the next hub visit triggers a fresh analysis.
+export async function clearDMAInsight(orgId: string): Promise<void> {
+  await supabase.from("dma_insights").delete().eq("organization_id", orgId);
+}
+
+// Replace undismissed DMA suggested tasks with a fresh batch from the AI.
+export async function saveDMASuggestedTasks(
+  orgId: string,
+  actions: RecommendedAction[],
+  assessments: AssessmentData[],
+): Promise<void> {
+  // Remove stale undismissed DMA suggestions before inserting new ones.
+  await supabase
+    .from("suggested_tasks")
+    .delete()
+    .eq("organization_id", orgId)
+    .eq("source_type", "dma")
+    .eq("dismissed", false);
+
+  if (actions.length === 0) return;
+
+  // Resolve each action's topic code to an assessment UUID for traceability.
+  const topicToId = new Map(assessments.map((a) => [String(a.topic).split(" ")[0], a.id]));
+
+  const { error } = await supabase.from("suggested_tasks").insert(
+    actions.map((a) => ({
+      organization_id: orgId,
+      title: a.title,
+      description: a.description,
+      type: a.type,
+      priority: a.priority,
+      source_type: "dma",
+      source_id: topicToId.get(a.source_id) ?? null,
+      esrs_ref: a.esrs_ref,
+      estimated_time: a.estimated_time,
+    })),
+  );
+  if (error) console.warn("saveDMASuggestedTasks failed:", error.message);
 }
 
 // =================================================================

--- a/services/dbService.ts
+++ b/services/dbService.ts
@@ -303,6 +303,7 @@ export const fromDbAssessment = (row: any): AssessmentData => ({
   financialMaterialityValue: Number(row.financial_materiality_value ?? 0),
   isMaterial: !!row.is_material,
   aiScoringSuggestion: (row.ai_scoring_suggestion as (AssessmentScoring & { suggestedAt: string }) | null) ?? null,
+  updatedAt: row.updated_at ?? undefined,
 });
 
 const toDbAssessment = (data: AssessmentData, orgId: string) => ({

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -55,16 +55,12 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "An unexpected error occurred. Please try again.";
 }
 
+// Re-throws on error — caller must catch and show an error state.
 export const generateAssessmentSuggestions = async (
   profile: CompanyProfile,
   topic: ESRSTopic
-) => {
-  try {
-    return await callApi("generateAssessmentSuggestions", { profile, topic });
-  } catch (error) {
-    const msg = errorMessage(error);
-    return { impactSuggestion: msg, financialSuggestion: msg };
-  }
+): Promise<{ impactSuggestion: string; financialSuggestion: string }> => {
+  return await callApi("generateAssessmentSuggestions", { profile, topic });
 };
 
 export const generateAssessmentScoring = async (

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -1,4 +1,4 @@
-import { ESRSTopic, SustainabilityBusinessModel, SwotAnalysis, BSCPerspective, AssessmentData, CompanyProfile, AssessmentScoring, InsightHubResponse, QualityCheck } from "../types";
+import { ESRSTopic, SustainabilityBusinessModel, SwotAnalysis, BSCPerspective, AssessmentData, CompanyProfile, AssessmentScoring, InsightHubResponse, QualityCheck, StrategicInsight, RecommendedAction } from "../types";
 import { supabase } from "../lib/supabaseClient";
 
 const API_ENDPOINT = "/.netlify/functions/api";
@@ -142,6 +142,46 @@ export const generateSustainabilityStatement = async (
   return await callApi("generateSustainabilityStatement", { profile, materialAssessments });
 };
 
+// Pass 1 — quality check for a single topic. Called once per assessment from the frontend.
+export const analyzeTopicQuality = async (
+  assessment: AssessmentData,
+  profile: CompanyProfile,
+  bmcData: SustainabilityBusinessModel,
+  swotData: SwotAnalysis,
+): Promise<QualityCheck> => {
+  const bmcItems = {
+    key_activities: bmcData.keyActivities,
+    eco_social_costs: bmcData.ecoSocialCosts,
+    eco_social_benefits: bmcData.ecoSocialBenefits,
+  };
+  const swotItems = {
+    threats: swotData.threats,
+    opportunities: swotData.opportunities,
+  };
+  return await callApi("analyzeTopicQuality", { assessment, profile, bmcItems, swotItems });
+};
+
+// Pass 2 — holistic synthesis. Called once after all topic checks complete.
+export const analyzeDMASynthesis = async (
+  qualityChecks: QualityCheck[],
+  assessments: AssessmentData[],
+  profile: CompanyProfile,
+  bmcData: SustainabilityBusinessModel,
+  swotData: SwotAnalysis,
+): Promise<{ strategicInsight: StrategicInsight; recommendedActions: RecommendedAction[] }> => {
+  const bmcItems = {
+    key_activities: bmcData.keyActivities,
+    eco_social_costs: bmcData.ecoSocialCosts,
+    eco_social_benefits: bmcData.ecoSocialBenefits,
+  };
+  const swotItems = {
+    threats: swotData.threats,
+    opportunities: swotData.opportunities,
+  };
+  return await callApi("analyzeDMASynthesis", { qualityChecks, assessments, profile, bmcItems, swotItems });
+};
+
+// Legacy — kept for backward compat, no longer used by the UI.
 export const generateDMAInsight = async (
   assessments: AssessmentData[],
   bmcData: SustainabilityBusinessModel,
@@ -157,6 +197,5 @@ export const generateDMAInsight = async (
     threats: swotData.threats,
     opportunities: swotData.opportunities,
   };
-  // Re-throws so the caller can show a meaningful error.
   return await callApi("analyzeDMAQuality", { assessments, bmcItems, swotItems, profile });
 };

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -1,4 +1,4 @@
-import { ESRSTopic, SustainabilityBusinessModel, SwotAnalysis, BSCPerspective, AssessmentData, CompanyProfile, AssessmentScoring, InsightHubResponse } from "../types";
+import { ESRSTopic, SustainabilityBusinessModel, SwotAnalysis, BSCPerspective, AssessmentData, CompanyProfile, AssessmentScoring, InsightHubResponse, QualityCheck } from "../types";
 import { supabase } from "../lib/supabaseClient";
 
 const API_ENDPOINT = "/.netlify/functions/api";
@@ -58,9 +58,10 @@ function errorMessage(error: unknown): string {
 // Re-throws on error — caller must catch and show an error state.
 export const generateAssessmentSuggestions = async (
   profile: CompanyProfile,
-  topic: ESRSTopic
+  topic: ESRSTopic,
+  qualityCheckContext?: QualityCheck,
 ): Promise<{ impactSuggestion: string; financialSuggestion: string }> => {
-  return await callApi("generateAssessmentSuggestions", { profile, topic });
+  return await callApi("generateAssessmentSuggestions", { profile, topic, qualityCheckContext });
 };
 
 export const generateAssessmentScoring = async (

--- a/supabase/migrations/008_dma_insights.sql
+++ b/supabase/migrations/008_dma_insights.sql
@@ -1,0 +1,56 @@
+-- Migration 008: Persist DMA quality checks, strategic insights, and suggested tasks
+--
+-- Changes:
+--   assessments       — add quality_check_status, quality_check_issues columns
+--   dma_insights      — new singleton-per-org table for strategic insight + recommended actions
+--   suggested_tasks   — make source_id nullable; add INSERT policy; add estimated_time column
+--
+-- Rollback plan:
+--   ALTER TABLE assessments DROP COLUMN IF EXISTS quality_check_status;
+--   ALTER TABLE assessments DROP COLUMN IF EXISTS quality_check_issues;
+--   DROP TABLE IF EXISTS dma_insights CASCADE;
+--   ALTER TABLE suggested_tasks ALTER COLUMN source_id SET NOT NULL;
+--   ALTER TABLE suggested_tasks DROP COLUMN IF EXISTS estimated_time;
+--   DROP POLICY IF EXISTS "members_insert_suggested" ON suggested_tasks;
+
+-- ── 1. Quality check columns on assessments ───────────────────────────────────
+
+ALTER TABLE assessments
+  ADD COLUMN IF NOT EXISTS quality_check_status text
+    CHECK (quality_check_status IN ('ok', 'review', 'needs_fix')),
+  ADD COLUMN IF NOT EXISTS quality_check_issues  jsonb NOT NULL DEFAULT '[]';
+
+-- ── 2. DMA strategic insight (singleton per org) ──────────────────────────────
+
+CREATE TABLE IF NOT EXISTS dma_insights (
+  organization_id     uuid PRIMARY KEY REFERENCES organizations(id) ON DELETE CASCADE,
+  strategic_insight   jsonb NOT NULL DEFAULT '{}',
+  recommended_actions jsonb NOT NULL DEFAULT '[]',
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  updated_at          timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TRIGGER trg_dma_insights_updated_at
+  BEFORE UPDATE ON dma_insights FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+ALTER TABLE dma_insights ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "members_read_dma_insights" ON dma_insights
+  FOR SELECT USING (is_org_member(organization_id));
+
+CREATE POLICY "members_write_dma_insights" ON dma_insights
+  FOR ALL USING (is_org_member(organization_id));
+
+-- ── 3. Fix suggested_tasks for DMA use ───────────────────────────────────────
+
+-- source_id was uuid NOT NULL; DMA actions reference ESRS topic codes, not UUIDs
+ALTER TABLE suggested_tasks
+  ALTER COLUMN source_id DROP NOT NULL;
+
+-- estimated_time was missing
+ALTER TABLE suggested_tasks
+  ADD COLUMN IF NOT EXISTS estimated_time text;
+
+-- INSERT policy was missing
+CREATE POLICY "members_insert_suggested" ON suggested_tasks
+  FOR INSERT WITH CHECK (is_org_member(organization_id));

--- a/types.ts
+++ b/types.ts
@@ -53,6 +53,7 @@ export interface AssessmentData {
   financialMaterialityValue: number; // Calculated
   isMaterial: boolean;
   aiScoringSuggestion?: (AssessmentScoring & { suggestedAt: string }) | null;
+  updatedAt?: string;
 }
 
 export interface User {


### PR DESCRIPTION
Closes #33
Depends on #50 (Issue #05 backend — merge that first)

## Summary
- New `components/DMAInsightHub.tsx` — full-screen AI analysis screen with score banner, quality check cards, strategic insight panel, and recommended actions
- Added `insight_hub` to App.tsx view union; wired "Review & Continue" button on the Assessments screen
- Back → Assessments, Continue → KPI Dashboard

## What's on screen
- **Score banner** — material topic count, completion %, quality status, statement readiness
- **Quality check cards** — per-topic traffic lights (🔴/🟡/🟢) with collapsible issue detail, ESRS refs, fix suggestions; sorted worst-first
- **Strategic insight panel** — blue gradient panel with summary, key risks, opportunities, bottom line
- **Recommended actions** — grouped by type (Fix / Comply / Improve), colour-coded by priority with ESRS ref and time estimate
- **Navigation** — amber warning if any `needs_fix` topics; Back + Continue buttons

## Test plan
- [x] Navigate to Assessments → click "Review & Continue" button (appears when ≥1 assessment exists)
- [x] Loading state shows "Analysing your assessments…" animation
- [ ] Quality cards render correctly; `needs_fix` cards expand by default
- [ ] Click card header toggles expand/collapse
- [ ] Strategic insight panel shows all four fields
- [ ] Actions grouped by Fix/Comply/Improve
- [ ] Back button returns to Assessments view
- [ ] Continue button goes to KPI Dashboard
- [ ] Retry button shown on AI error
- [ ] Dark mode works

🤖 Generated with [Claude Code](https://claude.com/claude-code)