### PR TITLE
feat(#41): Evidence Vault service layer and Netlify upload function

### DIFF
--- a/netlify/functions/evidence.ts
+++ b/netlify/functions/evidence.ts
@@ -1,0 +1,375 @@
+/**
+ * netlify/functions/evidence.ts
+ *
+ * Server-side evidence handler (uses service-role key).
+ * Handles:
+ *   GET  /?action=quota&organization_id=... — storage quota for the org
+ *   POST /                                  — direct file upload (Pro tier)
+ *   DELETE /                                — delete file from storage + DB row
+ *
+ * External links (Drive/OneDrive/URL) are saved client-side via supabase anon key.
+ *
+ * Storage bucket: 'evidence-files'
+ * Create it in Supabase dashboard → Storage → New bucket → evidence-files (private).
+ *
+ * Quota limits (MB):
+ *   free       → 0 (link-only, no direct upload)
+ *   pro        → 10 240 (10 GB)
+ *   enterprise → 102 400 (100 GB)
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL   = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL || '';
+const SERVICE_KEY    = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
+const BUCKET         = 'evidence-files';
+const MAX_MB         = 25;
+
+const QUOTA_MAP: Record<string, number> = {
+  free:       0,
+  pro:        10_240,
+  enterprise: 102_400,
+};
+
+const ALLOWED_MIME = new Set([
+  'application/pdf',
+  'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  'application/vnd.ms-excel',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  'application/msword',
+  'image/jpeg',
+  'image/png',
+  'image/gif',
+  'image/webp',
+  'text/csv',
+  'text/plain',
+]);
+
+const json = (code: number, body: unknown) => ({
+  statusCode: code,
+  headers: { 'Content-Type': 'application/json' },
+  body: JSON.stringify(body),
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Handler
+// ─────────────────────────────────────────────────────────────────────────────
+
+export const handler = async (event: any) => {
+  if (!SUPABASE_URL || !SERVICE_KEY) {
+    return json(503, { error: 'Server configuration error: missing Supabase credentials.' });
+  }
+
+  const admin = createClient(SUPABASE_URL, SERVICE_KEY, {
+    auth: { persistSession: false },
+  });
+
+  // Auth — require Bearer token
+  const authHeader = (event.headers.authorization || event.headers.Authorization) as string | undefined;
+  if (!authHeader?.startsWith('Bearer ')) {
+    return json(401, { error: 'Authentication required.' });
+  }
+  const accessToken = authHeader.slice('Bearer '.length);
+  const { data: userResp, error: authErr } = await admin.auth.getUser(accessToken);
+  if (authErr || !userResp?.user) {
+    return json(401, { error: 'Session expired. Please sign in again.' });
+  }
+  const user = userResp.user;
+
+  // ── GET: quota ──────────────────────────────────────────────────────────────
+  if (event.httpMethod === 'GET') {
+    const orgId = event.queryStringParameters?.organization_id as string | undefined;
+    if (!orgId) return json(400, { error: 'Missing organization_id.' });
+
+    const memberCheck = await isMember(admin, orgId, user.id);
+    if (!memberCheck) return json(403, { error: 'Access denied.' });
+
+    const quota = await getStorageQuota(admin, orgId);
+    return json(200, quota);
+  }
+
+  // ── DELETE: remove storage file + DB row ────────────────────────────────────
+  if (event.httpMethod === 'DELETE') {
+    let body: any;
+    try { body = JSON.parse(event.body || '{}'); } catch { return json(400, { error: 'Invalid JSON.' }); }
+
+    const { id, organization_id } = body as { id?: string; organization_id?: string };
+    if (!id || !organization_id) return json(400, { error: 'Missing id or organization_id.' });
+
+    const memberCheck = await isMember(admin, organization_id, user.id);
+    if (!memberCheck) return json(403, { error: 'Access denied.' });
+
+    // Fetch the row to get storage_path
+    const { data: row, error: fetchErr } = await admin
+      .from('evidence_attachments')
+      .select('storage_type, storage_path, organization_id')
+      .eq('id', id)
+      .eq('organization_id', organization_id)
+      .single();
+    if (fetchErr || !row) return json(404, { error: 'Evidence record not found.' });
+
+    // Delete from storage if applicable
+    if (row.storage_type === 'supabase_storage' && row.storage_path) {
+      const { error: storageErr } = await admin.storage.from(BUCKET).remove([row.storage_path]);
+      if (storageErr) {
+        console.warn('Storage delete warning:', storageErr.message);
+        // Continue — still delete the DB row even if storage delete fails
+      }
+    }
+
+    const { error: dbErr } = await admin.from('evidence_attachments').delete().eq('id', id);
+    if (dbErr) return json(500, { error: 'Failed to delete evidence record.' });
+
+    return json(200, { success: true });
+  }
+
+  // ── POST: direct file upload ─────────────────────────────────────────────────
+  if (event.httpMethod === 'POST') {
+    // Netlify passes multipart as base64-encoded body with isBase64Encoded=true
+    if (!event.isBase64Encoded && !event.body) {
+      return json(400, { error: 'Expected multipart/form-data body.' });
+    }
+
+    // Parse multipart/form-data
+    let fields: Record<string, string> = {};
+    let fileBuffer: Buffer | null = null;
+    let fileName = '';
+    let fileMimeType = '';
+
+    try {
+      const boundary = getBoundary(event.headers['content-type'] || event.headers['Content-Type'] || '');
+      if (!boundary) return json(400, { error: 'Missing multipart boundary.' });
+
+      const rawBody = event.isBase64Encoded
+        ? Buffer.from(event.body, 'base64')
+        : Buffer.from(event.body as string, 'utf-8');
+
+      ({ fields, fileBuffer, fileName, fileMimeType } = parseMultipart(rawBody, boundary));
+    } catch (e: any) {
+      return json(400, { error: `Failed to parse upload: ${e?.message}` });
+    }
+
+    const { organization_id, linked_to_type, linked_to_id, notes } = fields;
+    if (!organization_id || !linked_to_type || !linked_to_id) {
+      return json(400, { error: 'Missing required fields: organization_id, linked_to_type, linked_to_id.' });
+    }
+    if (!fileBuffer || !fileName) {
+      return json(400, { error: 'No file attached.' });
+    }
+
+    // Auth: membership check
+    const memberCheck = await isMember(admin, organization_id, user.id);
+    if (!memberCheck) return json(403, { error: 'Access denied.' });
+
+    // Tier check: only Pro/Enterprise can upload
+    const quota = await getStorageQuota(admin, organization_id);
+    if (quota.total_mb === 0) {
+      return json(403, { error: 'Direct upload requires a Pro subscription. Link files from Google Drive or a URL instead.' });
+    }
+
+    // File type validation
+    if (fileMimeType && !ALLOWED_MIME.has(fileMimeType)) {
+      return json(415, { error: `File type '${fileMimeType}' is not allowed.` });
+    }
+
+    // File size validation
+    const fileSizeMb = fileBuffer.byteLength / (1024 * 1024);
+    if (fileSizeMb > MAX_MB) {
+      return json(413, { error: `File too large (${fileSizeMb.toFixed(1)} MB). Maximum is ${MAX_MB} MB.` });
+    }
+
+    // Quota check
+    if (quota.available_mb < fileSizeMb) {
+      return json(413, {
+        error: `Storage quota exceeded. Available: ${quota.available_mb.toFixed(0)} MB, required: ${fileSizeMb.toFixed(1)} MB.`,
+      });
+    }
+
+    // Upload to Supabase Storage
+    const storagePath = `${organization_id}/${Date.now()}-${sanitizeFileName(fileName)}`;
+    const { error: uploadErr } = await admin.storage
+      .from(BUCKET)
+      .upload(storagePath, fileBuffer, {
+        contentType: fileMimeType || 'application/octet-stream',
+        upsert: false,
+      });
+    if (uploadErr) {
+      console.error('Storage upload error:', uploadErr);
+      return json(500, { error: 'File upload failed. Please try again.' });
+    }
+
+    // Derive file extension for file_type
+    const ext = fileName.split('.').pop()?.toLowerCase() ?? null;
+
+    // Insert DB row
+    const { data: row, error: dbErr } = await admin
+      .from('evidence_attachments')
+      .insert({
+        organization_id,
+        file_name:      fileName,
+        file_type:      ext,
+        file_size_mb:   Math.round(fileSizeMb * 100) / 100,
+        storage_type:   'supabase_storage',
+        external_url:   null,
+        external_id:    null,
+        storage_path:   storagePath,
+        linked_to_type,
+        linked_to_id,
+        notes:          notes ?? null,
+        uploaded_by:    user.id,
+      })
+      .select()
+      .single();
+
+    if (dbErr) {
+      // Cleanup: remove the file we just uploaded
+      await admin.storage.from(BUCKET).remove([storagePath]);
+      return json(500, { error: 'Failed to save evidence record.' });
+    }
+
+    return json(201, row);
+  }
+
+  return json(405, { error: 'Method not allowed.' });
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+async function isMember(admin: any, orgId: string, userId: string): Promise<boolean> {
+  const { data } = await admin
+    .from('organization_members')
+    .select('id')
+    .eq('organization_id', orgId)
+    .eq('user_id', userId)
+    .maybeSingle();
+  return !!data;
+}
+
+async function getOrgTier(admin: any, orgId: string): Promise<string> {
+  // Placeholder — when subscription management is added, query it here.
+  // For now: all orgs are 'free' (link-only). Set to 'pro' to unlock uploads.
+  const { data } = await admin
+    .from('organizations')
+    .select('subscription_tier')
+    .eq('id', orgId)
+    .maybeSingle();
+  return (data?.subscription_tier as string | null) ?? 'free';
+}
+
+async function getStorageQuota(
+  admin: any,
+  orgId: string,
+): Promise<{ used_mb: number; total_mb: number; available_mb: number }> {
+  const tier = await getOrgTier(admin, orgId);
+  const total_mb = QUOTA_MAP[tier] ?? 0;
+
+  const { data } = await admin
+    .from('evidence_attachments')
+    .select('file_size_mb')
+    .eq('organization_id', orgId)
+    .eq('storage_type', 'supabase_storage');
+
+  const used_mb = (data ?? []).reduce(
+    (sum: number, r: any) => sum + (Number(r.file_size_mb) || 0),
+    0,
+  );
+
+  return {
+    used_mb:      Math.round(used_mb * 100) / 100,
+    total_mb,
+    available_mb: Math.max(0, total_mb - used_mb),
+  };
+}
+
+function getBoundary(contentType: string): string | null {
+  const match = contentType.match(/boundary=(?:"([^"]+)"|([^\s;]+))/i);
+  return match ? (match[1] ?? match[2]) : null;
+}
+
+function sanitizeFileName(name: string): string {
+  return name.replace(/[^a-zA-Z0-9._-]/g, '_').slice(0, 120);
+}
+
+/**
+ * Minimal multipart/form-data parser.
+ * Extracts text fields and the first file part.
+ */
+function parseMultipart(
+  body: Buffer,
+  boundary: string,
+): {
+  fields: Record<string, string>;
+  fileBuffer: Buffer | null;
+  fileName: string;
+  fileMimeType: string;
+} {
+  const sep = Buffer.from(`--${boundary}`);
+  const fields: Record<string, string> = {};
+  let fileBuffer: Buffer | null = null;
+  let fileName = '';
+  let fileMimeType = '';
+
+  let pos = 0;
+  while (pos < body.length) {
+    // Find next boundary
+    const boundaryPos = indexOfBuffer(body, sep, pos);
+    if (boundaryPos === -1) break;
+    pos = boundaryPos + sep.length;
+
+    // Check for terminal boundary
+    if (body[pos] === 0x2d && body[pos + 1] === 0x2d) break; // "--"
+
+    // Skip CRLF after boundary
+    if (body[pos] === 0x0d) pos++;
+    if (body[pos] === 0x0a) pos++;
+
+    // Find end of headers (double CRLF)
+    const headerEnd = indexOfBuffer(body, Buffer.from('\r\n\r\n'), pos);
+    if (headerEnd === -1) break;
+    const headerSection = body.slice(pos, headerEnd).toString('utf-8');
+    pos = headerEnd + 4;
+
+    // Find end of part (next boundary or end)
+    const nextBoundary = indexOfBuffer(body, sep, pos);
+    const partEnd = nextBoundary !== -1 ? nextBoundary - 2 : body.length; // -2 for CRLF before boundary
+    const partData = body.slice(pos, partEnd);
+    pos = partEnd;
+
+    // Parse Content-Disposition
+    const cdMatch = headerSection.match(/Content-Disposition:\s*form-data;(.+?)(?:\r\n|$)/i);
+    if (!cdMatch) continue;
+    const cdPart = cdMatch[1];
+
+    const nameMatch = cdPart.match(/name="([^"]+)"/i);
+    const fileNameMatch = cdPart.match(/filename="([^"]+)"/i);
+
+    if (!nameMatch) continue;
+    const fieldName = nameMatch[1];
+
+    if (fileNameMatch) {
+      // File part
+      fileName = fileNameMatch[1];
+      const ctMatch = headerSection.match(/Content-Type:\s*([^\r\n]+)/i);
+      fileMimeType = ctMatch ? ctMatch[1].trim() : '';
+      fileBuffer = partData;
+    } else {
+      // Text field
+      fields[fieldName] = partData.toString('utf-8');
+    }
+  }
+
+  return { fields, fileBuffer, fileName, fileMimeType };
+}
+
+function indexOfBuffer(haystack: Buffer, needle: Buffer, offset = 0): number {
+  for (let i = offset; i <= haystack.length - needle.length; i++) {
+    let found = true;
+    for (let j = 0; j < needle.length; j++) {
+      if (haystack[i + j] !== needle[j]) { found = false; break; }
+    }
+    if (found) return i;
+  }
+  return -1;
+}

