### PR TITLE
ux: replace footer badges with single Electric Lime sentence

### DIFF
--- a/components/AuthScreen.tsx
+++ b/components/AuthScreen.tsx
@@ -131,18 +131,10 @@ const AuthScreen: React.FC = () => {
           </div>
         </div>
 
-        {/* Footer badges */}
-        <div className="flex flex-wrap gap-2 font-sans">
-          {["CSRD/ESRS Ready", "GRI Compatible"].map((tag) => (
-            <span
-              key={tag}
-              className="text-xs font-semibold px-3 py-1 rounded-full border"
-              style={{ borderColor: "rgba(204,255,0,0.4)", color: "rgba(255,255,255,0.7)" }}
-            >
-              {tag}
-            </span>
-          ))}
-        </div>
+        {/* Footer */}
+        <p className="text-sm font-sans font-semibold" style={{ color: "#ccff00" }}>
+          CSRD/ESRS-aligned reporting with GRI compatibility
+        </p>
       </div>
 
       {/* Form panel */}


### PR DESCRIPTION
'CSRD/ESRS Ready · GRI Compatible' pills → one line 'CSRD/ESRS-aligned reporting with GRI compatibility' in #ccff00.

## Summary

<!-- What does this PR do? One or two sentences. -->

## Type of change

- [ ] Feature
- [ ] Bug fix
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Database migration (add label `migration` to this PR)

## Related issue

<!-- Closes #123 — or "None" -->

## Database migration

- [ ] This PR does NOT include a database migration
- [ ] This PR includes a migration: `supabase/migrations/<file>.sql`
  - [ ] Migration tested on a local/dev Supabase project
  - [ ] Migration must be applied to all environments BEFORE merging (code depends on schema change)
  - [ ] `supabase/schema.sql` snapshot updated

## Testing

<!-- Describe how you tested this. At minimum: what you clicked, what you observed. -->

- [ ] TypeScript check passes: `npx tsc --noEmit`
- [ ] Build succeeds: `npm run build`
- [ ] Affected feature tested end-to-end in browser
- [ ] Light mode and dark mode both look correct (for UI changes)
- [ ] Invite / auth flow tested (for changes touching auth or invites)

## AI changes

- [ ] This PR does NOT add or modify an AI action
- [ ] This PR adds/modifies an AI action
  - Action name: `_______________`
  - Token usage is logged via the existing `ai_usage_log` pattern: [ ] Yes

## Notes for reviewers

<!-- Anything non-obvious the reviewer should know. Known limitations, trade-offs, follow-up work. -->