--- a/services/evidenceService.ts
+++ b/services/evidenceService.ts
@@ -1,0 +1,242 @@
+/**
+ * evidenceService.ts
+ *
+ * Client-side CRUD helpers for evidence_attachments.
+ *
+ * External links (google_drive, onedrive, dropbox, url) are saved directly
+ * via the Supabase anon key — RLS ensures org isolation.
+ *
+ * Direct uploads (supabase_storage) require the Netlify function at
+ * /.netlify/functions/evidence which uses the service-role key to write
+ * to Supabase Storage and enforce Pro-tier quota limits.
+ */
+
+import { supabase } from '../lib/supabaseClient';
+import {
+  EvidenceAttachment,
+  EvidenceLinkedToType,
+  StorageType,
+} from '../types';
+
+// ─────────────────────────────────────────────────────────────────────────────
+// DB ↔ TS mapping
+// ─────────────────────────────────────────────────────────────────────────────
+
+const fromDbRow = (row: any): EvidenceAttachment => ({
+  id:              row.id,
+  organization_id: row.organization_id,
+  file_name:       row.file_name,
+  file_type:       row.file_type    ?? null,
+  file_size_mb:    row.file_size_mb != null ? Number(row.file_size_mb) : null,
+  storage_type:    row.storage_type as StorageType,
+  external_url:    row.external_url  ?? null,
+  external_id:     row.external_id   ?? null,
+  storage_path:    row.storage_path  ?? null,
+  linked_to_type:  row.linked_to_type as EvidenceLinkedToType,
+  linked_to_id:    row.linked_to_id,
+  notes:           row.notes         ?? null,
+  uploaded_by:     row.uploaded_by   ?? null,
+  uploaded_at:     row.uploaded_at,
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Read helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Fetch all evidence attached to a specific entity. */
+export async function fetchEvidence(
+  orgId: string,
+  linkedToType: EvidenceLinkedToType,
+  linkedToId: string,
+): Promise<EvidenceAttachment[]> {
+  const { data, error } = await supabase
+    .from('evidence_attachments')
+    .select('*')
+    .eq('organization_id', orgId)
+    .eq('linked_to_type', linkedToType)
+    .eq('linked_to_id', linkedToId)
+    .order('uploaded_at', { ascending: false });
+  if (error) throw error;
+  return (data ?? []).map(fromDbRow);
+}
+
+/** Count evidence items for a badge. Cheaper than a full select. */
+export async function countEvidence(
+  orgId: string,
+  linkedToType: EvidenceLinkedToType,
+  linkedToId: string,
+): Promise<number> {
+  const { count, error } = await supabase
+    .from('evidence_attachments')
+    .select('id', { count: 'exact', head: true })
+    .eq('organization_id', orgId)
+    .eq('linked_to_type', linkedToType)
+    .eq('linked_to_id', linkedToId);
+  if (error) throw error;
+  return count ?? 0;
+}
+
+/** Batch-count evidence across many entity IDs in one query. */
+export async function batchCountEvidence(
+  orgId: string,
+  linkedToType: EvidenceLinkedToType,
+  linkedToIds: string[],
+): Promise<Record<string, number>> {
+  if (linkedToIds.length === 0) return {};
+
+  const { data, error } = await supabase
+    .from('evidence_attachments')
+    .select('linked_to_id')
+    .eq('organization_id', orgId)
+    .eq('linked_to_type', linkedToType)
+    .in('linked_to_id', linkedToIds);
+  if (error) throw error;
+
+  const counts: Record<string, number> = {};
+  for (const id of linkedToIds) counts[id] = 0;
+  for (const row of data ?? []) {
+    counts[row.linked_to_id] = (counts[row.linked_to_id] ?? 0) + 1;
+  }
+  return counts;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Write helpers — external links (free tier)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface LinkEvidencePayload {
+  file_name:      string;
+  file_type?:     string;
+  file_size_mb?:  number;
+  storage_type:   Exclude<StorageType, 'supabase_storage' | 's3'>;
+  external_url?:  string;
+  external_id?:   string;   // cloud provider file ID (Drive ID, OneDrive item ID…)
+  linked_to_type: EvidenceLinkedToType;
+  linked_to_id:   string;
+  notes?:         string;
+}
+
+/** Save a link to an external file (Google Drive / OneDrive / Dropbox / URL). */
+export async function linkExternalEvidence(
+  orgId: string,
+  payload: LinkEvidencePayload,
+  userId: string,
+): Promise<EvidenceAttachment> {
+  const { data, error } = await supabase
+    .from('evidence_attachments')
+    .insert({
+      organization_id: orgId,
+      file_name:       payload.file_name,
+      file_type:       payload.file_type    ?? null,
+      file_size_mb:    payload.file_size_mb ?? null,
+      storage_type:    payload.storage_type,
+      external_url:    payload.external_url ?? null,
+      external_id:     payload.external_id  ?? null,
+      storage_path:    null,
+      linked_to_type:  payload.linked_to_type,
+      linked_to_id:    payload.linked_to_id,
+      notes:           payload.notes        ?? null,
+      uploaded_by:     userId,
+    })
+    .select()
+    .single();
+  if (error) throw error;
+  return fromDbRow(data);
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Write helpers — direct upload (Pro tier, via Netlify function)
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface UploadEvidencePayload {
+  file:           File;
+  linked_to_type: EvidenceLinkedToType;
+  linked_to_id:   string;
+  notes?:         string;
+}
+
+/**
+ * Upload a file directly to Supabase Storage (Pro tier only).
+ * Calls /.netlify/functions/evidence which:
+ *   1. Checks the org's subscription tier (Pro/Enterprise only)
+ *   2. Enforces storage quota
+ *   3. Uploads to the 'evidence-files' bucket using the service-role key
+ *   4. Inserts the evidence_attachments row
+ */
+export async function uploadDirectEvidence(
+  orgId: string,
+  payload: UploadEvidencePayload,
+  accessToken: string,
+): Promise<EvidenceAttachment> {
+  const form = new FormData();
+  form.append('file', payload.file);
+  form.append('organization_id', orgId);
+  form.append('linked_to_type', payload.linked_to_type);
+  form.append('linked_to_id', payload.linked_to_id);
+  if (payload.notes) form.append('notes', payload.notes);
+
+  const resp = await fetch('/.netlify/functions/evidence', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${accessToken}` },
+    body: form,
+  });
+
+  const body = await resp.json().catch(() => ({ error: 'Invalid response' }));
+  if (!resp.ok) throw new Error(body.error ?? 'Upload failed');
+  return fromDbRow(body);
+}
+
+/** Check the org's current storage usage and quota (Pro tier). */
+export async function getStorageQuota(
+  orgId: string,
+  accessToken: string,
+): Promise<{ used_mb: number; total_mb: number; available_mb: number }> {
+  const resp = await fetch(
+    `/.netlify/functions/evidence?action=quota&organization_id=${encodeURIComponent(orgId)}`,
+    { headers: { Authorization: `Bearer ${accessToken}` } },
+  );
+  const body = await resp.json().catch(() => ({ error: 'Invalid response' }));
+  if (!resp.ok) throw new Error(body.error ?? 'Could not fetch quota');
+  return body;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Delete
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Delete an evidence record.
+ * - External links: deletes only the DB row (client-side).
+ * - Direct uploads: calls the Netlify function to also remove the file from
+ *   Supabase Storage before deleting the DB row.
+ */
+export async function deleteEvidence(
+  id: string,
+  orgId: string,
+  storageType: StorageType,
+  accessToken?: string,
+): Promise<void> {
+  if (storageType === 'supabase_storage' && accessToken) {
+    // Server-side: deletes storage file + DB row
+    const resp = await fetch('/.netlify/functions/evidence', {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${accessToken}`,
+      },
+      body: JSON.stringify({ id, organization_id: orgId }),
+    });
+    if (!resp.ok) {
+      const body = await resp.json().catch(() => ({}));
+      throw new Error(body.error ?? 'Failed to delete file from storage');
+    }
+    return;
+  }
+
+  // External link / URL — delete DB row directly
+  const { error } = await supabase
+    .from('evidence_attachments')
+    .delete()
+    .eq('id', id);
+  if (error) throw error;
+}

--- a/supabase/migrations/011_organization_integrations.sql
+++ b/supabase/migrations/011_organization_integrations.sql
@@ -1,0 +1,40 @@
+-- Migration 011: organization_integrations table
+-- Issue: #41 (Evidence Vault API) / #42 (Google Drive OAuth)
+--
+-- Stores OAuth tokens for Google Drive, OneDrive, and Dropbox integrations.
+-- Tokens are stored encrypted at rest by Supabase (vault optional for extra
+-- security — swap access_token/refresh_token columns for vault secret IDs).
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS organization_integrations CASCADE;
+
+CREATE TABLE organization_integrations (
+  id               uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id  uuid        NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  integration_type text        NOT NULL
+                     CHECK (integration_type IN ('google_drive', 'onedrive', 'dropbox')),
+  access_token     text        NOT NULL,
+  refresh_token    text,
+  expires_at       timestamptz,
+  connected_by     uuid        REFERENCES auth.users(id) ON DELETE SET NULL,
+  connected_at     timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (organization_id, integration_type)
+);
+
+CREATE INDEX idx_org_integrations_org
+  ON organization_integrations (organization_id, integration_type);
+
+ALTER TABLE organization_integrations ENABLE ROW LEVEL SECURITY;
+
+-- Only Owner/Admin can connect/disconnect integrations
+CREATE POLICY "admins_manage_integrations" ON organization_integrations
+  FOR ALL USING (
+    is_org_member(organization_id)
+    AND user_org_role(organization_id) IN ('Owner', 'Admin')
+  );
+
+COMMENT ON TABLE  organization_integrations IS 'OAuth tokens for cloud storage integrations (Drive, OneDrive, Dropbox)';
+COMMENT ON COLUMN organization_integrations.integration_type IS 'google_drive | onedrive | dropbox';
+COMMENT ON COLUMN organization_integrations.access_token     IS 'Short-lived OAuth access token';
+COMMENT ON COLUMN organization_integrations.refresh_token    IS 'Long-lived token for refreshing access_token';
+COMMENT ON COLUMN organization_integrations.expires_at       IS 'When access_token expires; refresh before this time';


### PR DESCRIPTION
## Summary
- **`services/evidenceService.ts`** (new) — client-side CRUD for `evidence_attachments`: `fetchEvidence`, `countEvidence`, `batchCountEvidence`, `linkExternalEvidence`, `uploadDirectEvidence`, `getStorageQuota`, `deleteEvidence`
- **`netlify/functions/evidence.ts`** (new) — server-side handler: GET for quota, POST for direct file upload (Pro tier), DELETE for storage + DB cleanup; includes multipart form-data parser and quota enforcement
- **`supabase/migrations/011_organization_integrations.sql`** (new) — `organization_integrations` table with RLS for Owner/Admin-only OAuth token management (prep for #42 Google Drive OAuth)

The `evidence_attachments` table already exists from migration 007. No schema changes needed.

## API

| Method | Path | Purpose |
|--------|------|---------|
| GET | `/.netlify/functions/evidence?action=quota&organization_id=...` | Storage quota |
| POST | `/.netlify/functions/evidence` | Direct upload (Pro only, multipart/form-data) |
| DELETE | `/.netlify/functions/evidence` | Delete storage file + DB row |

## Test plan
- [ ] `linkExternalEvidence()` saves a URL-type record correctly
- [ ] `fetchEvidence()` returns records filtered by entity type + ID
- [ ] `countEvidence()` returns correct count
- [ ] `batchCountEvidence()` returns map of counts for multiple entity IDs
- [ ] `deleteEvidence()` for external link deletes only the DB row
- [ ] POST to `/evidence` with Pro org → file uploaded to storage bucket, DB row inserted
- [ ] POST to `/evidence` with Free org → `403` error
- [ ] POST with oversized file → `413` error
- [ ] POST with disallowed MIME type → `415` error
- [ ] DELETE for `supabase_storage` type → removes file from bucket + DB row
- [ ] `getStorageQuota()` returns correct used/total/available

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)