### PR TITLE
feat(#72): Admin Portal — foundation, auth, shell, dashboard

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,10 @@ SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
 # Google Drive OAuth — server-only secrets (never use VITE_ prefix for these)
 GOOGLE_CLIENT_ID=your_google_oauth_client_id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your_google_oauth_client_secret
+
+# Platform Admin Portal (server-only — never use VITE_ prefix)
+# PLATFORM_ADMIN_EMAIL: email of the first platform admin.
+#   On first call to /.netlify/functions/admin after the DB migration is applied,
+#   if platform_admins is empty and this email matches the logged-in Supabase user,
+#   the first admin row is auto-seeded.  Change or remove after bootstrapping.
+PLATFORM_ADMIN_EMAIL=admin@your-domain.com

--- a/.env.example
+++ b/.env.example
@@ -19,7 +19,14 @@ GOOGLE_CLIENT_SECRET=your_google_oauth_client_secret
 
 # Platform Admin Portal (server-only — never use VITE_ prefix)
 # PLATFORM_ADMIN_EMAIL: email of the first platform admin.
-#   On first call to /.netlify/functions/admin after the DB migration is applied,
-#   if platform_admins is empty and this email matches the logged-in Supabase user,
-#   the first admin row is auto-seeded.  Change or remove after bootstrapping.
+#   On the first successful magic-link login, if platform_admins is empty and
+#   this email matches, the first admin row is auto-seeded.
 PLATFORM_ADMIN_EMAIL=admin@your-domain.com
+
+# Resend — transactional email for admin magic-link emails.
+# Sign up free at https://resend.com (3,000 emails/month on free tier).
+# Without this key the server runs in dev mode: the magic link is returned
+# in the API response and shown directly in the UI instead of being emailed.
+RESEND_API_KEY=re_your_resend_api_key_here
+# Sender address — must be a verified domain/email in your Resend account.
+RESEND_FROM_EMAIL=noreply@your-domain.com

--- a/.env.example
+++ b/.env.example
@@ -18,10 +18,15 @@ GOOGLE_CLIENT_ID=your_google_oauth_client_id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your_google_oauth_client_secret
 
 # Platform Admin Portal (server-only — never use VITE_ prefix)
-# PLATFORM_ADMIN_EMAIL: email of the first platform admin.
-#   On the first successful magic-link login, if platform_admins is empty and
-#   this email matches, the first admin row is auto-seeded.
+# Bootstrap credentials — used ONLY when the platform_admins table is empty.
+# After the first sign-in the admin row is seeded and magic link becomes the
+# primary login method (password login is rejected once the table has rows).
 PLATFORM_ADMIN_EMAIL=admin@your-domain.com
+PLATFORM_ADMIN_PASSWORD=change-me-to-something-strong
+
+# Optional — custom JWT signing secret for admin tokens (8 h TTL).
+# If omitted, a secret is derived from SUPABASE_SERVICE_ROLE_KEY automatically.
+# PLATFORM_ADMIN_JWT_SECRET=
 
 # Resend — transactional email for admin magic-link emails.
 # Sign up free at https://resend.com (3,000 emails/month on free tier).

--- a/AdminApp.tsx
+++ b/AdminApp.tsx
@@ -1,0 +1,96 @@
+/**
+ * AdminApp.tsx
+ *
+ * Root component for the Platform Admin portal rendered at /admin.
+ * Manages the admin authentication lifecycle:
+ *   - No session → show AdminLoginScreen
+ *   - Valid session → show AdminShell
+ *
+ * The session is persisted in localStorage under 'aeternum_admin_session'
+ * as { token: string, email: string, expiresAt: number }.
+ * Token is the raw Supabase access_token; it expires after 1 hour.
+ */
+
+import React, { useState, useEffect } from 'react';
+import AdminLoginScreen from './components/admin/AdminLoginScreen';
+import AdminShell from './components/admin/AdminShell';
+import { supabase } from './lib/supabaseClient';
+import { Loader2 } from 'lucide-react';
+
+const SESSION_KEY = 'aeternum_admin_session';
+
+interface AdminSession {
+  token:     string;
+  email:     string;
+  expiresAt: number; // epoch ms
+}
+
+function loadSession(): AdminSession | null {
+  try {
+    const raw = localStorage.getItem(SESSION_KEY);
+    if (!raw) return null;
+    const s = JSON.parse(raw) as AdminSession;
+    if (Date.now() >= s.expiresAt) { localStorage.removeItem(SESSION_KEY); return null; }
+    return s;
+  } catch { return null; }
+}
+
+function saveSession(token: string, email: string) {
+  const session: AdminSession = {
+    token,
+    email,
+    expiresAt: Date.now() + 55 * 60 * 1000, // 55 min (Supabase tokens expire at 60)
+  };
+  localStorage.setItem(SESSION_KEY, JSON.stringify(session));
+}
+
+function clearSession() {
+  localStorage.removeItem(SESSION_KEY);
+}
+
+// ---------------------------------------------------------------------------
+
+const AdminApp: React.FC = () => {
+  const [session, setSession] = useState<AdminSession | null>(null);
+  const [booting, setBooting] = useState(true);
+
+  // On mount, restore session from localStorage if still valid
+  useEffect(() => {
+    const s = loadSession();
+    setSession(s);
+    setBooting(false);
+  }, []);
+
+  const handleLoginSuccess = (token: string, email: string) => {
+    saveSession(token, email);
+    setSession({ token, email, expiresAt: Date.now() + 55 * 60 * 1000 });
+  };
+
+  const handleSignOut = async () => {
+    clearSession();
+    setSession(null);
+    await supabase.auth.signOut();
+  };
+
+  if (booting) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-slate-950">
+        <Loader2 className="w-6 h-6 animate-spin text-slate-500" />
+      </div>
+    );
+  }
+
+  if (!session) {
+    return <AdminLoginScreen onLoginSuccess={handleLoginSuccess} />;
+  }
+
+  return (
+    <AdminShell
+      adminToken={session.token}
+      adminEmail={session.email}
+      onSignOut={handleSignOut}
+    />
+  );
+};
+
+export default AdminApp;

--- a/AdminApp.tsx
+++ b/AdminApp.tsx
@@ -118,11 +118,12 @@ const AdminApp: React.FC = () => {
     setSession({ token, email, expiresAt: Date.now() + 55 * 60 * 1000 });
   };
 
-  const handleSignOut = async () => {
+  const handleSignOut = () => {
     clearSession();
-    setSession(null);
-    setBootError('');
-    await supabase.auth.signOut();
+    // Silently attempt Supabase sign-out (may be a no-op for password-only logins)
+    supabase.auth.signOut().catch(() => {});
+    // Hard redirect ensures clean state regardless of Supabase session presence
+    window.location.href = '/admin';
   };
 
   // ── Booting ──

--- a/AdminApp.tsx
+++ b/AdminApp.tsx
@@ -3,26 +3,26 @@
  *
  * Root component for the Platform Admin portal rendered at /admin.
  * Manages the admin authentication lifecycle:
- *   - No session → show AdminLoginScreen
- *   - Valid session → show AdminShell
+ *   - No session → show AdminLoginScreen (magic link form)
+ *   - Magic link callback (URL hash has access_token) → verify admin → enter shell
+ *   - Valid stored session → show AdminShell directly
  *
- * The session is persisted in localStorage under 'aeternum_admin_session'
- * as { token: string, email: string, expiresAt: number }.
- * Token is the raw Supabase access_token; it expires after 1 hour.
+ * Session persisted in localStorage under 'aeternum_admin_session':
+ *   { token: string, email: string, expiresAt: number }
  */
 
 import React, { useState, useEffect } from 'react';
 import AdminLoginScreen from './components/admin/AdminLoginScreen';
 import AdminShell from './components/admin/AdminShell';
 import { supabase } from './lib/supabaseClient';
-import { Loader2 } from 'lucide-react';
+import { Loader2, ShieldCheck, AlertCircle } from 'lucide-react';
 
 const SESSION_KEY = 'aeternum_admin_session';
 
 interface AdminSession {
   token:     string;
   email:     string;
-  expiresAt: number; // epoch ms
+  expiresAt: number;
 }
 
 function loadSession(): AdminSession | null {
@@ -36,29 +36,81 @@ function loadSession(): AdminSession | null {
 }
 
 function saveSession(token: string, email: string) {
-  const session: AdminSession = {
-    token,
-    email,
-    expiresAt: Date.now() + 55 * 60 * 1000, // 55 min (Supabase tokens expire at 60)
-  };
-  localStorage.setItem(SESSION_KEY, JSON.stringify(session));
+  const s: AdminSession = { token, email, expiresAt: Date.now() + 55 * 60 * 1000 };
+  localStorage.setItem(SESSION_KEY, JSON.stringify(s));
 }
 
-function clearSession() {
-  localStorage.removeItem(SESSION_KEY);
-}
+function clearSession() { localStorage.removeItem(SESSION_KEY); }
 
 // ---------------------------------------------------------------------------
 
 const AdminApp: React.FC = () => {
-  const [session, setSession] = useState<AdminSession | null>(null);
-  const [booting, setBooting] = useState(true);
+  const [session, setSession]       = useState<AdminSession | null>(null);
+  const [booting, setBooting]       = useState(true);
+  const [bootError, setBootError]   = useState('');
 
-  // On mount, restore session from localStorage if still valid
   useEffect(() => {
-    const s = loadSession();
-    setSession(s);
-    setBooting(false);
+    let cancelled = false;
+
+    const boot = async () => {
+      // 1. Check stored session first
+      const stored = loadSession();
+      if (stored) {
+        if (!cancelled) { setSession(stored); setBooting(false); }
+        return;
+      }
+
+      // 2. Check if Supabase just redirected back with a magic-link token
+      //    Supabase puts #access_token=...&type=magiclink in the URL hash
+      const { data: { session: sbSession } } = await supabase.auth.getSession();
+
+      if (sbSession?.access_token) {
+        // Verify the user is an active platform admin
+        try {
+          const res = await fetch('/.netlify/functions/admin', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              'Authorization': `Bearer ${sbSession.access_token}`,
+            },
+            body: JSON.stringify({ action: 'verify_admin' }),
+          });
+          const json = await res.json();
+
+          if (!res.ok) {
+            await supabase.auth.signOut();
+            if (!cancelled) {
+              setBootError(json.error ?? 'Not authorized as platform admin');
+              setBooting(false);
+            }
+            return;
+          }
+
+          // Clean the hash from the URL so tokens don't sit in the address bar
+          window.history.replaceState(null, '', '/admin');
+
+          const newSession: AdminSession = {
+            token:     sbSession.access_token,
+            email:     json.email,
+            expiresAt: Date.now() + 55 * 60 * 1000,
+          };
+          saveSession(newSession.token, newSession.email);
+          if (!cancelled) { setSession(newSession); setBooting(false); }
+        } catch (err: any) {
+          if (!cancelled) {
+            setBootError(err?.message ?? 'Verification failed');
+            setBooting(false);
+          }
+        }
+        return;
+      }
+
+      // 3. No session, no magic-link callback → show login screen
+      if (!cancelled) setBooting(false);
+    };
+
+    boot();
+    return () => { cancelled = true; };
   }, []);
 
   const handleLoginSuccess = (token: string, email: string) => {
@@ -69,21 +121,50 @@ const AdminApp: React.FC = () => {
   const handleSignOut = async () => {
     clearSession();
     setSession(null);
+    setBootError('');
     await supabase.auth.signOut();
   };
 
+  // ── Booting ──
   if (booting) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-slate-950">
-        <Loader2 className="w-6 h-6 animate-spin text-slate-500" />
+      <div className="min-h-screen flex flex-col items-center justify-center gap-3 bg-slate-950">
+        <div className="w-12 h-12 rounded-2xl bg-esg-700 flex items-center justify-center">
+          <ShieldCheck className="w-6 h-6 text-white" />
+        </div>
+        <Loader2 className="w-5 h-5 animate-spin text-slate-500" />
+        <p className="text-xs text-slate-500">Verifying admin access…</p>
       </div>
     );
   }
 
+  // ── Boot error (e.g. magic link but not an admin) ──
+  if (bootError) {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-slate-950 px-4">
+        <div className="w-full max-w-sm bg-slate-900 border border-slate-800 rounded-2xl p-6 text-center space-y-4">
+          <AlertCircle className="w-8 h-8 text-red-400 mx-auto" />
+          <div>
+            <p className="text-white font-semibold">Access Denied</p>
+            <p className="text-sm text-slate-400 mt-1">{bootError}</p>
+          </div>
+          <button
+            onClick={handleSignOut}
+            className="px-4 py-2 text-sm bg-slate-800 hover:bg-slate-700 text-white rounded-lg transition-colors"
+          >
+            Back to Login
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  // ── No session → show login ──
   if (!session) {
     return <AdminLoginScreen onLoginSuccess={handleLoginSuccess} />;
   }
 
+  // ── Authenticated ──
   return (
     <AdminShell
       adminToken={session.token}

--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -1,0 +1,168 @@
+import React, { useState, useEffect } from 'react';
+import { Building2, Users, Zap, AlertTriangle, Loader2, RefreshCw, TrendingUp, ShieldOff } from 'lucide-react';
+
+interface DashboardStats {
+  totalCompanies:    number;
+  activeCompanies:   number;
+  inactiveCompanies: number;
+  totalUsers:        number;
+  aiCallsToday:      number;
+  aiErrorsTotal:     number;
+}
+
+interface Props {
+  adminToken: string;
+}
+
+const AdminDashboard: React.FC<Props> = ({ adminToken }) => {
+  const [stats, setStats]     = useState<DashboardStats | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError]     = useState('');
+
+  const fetchStats = async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetch('/.netlify/functions/admin', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${adminToken}`,
+        },
+        body: JSON.stringify({ action: 'admin_dashboard' }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error ?? 'Failed to load stats');
+      setStats(json);
+    } catch (err: any) {
+      setError(err?.message ?? 'Error loading dashboard');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => { fetchStats(); }, [adminToken]);
+
+  return (
+    <div className="space-y-6 animate-in fade-in duration-500">
+      {/* Header row */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-800 dark:text-white">Platform Overview</h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400 mt-0.5">Live metrics across all registered companies</p>
+        </div>
+        <button
+          onClick={fetchStats}
+          disabled={loading}
+          className="flex items-center gap-1.5 px-3 py-1.5 text-sm text-slate-500 dark:text-slate-400 hover:text-slate-800 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg transition-colors disabled:opacity-50"
+        >
+          <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+          Refresh
+        </button>
+      </div>
+
+      {error && (
+        <div className="flex items-center gap-2 text-sm text-red-600 dark:text-red-400 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg px-4 py-3">
+          <AlertTriangle className="w-4 h-4 flex-shrink-0" />
+          {error}
+        </div>
+      )}
+
+      {loading && !stats ? (
+        <div className="flex items-center justify-center min-h-[300px]">
+          <div className="flex items-center gap-3 text-slate-500 dark:text-slate-400">
+            <Loader2 className="w-5 h-5 animate-spin" />
+            Loading platform stats…
+          </div>
+        </div>
+      ) : stats ? (
+        <>
+          {/* Stat cards */}
+          <div className="grid grid-cols-2 lg:grid-cols-3 gap-4">
+            <StatCard
+              icon={<Building2 className="w-5 h-5 text-blue-500" />}
+              label="Total Companies"
+              value={stats.totalCompanies}
+              sub={`${stats.activeCompanies} active · ${stats.inactiveCompanies} inactive`}
+              color="blue"
+            />
+            <StatCard
+              icon={<Users className="w-5 h-5 text-violet-500" />}
+              label="Total Members"
+              value={stats.totalUsers}
+              sub="Across all organisations"
+              color="violet"
+            />
+            <StatCard
+              icon={<Zap className="w-5 h-5 text-amber-500" />}
+              label="AI Calls Today"
+              value={stats.aiCallsToday}
+              sub="Since midnight UTC"
+              color="amber"
+            />
+            <StatCard
+              icon={<ShieldOff className="w-5 h-5 text-red-500" />}
+              label="AI Errors (Total)"
+              value={stats.aiErrorsTotal}
+              sub="All time"
+              color="red"
+            />
+            <StatCard
+              icon={<TrendingUp className="w-5 h-5 text-esg-500" />}
+              label="Active Companies"
+              value={stats.activeCompanies}
+              sub={`${stats.totalCompanies > 0 ? Math.round((stats.activeCompanies / stats.totalCompanies) * 100) : 0}% of total`}
+              color="green"
+            />
+          </div>
+
+          {/* Placeholder panels for future issues */}
+          <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+            <PlaceholderPanel title="AI Usage by Month" issueRef="#77" />
+            <PlaceholderPanel title="Top Active Companies" issueRef="#74" />
+          </div>
+        </>
+      ) : null}
+    </div>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+const COLORS: Record<string, string> = {
+  blue:   'bg-blue-50 dark:bg-blue-900/20 border-blue-100 dark:border-blue-800',
+  violet: 'bg-violet-50 dark:bg-violet-900/20 border-violet-100 dark:border-violet-800',
+  amber:  'bg-amber-50 dark:bg-amber-900/20 border-amber-100 dark:border-amber-800',
+  red:    'bg-red-50 dark:bg-red-900/20 border-red-100 dark:border-red-800',
+  green:  'bg-esg-50 dark:bg-esg-900/20 border-esg-100 dark:border-esg-800',
+};
+
+const StatCard: React.FC<{
+  icon: React.ReactNode;
+  label: string;
+  value: number;
+  sub: string;
+  color: string;
+}> = ({ icon, label, value, sub, color }) => (
+  <div className={`rounded-xl border p-5 flex items-start gap-4 ${COLORS[color] ?? COLORS.blue}`}>
+    <div className="w-10 h-10 rounded-lg bg-white dark:bg-slate-900/50 flex items-center justify-center flex-shrink-0 shadow-sm">
+      {icon}
+    </div>
+    <div className="min-w-0">
+      <p className="text-xs font-medium text-slate-500 dark:text-slate-400 uppercase tracking-wide truncate">{label}</p>
+      <p className="text-2xl font-bold text-slate-800 dark:text-white mt-0.5">{value.toLocaleString()}</p>
+      <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5 truncate">{sub}</p>
+    </div>
+  </div>
+);
+
+const PlaceholderPanel: React.FC<{ title: string; issueRef: string }> = ({ title, issueRef }) => (
+  <div className="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 p-6 flex flex-col items-center justify-center min-h-[180px] text-center">
+    <p className="text-sm font-medium text-slate-500 dark:text-slate-400">{title}</p>
+    <p className="text-xs text-slate-400 dark:text-slate-500 mt-1">Coming in issue {issueRef}</p>
+  </div>
+);
+
+export default AdminDashboard;

--- a/components/admin/AdminLoginScreen.tsx
+++ b/components/admin/AdminLoginScreen.tsx
@@ -30,6 +30,9 @@ const AdminLoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
       });
 
       if (error) throw error;
+      // Mark that an admin OTP is in-flight so index.tsx can intercept the
+      // Supabase redirect even if it lands on '/' instead of '/admin'
+      try { localStorage.setItem('admin_otp_pending', '1'); } catch {}
       setStage('sent');
     } catch (err: any) {
       setError(err?.message ?? 'Failed to send magic link');
@@ -38,6 +41,7 @@ const AdminLoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
   };
 
   const handleResend = () => {
+    try { localStorage.removeItem('admin_otp_pending'); } catch {}
     setStage('input');
     setError('');
   };

--- a/components/admin/AdminLoginScreen.tsx
+++ b/components/admin/AdminLoginScreen.tsx
@@ -1,33 +1,70 @@
 import React, { useState } from 'react';
-import { Loader2, ShieldCheck, AlertCircle, Mail, CheckCircle, ExternalLink } from 'lucide-react';
+import { Loader2, ShieldCheck, AlertCircle, Mail, CheckCircle, ExternalLink, Lock, Eye, EyeOff } from 'lucide-react';
 
 interface Props {
   onLoginSuccess: (token: string, email: string) => void;
 }
 
-type Stage = 'input' | 'sending' | 'sent' | 'error';
+type Mode  = 'password' | 'magic_link';
+type Stage = 'input' | 'submitting' | 'sent' | 'error';
 
 const AdminLoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
-  const [email, setEmail]     = useState('');
-  const [stage, setStage]     = useState<Stage>('input');
-  const [errorMsg, setError]  = useState('');
-  const [devLink, setDevLink] = useState<string | null>(null);   // dev mode only
+  const [mode, setMode]         = useState<Mode>('password');
+  const [email, setEmail]       = useState('');
+  const [password, setPassword] = useState('');
+  const [showPw, setShowPw]     = useState(false);
+  const [stage, setStage]       = useState<Stage>('input');
+  const [errorMsg, setError]    = useState('');
+  const [devLink, setDevLink]   = useState<string | null>(null);
 
+  // ── Password login (bootstrap: table must be empty) ──────────────────────
+  const handlePasswordLogin = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setStage('submitting');
+
+    try {
+      const res = await fetch('/.netlify/functions/admin', {
+        method:  'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body:    JSON.stringify({ action: 'admin_login', email: email.trim(), password }),
+      });
+
+      const json = await res.json();
+
+      if (!res.ok) {
+        // Server returns 403 when the table already has admins
+        if (res.status === 403) {
+          setError(json.error ?? 'Admin accounts already exist.');
+          // Auto-switch to magic link so the user knows what to do next
+          setMode('magic_link');
+          setStage('error');
+        } else {
+          throw new Error(json.error ?? 'Login failed');
+        }
+        return;
+      }
+
+      // Success — exchange token with parent
+      onLoginSuccess(json.token, json.email);
+    } catch (err: any) {
+      setError(err?.message ?? 'Login failed');
+      setStage('error');
+    }
+  };
+
+  // ── Magic-link request (normal mode: table has rows) ─────────────────────
   const handleSendLink = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
     setDevLink(null);
-    setStage('sending');
+    setStage('submitting');
 
     try {
-      // Request the magic link through our Netlify function — NOT directly
-      // through Supabase.  The server uses the admin SDK to generate the link
-      // with redirectTo: /admin (bypasses Supabase's redirect-URL allowlist)
-      // and sends a custom admin-branded email via Resend.
       const res = await fetch('/.netlify/functions/admin', {
-        method: 'POST',
+        method:  'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ action: 'request_admin_magic_link', email: email.trim() }),
+        body:    JSON.stringify({ action: 'request_admin_magic_link', email: email.trim() }),
       });
 
       const json = await res.json();
@@ -43,39 +80,176 @@ const AdminLoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
     }
   };
 
-  const handleResend = () => {
-    setStage('input');
-    setError('');
-    setDevLink(null);
-  };
+  const handleReset = () => { setStage('input'); setError(''); setDevLink(null); };
+
+  const switchMode = (m: Mode) => { setMode(m); handleReset(); };
+
+  // ── Shared "sent" confirmation (magic link) ───────────────────────────────
+  if (stage === 'sent') {
+    return (
+      <div className="min-h-screen flex items-center justify-center bg-slate-950 px-4">
+        <div className="w-full max-w-sm">
+          <Header />
+          <div className="bg-slate-900 border border-slate-800 rounded-2xl p-6 shadow-xl space-y-4">
+            <div className="text-center space-y-3 py-1">
+              <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-esg-900/50 border border-esg-700">
+                <CheckCircle className="w-6 h-6 text-esg-400" />
+              </div>
+              <div>
+                <p className="text-white font-semibold">Check your inbox</p>
+                <p className="text-sm text-slate-400 mt-1.5 leading-relaxed">
+                  A sign-in link was sent to{' '}
+                  <span className="text-white font-medium">{email}</span>.
+                  Click the link to open the admin portal.
+                </p>
+              </div>
+            </div>
+
+            {devLink && (
+              <div className="bg-amber-950/40 border border-amber-700/50 rounded-lg p-3 space-y-2">
+                <p className="text-xs font-semibold text-amber-400 uppercase tracking-wide">
+                  ⚠️ Dev mode — no RESEND_API_KEY set
+                </p>
+                <p className="text-xs text-amber-300/70">
+                  No email was sent. Use the link below to sign in:
+                </p>
+                <a
+                  href={devLink}
+                  className="flex items-center gap-1.5 text-xs text-amber-300 hover:text-amber-200 underline break-all transition-colors"
+                >
+                  <ExternalLink className="w-3 h-3 flex-shrink-0" />
+                  {devLink}
+                </a>
+              </div>
+            )}
+
+            <p className="text-center text-xs text-slate-500">
+              Didn't receive it?{' '}
+              <button onClick={handleReset} className="text-slate-400 hover:text-white underline transition-colors">
+                Resend
+              </button>
+            </p>
+          </div>
+          <Footer />
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-slate-950 px-4">
       <div className="w-full max-w-sm">
-        {/* Logo / title */}
-        <div className="text-center mb-8">
-          <div className="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-esg-700 mb-4">
-            <ShieldCheck className="w-7 h-7 text-white" />
+        <Header />
+
+        <div className="bg-slate-900 border border-slate-800 rounded-2xl p-6 shadow-xl space-y-5">
+
+          {/* ── Mode tabs ── */}
+          <div className="flex rounded-lg overflow-hidden border border-slate-700 text-xs font-medium">
+            <button
+              type="button"
+              onClick={() => switchMode('password')}
+              className={`flex-1 py-2 transition-colors ${
+                mode === 'password'
+                  ? 'bg-esg-700 text-white'
+                  : 'bg-slate-800 text-slate-400 hover:text-slate-200'
+              }`}
+            >
+              Password
+            </button>
+            <button
+              type="button"
+              onClick={() => switchMode('magic_link')}
+              className={`flex-1 py-2 transition-colors ${
+                mode === 'magic_link'
+                  ? 'bg-esg-700 text-white'
+                  : 'bg-slate-800 text-slate-400 hover:text-slate-200'
+              }`}
+            >
+              Magic Link
+            </button>
           </div>
-          <h1 className="text-2xl font-bold text-white">Admin Portal</h1>
-          <p className="text-slate-400 text-sm mt-1">Aeternum Ally — Platform Administration</p>
-        </div>
 
-        <div className="bg-slate-900 border border-slate-800 rounded-2xl p-6 shadow-xl space-y-4">
+          {/* ── Error banner ── */}
+          {stage === 'error' && errorMsg && (
+            <div className="flex items-start gap-2.5 text-sm text-red-400 bg-red-950/40 border border-red-800/50 rounded-lg px-3 py-2.5">
+              <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+              <span>{errorMsg}</span>
+            </div>
+          )}
 
-          {/* ── Input / sending / error ── */}
-          {stage !== 'sent' && (
-            <form onSubmit={handleSendLink} className="space-y-4">
-              <p className="text-sm text-slate-400 text-center">
-                Enter your admin email — we'll send a secure one-time sign-in link.
+          {/* ── Password form ── */}
+          {mode === 'password' && (
+            <form onSubmit={handlePasswordLogin} className="space-y-4">
+              <p className="text-xs text-slate-500 text-center leading-relaxed">
+                Bootstrap only — available when no admin accounts exist yet.
+                Credentials are stored in environment variables.
               </p>
 
-              {stage === 'error' && errorMsg && (
-                <div className="flex items-start gap-2.5 text-sm text-red-400 bg-red-950/40 border border-red-800/50 rounded-lg px-3 py-2.5">
-                  <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
-                  {errorMsg}
+              {/* Email */}
+              <div>
+                <label className="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide">
+                  Admin Email
+                </label>
+                <div className="relative">
+                  <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500 pointer-events-none" />
+                  <input
+                    type="email"
+                    value={email}
+                    onChange={e => setEmail(e.target.value)}
+                    required
+                    autoFocus
+                    placeholder="admin@example.com"
+                    className="w-full pl-9 pr-3 py-2.5 rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-500 focus:ring-2 focus:ring-esg-500 focus:border-transparent outline-none text-sm transition-colors"
+                  />
                 </div>
-              )}
+              </div>
+
+              {/* Password */}
+              <div>
+                <label className="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide">
+                  Password
+                </label>
+                <div className="relative">
+                  <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500 pointer-events-none" />
+                  <input
+                    type={showPw ? 'text' : 'password'}
+                    value={password}
+                    onChange={e => setPassword(e.target.value)}
+                    required
+                    placeholder="••••••••"
+                    className="w-full pl-9 pr-10 py-2.5 rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-500 focus:ring-2 focus:ring-esg-500 focus:border-transparent outline-none text-sm transition-colors"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPw(v => !v)}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-300 transition-colors"
+                    tabIndex={-1}
+                  >
+                    {showPw ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+                  </button>
+                </div>
+              </div>
+
+              <button
+                type="submit"
+                disabled={stage === 'submitting' || !email || !password}
+                className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-esg-600 hover:bg-esg-700 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors text-sm"
+              >
+                {stage === 'submitting' ? (
+                  <><Loader2 className="w-4 h-4 animate-spin" /> Signing in…</>
+                ) : (
+                  <><ShieldCheck className="w-4 h-4" /> Sign in</>
+                )}
+              </button>
+            </form>
+          )}
+
+          {/* ── Magic link form ── */}
+          {mode === 'magic_link' && (
+            <form onSubmit={handleSendLink} className="space-y-4">
+              <p className="text-xs text-slate-500 text-center leading-relaxed">
+                Enter your admin email — we'll send a secure one-time sign-in link.
+              </p>
 
               <div>
                 <label className="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide">
@@ -97,10 +271,10 @@ const AdminLoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
 
               <button
                 type="submit"
-                disabled={stage === 'sending' || !email}
+                disabled={stage === 'submitting' || !email}
                 className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-esg-600 hover:bg-esg-700 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors text-sm"
               >
-                {stage === 'sending' ? (
+                {stage === 'submitting' ? (
                   <><Loader2 className="w-4 h-4 animate-spin" /> Sending link…</>
                 ) : (
                   <><Mail className="w-4 h-4" /> Send Admin Sign-in Link</>
@@ -108,63 +282,31 @@ const AdminLoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
               </button>
             </form>
           )}
-
-          {/* ── Sent confirmation ── */}
-          {stage === 'sent' && (
-            <div className="space-y-4">
-              <div className="text-center space-y-3 py-1">
-                <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-esg-900/50 border border-esg-700">
-                  <CheckCircle className="w-6 h-6 text-esg-400" />
-                </div>
-                <div>
-                  <p className="text-white font-semibold">Check your inbox</p>
-                  <p className="text-sm text-slate-400 mt-1.5 leading-relaxed">
-                    A sign-in link was sent to{' '}
-                    <span className="text-white font-medium">{email}</span>.
-                    Click the link in the email to open the admin portal.
-                  </p>
-                </div>
-              </div>
-
-              {/* Dev mode: show the link directly when Resend is not configured */}
-              {devLink && (
-                <div className="bg-amber-950/40 border border-amber-700/50 rounded-lg p-3 space-y-2">
-                  <p className="text-xs font-semibold text-amber-400 uppercase tracking-wide">
-                    ⚠️ Dev mode — no RESEND_API_KEY set
-                  </p>
-                  <p className="text-xs text-amber-300/70">
-                    No email was sent. Use the link below to sign in:
-                  </p>
-                  <a
-                    href={devLink}
-                    className="flex items-center gap-1.5 text-xs text-amber-300 hover:text-amber-200 underline break-all transition-colors"
-                  >
-                    <ExternalLink className="w-3 h-3 flex-shrink-0" />
-                    {devLink}
-                  </a>
-                </div>
-              )}
-
-              <p className="text-center text-xs text-slate-500">
-                Didn't receive it?{' '}
-                <button
-                  onClick={handleResend}
-                  className="text-slate-400 hover:text-white underline transition-colors"
-                >
-                  Resend
-                </button>
-              </p>
-            </div>
-          )}
         </div>
 
-        <p className="text-center text-xs text-slate-600 mt-6">
-          Platform Admin access only. Tenant app is at{' '}
-          <a href="/" className="text-slate-400 hover:text-white underline">/</a>
-        </p>
+        <Footer />
       </div>
     </div>
   );
 };
+
+// ── Small shared sub-components ──────────────────────────────────────────────
+
+const Header: React.FC = () => (
+  <div className="text-center mb-8">
+    <div className="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-esg-700 mb-4">
+      <ShieldCheck className="w-7 h-7 text-white" />
+    </div>
+    <h1 className="text-2xl font-bold text-white">Admin Portal</h1>
+    <p className="text-slate-400 text-sm mt-1">Aeternum Ally — Platform Administration</p>
+  </div>
+);
+
+const Footer: React.FC = () => (
+  <p className="text-center text-xs text-slate-600 mt-6">
+    Platform Admin access only. Tenant app is at{' '}
+    <a href="/" className="text-slate-400 hover:text-white underline">/</a>
+  </p>
+);
 
 export default AdminLoginScreen;

--- a/components/admin/AdminLoginScreen.tsx
+++ b/components/admin/AdminLoginScreen.tsx
@@ -1,38 +1,41 @@
 import React, { useState } from 'react';
-import { Loader2, ShieldCheck, AlertCircle, Mail, CheckCircle } from 'lucide-react';
-import { supabase } from '../../lib/supabaseClient';
+import { Loader2, ShieldCheck, AlertCircle, Mail, CheckCircle, ExternalLink } from 'lucide-react';
 
 interface Props {
   onLoginSuccess: (token: string, email: string) => void;
 }
 
-type Stage = 'input' | 'verifying' | 'sent' | 'error';
+type Stage = 'input' | 'sending' | 'sent' | 'error';
 
 const AdminLoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
-  const [email, setEmail]   = useState('');
-  const [stage, setStage]   = useState<Stage>('input');
-  const [errorMsg, setError] = useState('');
+  const [email, setEmail]     = useState('');
+  const [stage, setStage]     = useState<Stage>('input');
+  const [errorMsg, setError]  = useState('');
+  const [devLink, setDevLink] = useState<string | null>(null);   // dev mode only
 
   const handleSendLink = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
-    setStage('verifying');
+    setDevLink(null);
+    setStage('sending');
 
     try {
-      const { error } = await supabase.auth.signInWithOtp({
-        email: email.trim(),
-        options: {
-          // Redirect back to the admin portal after clicking the link
-          emailRedirectTo: `${window.location.origin}/admin`,
-          // Admin account must already exist in Supabase Auth
-          shouldCreateUser: false,
-        },
+      // Request the magic link through our Netlify function — NOT directly
+      // through Supabase.  The server uses the admin SDK to generate the link
+      // with redirectTo: /admin (bypasses Supabase's redirect-URL allowlist)
+      // and sends a custom admin-branded email via Resend.
+      const res = await fetch('/.netlify/functions/admin', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'request_admin_magic_link', email: email.trim() }),
       });
 
-      if (error) throw error;
-      // Mark that an admin OTP is in-flight so index.tsx can intercept the
-      // Supabase redirect even if it lands on '/' instead of '/admin'
-      try { localStorage.setItem('admin_otp_pending', '1'); } catch {}
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error ?? 'Failed to send link');
+
+      // Dev mode: server returns the link directly when RESEND_API_KEY is not set
+      if (json.dev_link) setDevLink(json.dev_link);
+
       setStage('sent');
     } catch (err: any) {
       setError(err?.message ?? 'Failed to send magic link');
@@ -41,9 +44,9 @@ const AdminLoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
   };
 
   const handleResend = () => {
-    try { localStorage.removeItem('admin_otp_pending'); } catch {}
     setStage('input');
     setError('');
+    setDevLink(null);
   };
 
   return (
@@ -58,13 +61,13 @@ const AdminLoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
           <p className="text-slate-400 text-sm mt-1">Aeternum Ally — Platform Administration</p>
         </div>
 
-        <div className="bg-slate-900 border border-slate-800 rounded-2xl p-6 shadow-xl">
+        <div className="bg-slate-900 border border-slate-800 rounded-2xl p-6 shadow-xl space-y-4">
 
-          {/* Stage: input / verifying / error */}
+          {/* ── Input / sending / error ── */}
           {stage !== 'sent' && (
             <form onSubmit={handleSendLink} className="space-y-4">
               <p className="text-sm text-slate-400 text-center">
-                Enter your admin email — we'll send a one-time sign-in link.
+                Enter your admin email — we'll send a secure one-time sign-in link.
               </p>
 
               {stage === 'error' && errorMsg && (
@@ -94,33 +97,55 @@ const AdminLoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
 
               <button
                 type="submit"
-                disabled={stage === 'verifying' || !email}
+                disabled={stage === 'sending' || !email}
                 className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-esg-600 hover:bg-esg-700 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors text-sm"
               >
-                {stage === 'verifying' ? (
+                {stage === 'sending' ? (
                   <><Loader2 className="w-4 h-4 animate-spin" /> Sending link…</>
                 ) : (
-                  <><Mail className="w-4 h-4" /> Send Magic Link</>
+                  <><Mail className="w-4 h-4" /> Send Admin Sign-in Link</>
                 )}
               </button>
             </form>
           )}
 
-          {/* Stage: sent */}
+          {/* ── Sent confirmation ── */}
           {stage === 'sent' && (
-            <div className="text-center space-y-4 py-2">
-              <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-esg-900/50 border border-esg-700">
-                <CheckCircle className="w-6 h-6 text-esg-400" />
+            <div className="space-y-4">
+              <div className="text-center space-y-3 py-1">
+                <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-esg-900/50 border border-esg-700">
+                  <CheckCircle className="w-6 h-6 text-esg-400" />
+                </div>
+                <div>
+                  <p className="text-white font-semibold">Check your inbox</p>
+                  <p className="text-sm text-slate-400 mt-1.5 leading-relaxed">
+                    A sign-in link was sent to{' '}
+                    <span className="text-white font-medium">{email}</span>.
+                    Click the link in the email to open the admin portal.
+                  </p>
+                </div>
               </div>
-              <div>
-                <p className="text-white font-semibold">Check your inbox</p>
-                <p className="text-sm text-slate-400 mt-1.5 leading-relaxed">
-                  A sign-in link was sent to{' '}
-                  <span className="text-white font-medium">{email}</span>.
-                  Click the link in the email — it will bring you straight back here.
-                </p>
-              </div>
-              <p className="text-xs text-slate-500 pt-1">
+
+              {/* Dev mode: show the link directly when Resend is not configured */}
+              {devLink && (
+                <div className="bg-amber-950/40 border border-amber-700/50 rounded-lg p-3 space-y-2">
+                  <p className="text-xs font-semibold text-amber-400 uppercase tracking-wide">
+                    ⚠️ Dev mode — no RESEND_API_KEY set
+                  </p>
+                  <p className="text-xs text-amber-300/70">
+                    No email was sent. Use the link below to sign in:
+                  </p>
+                  <a
+                    href={devLink}
+                    className="flex items-center gap-1.5 text-xs text-amber-300 hover:text-amber-200 underline break-all transition-colors"
+                  >
+                    <ExternalLink className="w-3 h-3 flex-shrink-0" />
+                    {devLink}
+                  </a>
+                </div>
+              )}
+
+              <p className="text-center text-xs text-slate-500">
                 Didn't receive it?{' '}
                 <button
                   onClick={handleResend}

--- a/components/admin/AdminLoginScreen.tsx
+++ b/components/admin/AdminLoginScreen.tsx
@@ -1,58 +1,45 @@
 import React, { useState } from 'react';
-import { Loader2, ShieldCheck, AlertCircle, LogIn } from 'lucide-react';
+import { Loader2, ShieldCheck, AlertCircle, Mail, CheckCircle } from 'lucide-react';
 import { supabase } from '../../lib/supabaseClient';
 
 interface Props {
   onLoginSuccess: (token: string, email: string) => void;
 }
 
-const AdminLoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
-  const [email, setEmail]       = useState('');
-  const [password, setPassword] = useState('');
-  const [loading, setLoading]   = useState(false);
-  const [error, setError]       = useState('');
+type Stage = 'input' | 'verifying' | 'sent' | 'error';
 
-  const handleSubmit = async (e: React.FormEvent) => {
+const AdminLoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
+  const [email, setEmail]   = useState('');
+  const [stage, setStage]   = useState<Stage>('input');
+  const [errorMsg, setError] = useState('');
+
+  const handleSendLink = async (e: React.FormEvent) => {
     e.preventDefault();
     setError('');
-    setLoading(true);
+    setStage('verifying');
 
     try {
-      // Step 1: sign in with Supabase Auth
-      const { data: authData, error: authError } = await supabase.auth.signInWithPassword({
+      const { error } = await supabase.auth.signInWithOtp({
         email: email.trim(),
-        password,
-      });
-
-      if (authError || !authData.session) {
-        throw new Error(authError?.message ?? 'Sign-in failed');
-      }
-
-      const token = authData.session.access_token;
-
-      // Step 2: verify admin status (server-side check + first-admin seed)
-      const res = await fetch('/.netlify/functions/admin', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${token}`,
+        options: {
+          // Redirect back to the admin portal after clicking the link
+          emailRedirectTo: `${window.location.origin}/admin`,
+          // Admin account must already exist in Supabase Auth
+          shouldCreateUser: false,
         },
-        body: JSON.stringify({ action: 'verify_admin' }),
       });
 
-      const json = await res.json();
-      if (!res.ok) {
-        // Sign out from Supabase so the session isn't left dangling
-        await supabase.auth.signOut();
-        throw new Error(json.error ?? 'Not authorized as platform admin');
-      }
-
-      onLoginSuccess(token, json.email);
+      if (error) throw error;
+      setStage('sent');
     } catch (err: any) {
-      setError(err?.message ?? 'Login failed');
-    } finally {
-      setLoading(false);
+      setError(err?.message ?? 'Failed to send magic link');
+      setStage('error');
     }
+  };
+
+  const handleResend = () => {
+    setStage('input');
+    setError('');
   };
 
   return (
@@ -67,61 +54,84 @@ const AdminLoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
           <p className="text-slate-400 text-sm mt-1">Aeternum Ally — Platform Administration</p>
         </div>
 
-        <form
-          onSubmit={handleSubmit}
-          className="bg-slate-900 border border-slate-800 rounded-2xl p-6 space-y-4 shadow-xl"
-        >
-          {error && (
-            <div className="flex items-start gap-2.5 text-sm text-red-400 bg-red-950/40 border border-red-800/50 rounded-lg px-3 py-2.5">
-              <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
-              {error}
-            </div>
+        <div className="bg-slate-900 border border-slate-800 rounded-2xl p-6 shadow-xl">
+
+          {/* Stage: input / verifying / error */}
+          {stage !== 'sent' && (
+            <form onSubmit={handleSendLink} className="space-y-4">
+              <p className="text-sm text-slate-400 text-center">
+                Enter your admin email — we'll send a one-time sign-in link.
+              </p>
+
+              {stage === 'error' && errorMsg && (
+                <div className="flex items-start gap-2.5 text-sm text-red-400 bg-red-950/40 border border-red-800/50 rounded-lg px-3 py-2.5">
+                  <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+                  {errorMsg}
+                </div>
+              )}
+
+              <div>
+                <label className="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide">
+                  Admin Email
+                </label>
+                <div className="relative">
+                  <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500 pointer-events-none" />
+                  <input
+                    type="email"
+                    value={email}
+                    onChange={e => setEmail(e.target.value)}
+                    required
+                    autoFocus
+                    placeholder="admin@example.com"
+                    className="w-full pl-9 pr-3 py-2.5 rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-500 focus:ring-2 focus:ring-esg-500 focus:border-transparent outline-none text-sm transition-colors"
+                  />
+                </div>
+              </div>
+
+              <button
+                type="submit"
+                disabled={stage === 'verifying' || !email}
+                className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-esg-600 hover:bg-esg-700 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors text-sm"
+              >
+                {stage === 'verifying' ? (
+                  <><Loader2 className="w-4 h-4 animate-spin" /> Sending link…</>
+                ) : (
+                  <><Mail className="w-4 h-4" /> Send Magic Link</>
+                )}
+              </button>
+            </form>
           )}
 
-          <div>
-            <label className="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide">
-              Email
-            </label>
-            <input
-              type="email"
-              value={email}
-              onChange={e => setEmail(e.target.value)}
-              required
-              autoFocus
-              placeholder="admin@example.com"
-              className="w-full px-3 py-2.5 rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-500 focus:ring-2 focus:ring-esg-500 focus:border-transparent outline-none text-sm transition-colors"
-            />
-          </div>
-
-          <div>
-            <label className="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide">
-              Password
-            </label>
-            <input
-              type="password"
-              value={password}
-              onChange={e => setPassword(e.target.value)}
-              required
-              placeholder="••••••••"
-              className="w-full px-3 py-2.5 rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-500 focus:ring-2 focus:ring-esg-500 focus:border-transparent outline-none text-sm transition-colors"
-            />
-          </div>
-
-          <button
-            type="submit"
-            disabled={loading || !email || !password}
-            className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-esg-600 hover:bg-esg-700 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors text-sm mt-2"
-          >
-            {loading ? (
-              <><Loader2 className="w-4 h-4 animate-spin" /> Verifying…</>
-            ) : (
-              <><LogIn className="w-4 h-4" /> Sign in to Admin Portal</>
-            )}
-          </button>
-        </form>
+          {/* Stage: sent */}
+          {stage === 'sent' && (
+            <div className="text-center space-y-4 py-2">
+              <div className="inline-flex items-center justify-center w-12 h-12 rounded-full bg-esg-900/50 border border-esg-700">
+                <CheckCircle className="w-6 h-6 text-esg-400" />
+              </div>
+              <div>
+                <p className="text-white font-semibold">Check your inbox</p>
+                <p className="text-sm text-slate-400 mt-1.5 leading-relaxed">
+                  A sign-in link was sent to{' '}
+                  <span className="text-white font-medium">{email}</span>.
+                  Click the link in the email — it will bring you straight back here.
+                </p>
+              </div>
+              <p className="text-xs text-slate-500 pt-1">
+                Didn't receive it?{' '}
+                <button
+                  onClick={handleResend}
+                  className="text-slate-400 hover:text-white underline transition-colors"
+                >
+                  Resend
+                </button>
+              </p>
+            </div>
+          )}
+        </div>
 
         <p className="text-center text-xs text-slate-600 mt-6">
-          Platform Admin access only. Tenant app is at <a href="/" className="text-slate-400 hover:text-white underline">/</a>
+          Platform Admin access only. Tenant app is at{' '}
+          <a href="/" className="text-slate-400 hover:text-white underline">/</a>
         </p>
       </div>
     </div>

--- a/components/admin/AdminLoginScreen.tsx
+++ b/components/admin/AdminLoginScreen.tsx
@@ -1,0 +1,131 @@
+import React, { useState } from 'react';
+import { Loader2, ShieldCheck, AlertCircle, LogIn } from 'lucide-react';
+import { supabase } from '../../lib/supabaseClient';
+
+interface Props {
+  onLoginSuccess: (token: string, email: string) => void;
+}
+
+const AdminLoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
+  const [email, setEmail]       = useState('');
+  const [password, setPassword] = useState('');
+  const [loading, setLoading]   = useState(false);
+  const [error, setError]       = useState('');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    setLoading(true);
+
+    try {
+      // Step 1: sign in with Supabase Auth
+      const { data: authData, error: authError } = await supabase.auth.signInWithPassword({
+        email: email.trim(),
+        password,
+      });
+
+      if (authError || !authData.session) {
+        throw new Error(authError?.message ?? 'Sign-in failed');
+      }
+
+      const token = authData.session.access_token;
+
+      // Step 2: verify admin status (server-side check + first-admin seed)
+      const res = await fetch('/.netlify/functions/admin', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${token}`,
+        },
+        body: JSON.stringify({ action: 'verify_admin' }),
+      });
+
+      const json = await res.json();
+      if (!res.ok) {
+        // Sign out from Supabase so the session isn't left dangling
+        await supabase.auth.signOut();
+        throw new Error(json.error ?? 'Not authorized as platform admin');
+      }
+
+      onLoginSuccess(token, json.email);
+    } catch (err: any) {
+      setError(err?.message ?? 'Login failed');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-slate-950 px-4">
+      <div className="w-full max-w-sm">
+        {/* Logo / title */}
+        <div className="text-center mb-8">
+          <div className="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-esg-700 mb-4">
+            <ShieldCheck className="w-7 h-7 text-white" />
+          </div>
+          <h1 className="text-2xl font-bold text-white">Admin Portal</h1>
+          <p className="text-slate-400 text-sm mt-1">Aeternum Ally — Platform Administration</p>
+        </div>
+
+        <form
+          onSubmit={handleSubmit}
+          className="bg-slate-900 border border-slate-800 rounded-2xl p-6 space-y-4 shadow-xl"
+        >
+          {error && (
+            <div className="flex items-start gap-2.5 text-sm text-red-400 bg-red-950/40 border border-red-800/50 rounded-lg px-3 py-2.5">
+              <AlertCircle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+              {error}
+            </div>
+          )}
+
+          <div>
+            <label className="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide">
+              Email
+            </label>
+            <input
+              type="email"
+              value={email}
+              onChange={e => setEmail(e.target.value)}
+              required
+              autoFocus
+              placeholder="admin@example.com"
+              className="w-full px-3 py-2.5 rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-500 focus:ring-2 focus:ring-esg-500 focus:border-transparent outline-none text-sm transition-colors"
+            />
+          </div>
+
+          <div>
+            <label className="block text-xs font-medium text-slate-400 mb-1.5 uppercase tracking-wide">
+              Password
+            </label>
+            <input
+              type="password"
+              value={password}
+              onChange={e => setPassword(e.target.value)}
+              required
+              placeholder="••••••••"
+              className="w-full px-3 py-2.5 rounded-lg bg-slate-800 border border-slate-700 text-white placeholder-slate-500 focus:ring-2 focus:ring-esg-500 focus:border-transparent outline-none text-sm transition-colors"
+            />
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading || !email || !password}
+            className="w-full flex items-center justify-center gap-2 px-4 py-2.5 bg-esg-600 hover:bg-esg-700 disabled:opacity-50 disabled:cursor-not-allowed text-white font-medium rounded-lg transition-colors text-sm mt-2"
+          >
+            {loading ? (
+              <><Loader2 className="w-4 h-4 animate-spin" /> Verifying…</>
+            ) : (
+              <><LogIn className="w-4 h-4" /> Sign in to Admin Portal</>
+            )}
+          </button>
+        </form>
+
+        <p className="text-center text-xs text-slate-600 mt-6">
+          Platform Admin access only. Tenant app is at <a href="/" className="text-slate-400 hover:text-white underline">/</a>
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default AdminLoginScreen;

--- a/components/admin/AdminShell.tsx
+++ b/components/admin/AdminShell.tsx
@@ -1,0 +1,165 @@
+import React, { useState } from 'react';
+import {
+  ShieldCheck, LayoutDashboard, Building2, Zap, Users,
+  LogOut, ChevronRight, Menu, X,
+} from 'lucide-react';
+import AdminDashboard from './AdminDashboard';
+
+type AdminView = 'dashboard' | 'companies' | 'ai_usage' | 'admins';
+
+interface Props {
+  adminToken: string;
+  adminEmail: string;
+  onSignOut: () => void;
+}
+
+const AdminShell: React.FC<Props> = ({ adminToken, adminEmail, onSignOut }) => {
+  const [view, setView]             = useState<AdminView>('dashboard');
+  const [mobileSidebarOpen, setMob] = useState(false);
+
+  const NAV: { id: AdminView; label: string; icon: React.ReactNode; badge?: string }[] = [
+    { id: 'dashboard',  label: 'Dashboard',       icon: <LayoutDashboard className="w-5 h-5" /> },
+    { id: 'companies',  label: 'Companies',        icon: <Building2 className="w-5 h-5" />,  badge: 'soon' },
+    { id: 'ai_usage',   label: 'AI Usage',         icon: <Zap className="w-5 h-5" />,         badge: 'soon' },
+    { id: 'admins',     label: 'Admin Users',      icon: <Users className="w-5 h-5" />,       badge: 'soon' },
+  ];
+
+  const VIEW_LABELS: Record<AdminView, string> = {
+    dashboard: 'Platform Overview',
+    companies: 'Company Management',
+    ai_usage:  'AI Usage',
+    admins:    'Admin Users',
+  };
+
+  const SidebarContent = () => (
+    <>
+      {/* Logo */}
+      <div className="p-5 border-b border-slate-800 flex items-center justify-between flex-shrink-0">
+        <div className="flex items-center gap-3">
+          <div className="w-8 h-8 rounded-lg bg-esg-700 flex items-center justify-center">
+            <ShieldCheck className="w-4 h-4 text-white" />
+          </div>
+          <div>
+            <p className="text-white font-bold text-sm leading-tight">Aeternum Ally</p>
+            <p className="text-slate-500 text-xs leading-tight">Admin Portal</p>
+          </div>
+        </div>
+        <button onClick={() => setMob(false)} className="lg:hidden text-slate-400 hover:text-white">
+          <X className="w-5 h-5" />
+        </button>
+      </div>
+
+      {/* Nav */}
+      <nav className="flex-1 p-3 space-y-1 overflow-y-auto">
+        {NAV.map(item => (
+          <button
+            key={item.id}
+            onClick={() => { setView(item.id); setMob(false); }}
+            className={`w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-sm font-medium transition-all ${
+              view === item.id
+                ? 'bg-esg-600 text-white shadow-md shadow-esg-600/20'
+                : 'text-slate-400 hover:bg-slate-800 hover:text-white'
+            }`}
+          >
+            <span>{item.icon}</span>
+            <span className="flex-1 text-left">{item.label}</span>
+            {item.badge && (
+              <span className="text-[10px] font-semibold bg-slate-700 text-slate-400 px-1.5 py-0.5 rounded-full">
+                {item.badge}
+              </span>
+            )}
+          </button>
+        ))}
+      </nav>
+
+      {/* User + sign out */}
+      <div className="p-3 border-t border-slate-800 flex-shrink-0">
+        <div className="flex items-center gap-3 px-2 py-2">
+          <div className="w-7 h-7 rounded-full bg-esg-700 flex items-center justify-center text-white text-xs font-bold flex-shrink-0">
+            {adminEmail.charAt(0).toUpperCase()}
+          </div>
+          <div className="flex-1 min-w-0">
+            <p className="text-xs font-medium text-white truncate">{adminEmail}</p>
+            <p className="text-xs text-slate-500">Platform Admin</p>
+          </div>
+          <button
+            onClick={onSignOut}
+            title="Sign out"
+            className="p-1.5 text-slate-400 hover:text-white hover:bg-slate-800 rounded-lg transition-colors"
+          >
+            <LogOut className="w-4 h-4" />
+          </button>
+        </div>
+      </div>
+    </>
+  );
+
+  return (
+    <div className="min-h-screen flex bg-slate-100 dark:bg-slate-900">
+      {/* Mobile overlay */}
+      {mobileSidebarOpen && (
+        <div
+          className="fixed inset-0 bg-black/50 z-40 lg:hidden"
+          onClick={() => setMob(false)}
+        />
+      )}
+
+      {/* Sidebar */}
+      <aside className={`
+        fixed top-0 bottom-0 left-0 z-50 w-60 bg-slate-900 text-slate-300 flex flex-col border-r border-slate-800
+        transition-transform duration-300
+        ${mobileSidebarOpen ? 'translate-x-0' : '-translate-x-full'}
+        lg:translate-x-0 lg:static lg:h-screen
+      `}>
+        <SidebarContent />
+      </aside>
+
+      {/* Main */}
+      <main className="flex-1 flex flex-col min-w-0 lg:ml-0">
+        {/* Header */}
+        <header className="bg-white dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700 h-14 flex items-center justify-between px-4 md:px-6 sticky top-0 z-10">
+          <div className="flex items-center gap-3">
+            <button
+              onClick={() => setMob(true)}
+              className="lg:hidden p-1.5 text-slate-500 hover:text-slate-800 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-700 rounded-lg"
+            >
+              <Menu className="w-5 h-5" />
+            </button>
+            <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+              <span className="font-semibold text-slate-400 dark:text-slate-500 hidden sm:inline">Admin</span>
+              <ChevronRight className="w-3.5 h-3.5 hidden sm:block" />
+              <span className="font-medium text-slate-800 dark:text-white">{VIEW_LABELS[view]}</span>
+            </div>
+          </div>
+          <a
+            href="/"
+            className="text-xs text-slate-400 hover:text-slate-700 dark:hover:text-white transition-colors hidden sm:inline"
+          >
+            ← Back to Tenant App
+          </a>
+        </header>
+
+        {/* Content */}
+        <div className="flex-1 p-4 md:p-8 overflow-auto">
+          {view === 'dashboard' && <AdminDashboard adminToken={adminToken} />}
+
+          {view !== 'dashboard' && (
+            <div className="flex flex-col items-center justify-center min-h-[400px] text-center">
+              <div className="w-16 h-16 rounded-2xl bg-slate-200 dark:bg-slate-800 flex items-center justify-center mb-4">
+                {NAV.find(n => n.id === view)?.icon}
+              </div>
+              <h2 className="text-lg font-bold text-slate-800 dark:text-white mb-1">
+                {VIEW_LABELS[view]}
+              </h2>
+              <p className="text-sm text-slate-500 dark:text-slate-400">
+                Coming soon — tracked in subsequent issues.
+              </p>
+            </div>
+          )}
+        </div>
+      </main>
+    </div>
+  );
+};
+
+export default AdminShell;

--- a/index.tsx
+++ b/index.tsx
@@ -38,9 +38,26 @@ if (!supabaseAnonKey) missing.push('VITE_SUPABASE_ANON_KEY');
 if (missing.length > 0) {
   renderConfigError(missing);
 } else {
-  // Route /admin to the Platform Admin portal; everything else → tenant App.
-  const isAdminRoute = window.location.pathname.startsWith('/admin');
-  const appModule = isAdminRoute ? import('./AdminApp') : import('./App');
+  // ── Admin magic-link intercept ──────────────────────────────────────────
+  // When an admin requests a magic link, AdminLoginScreen sets the flag
+  // 'admin_otp_pending' in localStorage.  Supabase may redirect back to the
+  // Site URL (root '/') rather than '/admin' if '/admin' is not in its
+  // allowed-redirect-URLs list.  We catch that here: if the URL hash contains
+  // an access_token AND the pending flag is set, redirect to /admin so
+  // AdminApp can pick up the session — before any React tree is rendered.
+  const hash = window.location.hash;
+  const hasMagicLinkToken = hash.includes('access_token') && hash.includes('type=magiclink');
+  const adminOtpPending   = (() => { try { return localStorage.getItem('admin_otp_pending') === '1'; } catch { return false; } })();
+
+  if (hasMagicLinkToken && adminOtpPending && !window.location.pathname.startsWith('/admin')) {
+    try { localStorage.removeItem('admin_otp_pending'); } catch {}
+    // Redirect to /admin, keeping the hash so AdminApp can exchange the token
+    window.location.replace('/admin' + hash);
+    // Stop — the page will reload at /admin
+  } else {
+    // Route /admin to the Platform Admin portal; everything else → tenant App.
+    const isAdminRoute = window.location.pathname.startsWith('/admin');
+    const appModule = isAdminRoute ? import('./AdminApp') : import('./App');
 
   // Dynamic import so module-load errors (e.g. Supabase client init) become
   // visible UI instead of a blank page.
@@ -66,4 +83,5 @@ if (missing.length > 0) {
         </div>
       `;
     });
+  } // end else (no magic-link intercept)
 }

--- a/index.tsx
+++ b/index.tsx
@@ -38,9 +38,13 @@ if (!supabaseAnonKey) missing.push('VITE_SUPABASE_ANON_KEY');
 if (missing.length > 0) {
   renderConfigError(missing);
 } else {
+  // Route /admin to the Platform Admin portal; everything else → tenant App.
+  const isAdminRoute = window.location.pathname.startsWith('/admin');
+  const appModule = isAdminRoute ? import('./AdminApp') : import('./App');
+
   // Dynamic import so module-load errors (e.g. Supabase client init) become
   // visible UI instead of a blank page.
-  import('./App')
+  appModule
     .then(({ default: App }) => {
       const root = ReactDOM.createRoot(rootElement!);
       root.render(

--- a/index.tsx
+++ b/index.tsx
@@ -38,24 +38,10 @@ if (!supabaseAnonKey) missing.push('VITE_SUPABASE_ANON_KEY');
 if (missing.length > 0) {
   renderConfigError(missing);
 } else {
-  // ── Admin magic-link intercept ──────────────────────────────────────────
-  // When an admin requests a magic link, AdminLoginScreen sets the flag
-  // 'admin_otp_pending' in localStorage.  Supabase may redirect back to the
-  // Site URL (root '/') rather than '/admin' if '/admin' is not in its
-  // allowed-redirect-URLs list.  We catch that here: if the URL hash contains
-  // an access_token AND the pending flag is set, redirect to /admin so
-  // AdminApp can pick up the session — before any React tree is rendered.
-  const hash = window.location.hash;
-  const hasMagicLinkToken = hash.includes('access_token') && hash.includes('type=magiclink');
-  const adminOtpPending   = (() => { try { return localStorage.getItem('admin_otp_pending') === '1'; } catch { return false; } })();
-
-  if (hasMagicLinkToken && adminOtpPending && !window.location.pathname.startsWith('/admin')) {
-    try { localStorage.removeItem('admin_otp_pending'); } catch {}
-    // Redirect to /admin, keeping the hash so AdminApp can exchange the token
-    window.location.replace('/admin' + hash);
-    // Stop — the page will reload at /admin
-  } else {
+  {
     // Route /admin to the Platform Admin portal; everything else → tenant App.
+    // The admin magic link is generated server-side with redirectTo: /admin,
+    // so it always lands here directly — no intercept hack needed.
     const isAdminRoute = window.location.pathname.startsWith('/admin');
     const appModule = isAdminRoute ? import('./AdminApp') : import('./App');
 
@@ -83,5 +69,5 @@ if (missing.length > 0) {
         </div>
       `;
     });
-  } // end else (no magic-link intercept)
+  }
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -7,3 +7,15 @@
   command = "npm run dev"
   port = 8888
   targetPort = 3000
+
+# SPA fallback — both the tenant app and the admin portal are served from
+# the same index.html; client-side routing handles the /admin split.
+[[redirects]]
+  from   = "/admin/*"
+  to     = "/index.html"
+  status = 200
+
+[[redirects]]
+  from   = "/*"
+  to     = "/index.html"
+  status = 200

--- a/netlify/functions/admin.ts
+++ b/netlify/functions/admin.ts
@@ -1,0 +1,214 @@
+/**
+ * admin.ts — Platform Admin API
+ *
+ * ALL admin operations route through here.
+ * Every request is authenticated: the caller must supply a valid Supabase JWT
+ * whose owner is an active row in platform_admins.
+ *
+ * Actions available in this file (issue #72 — Foundation):
+ *   verify_admin       — verify JWT + check platform_admins; seeds first admin if table empty
+ *   admin_dashboard    — summary counts: companies, users, ai calls today
+ */
+
+import { Handler } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+
+// ---------------------------------------------------------------------------
+// Supabase service-role client (server-only, never sent to browser)
+// ---------------------------------------------------------------------------
+const supabaseUrl    = process.env.SUPABASE_URL ?? process.env.VITE_SUPABASE_URL ?? '';
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+
+function getAdminClient() {
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  }
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Auth middleware — verifies JWT and checks platform_admins table
+// ---------------------------------------------------------------------------
+async function verifyAdminJwt(
+  authHeader: string | undefined
+): Promise<{ userId: string; email: string }> {
+  if (!authHeader?.startsWith('Bearer ')) {
+    throw Object.assign(new Error('Missing or malformed Authorization header'), { status: 401 });
+  }
+  const token = authHeader.slice(7);
+
+  // Verify the Supabase JWT by calling getUser (uses service-role client)
+  const sb = getAdminClient();
+  const { data, error } = await sb.auth.getUser(token);
+  if (error || !data.user) {
+    throw Object.assign(new Error('Invalid or expired token'), { status: 401 });
+  }
+
+  const email = data.user.email ?? '';
+  const userId = data.user.id;
+
+  // Check the platform_admins table
+  const { data: adminRow, error: adminErr } = await sb
+    .from('platform_admins')
+    .select('id, is_active')
+    .eq('email', email)
+    .maybeSingle();
+
+  if (adminErr) {
+    throw Object.assign(new Error('DB error checking admin status'), { status: 500 });
+  }
+  if (!adminRow || !adminRow.is_active) {
+    throw Object.assign(new Error('Not a platform admin'), { status: 403 });
+  }
+
+  return { userId, email };
+}
+
+// ---------------------------------------------------------------------------
+// Action handlers
+// ---------------------------------------------------------------------------
+
+/** verify_admin — called right after Supabase login to confirm admin access.
+ *  Also seeds the first admin row from PLATFORM_ADMIN_EMAIL if table is empty.
+ */
+async function handleVerifyAdmin(
+  body: any,
+  authHeader: string | undefined
+): Promise<object> {
+  const sb = getAdminClient();
+  const token = (authHeader ?? '').replace('Bearer ', '');
+
+  if (!token) throw Object.assign(new Error('Missing token'), { status: 401 });
+
+  // Resolve the calling user from the JWT
+  const { data: userData, error: userErr } = await sb.auth.getUser(token);
+  if (userErr || !userData.user) {
+    throw Object.assign(new Error('Invalid token'), { status: 401 });
+  }
+  const email = userData.user.email ?? '';
+
+  // Seed first admin if table is empty and env var matches
+  const { count } = await sb
+    .from('platform_admins')
+    .select('id', { count: 'exact', head: true });
+
+  const firstAdminEmail = process.env.PLATFORM_ADMIN_EMAIL ?? '';
+
+  if ((count ?? 0) === 0 && firstAdminEmail && email.toLowerCase() === firstAdminEmail.toLowerCase()) {
+    await sb.from('platform_admins').insert({ email, created_by: null });
+    console.info('[admin] First platform admin seeded:', email);
+  }
+
+  // Now check access
+  const { data: adminRow } = await sb
+    .from('platform_admins')
+    .select('id, is_active')
+    .eq('email', email)
+    .maybeSingle();
+
+  if (!adminRow || !adminRow.is_active) {
+    throw Object.assign(new Error('Not an active platform admin'), { status: 403 });
+  }
+
+  return { ok: true, email, adminId: adminRow.id };
+}
+
+/** admin_dashboard — platform-wide summary counts */
+async function handleAdminDashboard(adminEmail: string): Promise<object> {
+  const sb = getAdminClient();
+
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+
+  const [orgsRes, membersRes, aiTodayRes, aiErrorsRes] = await Promise.all([
+    sb.from('organizations').select('id, is_active', { count: 'exact' }),
+    sb.from('org_members').select('id', { count: 'exact', head: true }),
+    sb.from('ai_usage_log')
+      .select('id', { count: 'exact', head: true })
+      .gte('created_at', today.toISOString()),
+    sb.from('ai_usage_log')
+      .select('id', { count: 'exact', head: true })
+      .not('error', 'is', null),
+  ]);
+
+  const orgs = orgsRes.data ?? [];
+  const activeOrgs   = orgs.filter((o: any) => o.is_active !== false).length;
+  const inactiveOrgs = orgs.filter((o: any) => o.is_active === false).length;
+
+  return {
+    totalCompanies:   orgs.length,
+    activeCompanies:  activeOrgs,
+    inactiveCompanies: inactiveOrgs,
+    totalUsers:       membersRes.count ?? 0,
+    aiCallsToday:     aiTodayRes.count ?? 0,
+    aiErrorsTotal:    aiErrorsRes.count ?? 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main handler
+// ---------------------------------------------------------------------------
+export const handler: Handler = async (event) => {
+  const corsHeaders = {
+    'Access-Control-Allow-Origin': '*',
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+  };
+
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: corsHeaders, body: '' };
+  }
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, headers: corsHeaders, body: JSON.stringify({ error: 'Method not allowed' }) };
+  }
+
+  let body: any = {};
+  try {
+    body = JSON.parse(event.body ?? '{}');
+  } catch {
+    return { statusCode: 400, headers: corsHeaders, body: JSON.stringify({ error: 'Invalid JSON' }) };
+  }
+
+  const { action } = body;
+  const authHeader = event.headers['authorization'] ?? event.headers['Authorization'];
+
+  try {
+    let result: object;
+
+    if (action === 'verify_admin') {
+      // verify_admin does its own JWT parsing (handles seeding)
+      result = await handleVerifyAdmin(body, authHeader);
+    } else {
+      // All other actions require a verified admin
+      const { email } = await verifyAdminJwt(authHeader);
+
+      switch (action) {
+        case 'admin_dashboard':
+          result = await handleAdminDashboard(email);
+          break;
+        default:
+          return {
+            statusCode: 400,
+            headers: corsHeaders,
+            body: JSON.stringify({ error: `Unknown action: ${action}` }),
+          };
+      }
+    }
+
+    return {
+      statusCode: 200,
+      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      body: JSON.stringify(result),
+    };
+  } catch (err: any) {
+    const status = err?.status ?? 500;
+    console.error(`[admin] action=${action} error:`, err?.message ?? err);
+    return {
+      statusCode: status,
+      headers: corsHeaders,
+      body: JSON.stringify({ error: err?.message ?? 'Internal server error' }),
+    };
+  }
+};

--- a/netlify/functions/admin.ts
+++ b/netlify/functions/admin.ts
@@ -1,173 +1,157 @@
 /**
  * admin.ts — Platform Admin API
  *
- * ALL admin operations route through here.
+ * Authentication model
+ * ────────────────────
+ * Bootstrap  (platform_admins table is EMPTY):
+ *   POST { action: 'admin_login', email, password }
+ *   Server verifies against PLATFORM_ADMIN_EMAIL + PLATFORM_ADMIN_PASSWORD env vars.
+ *   On success: seeds first admin row + returns a signed admin JWT (8 h).
  *
- * Pre-auth actions (no JWT required):
- *   request_admin_magic_link  — generate a server-side magic link (bypasses
- *                               Supabase redirect-URL allowlist) and send a
- *                               custom admin-branded email via Resend.
+ * Normal     (platform_admins table has rows):
+ *   POST { action: 'request_admin_magic_link', email }
+ *   Server generates a Supabase magic link (server-side, bypasses redirect allowlist)
+ *   and sends a custom admin-branded email via Resend.
+ *   POST { action: 'verify_admin' } with Bearer <supabase-token>
+ *   After the magic link is clicked, AdminApp exchanges the Supabase session
+ *   for a signed admin JWT by calling this action.
  *
- * Post-auth actions (valid admin JWT required):
- *   verify_admin       — validate JWT + check platform_admins; seed first admin
- *   admin_dashboard    — platform-wide summary counts
+ * All other actions require Bearer <admin-jwt> (issued by this function).
+ *
+ * The admin JWT is signed with PLATFORM_ADMIN_JWT_SECRET (or derived from
+ * SUPABASE_SERVICE_ROLE_KEY if the secret is not set — no extra env var needed).
  */
 
 import { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
+import crypto from 'crypto';
 
 // ---------------------------------------------------------------------------
 // Config
 // ---------------------------------------------------------------------------
-const supabaseUrl    = process.env.SUPABASE_URL ?? process.env.VITE_SUPABASE_URL ?? '';
+const supabaseUrl    = process.env.SUPABASE_URL    ?? process.env.VITE_SUPABASE_URL ?? '';
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
-const appUrl         = process.env.VITE_APP_URL ?? 'http://localhost:8888';
-const resendApiKey   = process.env.RESEND_API_KEY ?? '';
+const appUrl         = process.env.VITE_APP_URL    ?? 'http://localhost:8888';
+const resendApiKey   = process.env.RESEND_API_KEY  ?? '';
 const fromEmail      = process.env.RESEND_FROM_EMAIL ?? 'noreply@aeternum-ally.com';
-const isDev          = !resendApiKey;
 
 function getAdminClient() {
-  if (!supabaseUrl || !serviceRoleKey) {
-    throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
-  }
+  if (!supabaseUrl || !serviceRoleKey) throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
   return createClient(supabaseUrl, serviceRoleKey, {
     auth: { autoRefreshToken: false, persistSession: false },
   });
 }
 
 // ---------------------------------------------------------------------------
-// Email — custom admin-branded HTML via Resend REST API
+// Custom admin JWT  (Node built-in crypto — no npm deps)
 // ---------------------------------------------------------------------------
-
-function buildAdminEmailHtml(magicLink: string): string {
-  return `<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Aeternum Ally — Admin Access</title>
-</head>
-<body style="margin:0;padding:0;background:#020617;font-family:Inter,'Helvetica Neue',Arial,sans-serif;">
-  <table width="100%" cellpadding="0" cellspacing="0" style="background:#020617;padding:48px 16px;">
-    <tr>
-      <td align="center">
-        <table width="100%" style="max-width:480px;background:#0f172a;border:1px solid #1e293b;border-radius:16px;overflow:hidden;">
-
-          <!-- Header -->
-          <tr>
-            <td style="background:#14532d;padding:28px 32px;text-align:center;">
-              <table cellpadding="0" cellspacing="0" style="margin:0 auto;">
-                <tr>
-                  <td style="background:#15803d;border-radius:12px;width:48px;height:48px;text-align:center;vertical-align:middle;">
-                    <span style="font-size:24px;line-height:48px;">🛡️</span>
-                  </td>
-                  <td style="padding-left:12px;text-align:left;">
-                    <div style="color:#ffffff;font-size:18px;font-weight:700;letter-spacing:-0.3px;">Aeternum Ally</div>
-                    <div style="color:#86efac;font-size:12px;font-weight:500;letter-spacing:0.5px;text-transform:uppercase;">Platform Admin Portal</div>
-                  </td>
-                </tr>
-              </table>
-            </td>
-          </tr>
-
-          <!-- Body -->
-          <tr>
-            <td style="padding:32px;">
-              <p style="margin:0 0 8px;color:#94a3b8;font-size:12px;font-weight:600;letter-spacing:1px;text-transform:uppercase;">
-                Secure Sign-In Link
-              </p>
-              <h1 style="margin:0 0 16px;color:#f1f5f9;font-size:22px;font-weight:700;line-height:1.3;">
-                Your admin access link is ready
-              </h1>
-              <p style="margin:0 0 24px;color:#94a3b8;font-size:15px;line-height:1.6;">
-                Click the button below to sign in to the <strong style="color:#e2e8f0;">Platform Admin Portal</strong>.
-                This link is valid for <strong style="color:#e2e8f0;">60 minutes</strong> and can only be used once.
-              </p>
-
-              <!-- CTA -->
-              <table cellpadding="0" cellspacing="0" style="margin:0 0 24px;">
-                <tr>
-                  <td style="background:#16a34a;border-radius:10px;">
-                    <a href="${magicLink}"
-                       style="display:inline-block;padding:14px 28px;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;letter-spacing:-0.1px;">
-                      Sign in to Admin Portal →
-                    </a>
-                  </td>
-                </tr>
-              </table>
-
-              <!-- Security notice -->
-              <table cellpadding="0" cellspacing="0" style="background:#1e293b;border:1px solid #334155;border-radius:10px;width:100%;">
-                <tr>
-                  <td style="padding:16px 20px;">
-                    <p style="margin:0 0 6px;color:#fbbf24;font-size:12px;font-weight:600;letter-spacing:0.5px;text-transform:uppercase;">
-                      ⚠️ Security Notice
-                    </p>
-                    <p style="margin:0;color:#94a3b8;font-size:13px;line-height:1.5;">
-                      This link grants <strong style="color:#e2e8f0;">platform-level admin access</strong> to all companies and data.
-                      If you did not request this link, please ignore this email — it will expire automatically.
-                    </p>
-                  </td>
-                </tr>
-              </table>
-            </td>
-          </tr>
-
-          <!-- Link fallback -->
-          <tr>
-            <td style="padding:0 32px 24px;">
-              <p style="margin:0 0 6px;color:#475569;font-size:12px;">
-                Button not working? Copy and paste this URL into your browser:
-              </p>
-              <p style="margin:0;font-size:11px;color:#64748b;word-break:break-all;font-family:monospace;">
-                ${magicLink}
-              </p>
-            </td>
-          </tr>
-
-          <!-- Footer -->
-          <tr>
-            <td style="padding:20px 32px;border-top:1px solid #1e293b;text-align:center;">
-              <p style="margin:0;color:#334155;font-size:12px;">
-                Aeternum Ally · Platform Administration<br/>
-                This is an automated message — do not reply.
-              </p>
-            </td>
-          </tr>
-
-        </table>
-      </td>
-    </tr>
-  </table>
-</body>
-</html>`;
+function getJwtSecret(): string {
+  return process.env.PLATFORM_ADMIN_JWT_SECRET
+    ?? crypto.createHash('sha256').update(serviceRoleKey + ':admin-portal').digest('hex');
 }
 
-async function sendAdminMagicLinkEmail(toEmail: string, magicLink: string): Promise<void> {
-  const res = await fetch('https://api.resend.com/emails', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${resendApiKey}`,
-    },
-    body: JSON.stringify({
-      from: `Aeternum Ally Admin <${fromEmail}>`,
-      to: [toEmail],
-      subject: '🛡️ Your Aeternum Ally Admin Access Link',
-      html: buildAdminEmailHtml(magicLink),
-    }),
-  });
+function signAdminToken(email: string): string {
+  const secret  = getJwtSecret();
+  const header  = Buffer.from('{"alg":"HS256","typ":"AdminJWT"}').toString('base64url');
+  const payload = Buffer.from(JSON.stringify({
+    sub:  email,
+    role: 'platform_admin',
+    iat:  Math.floor(Date.now() / 1000),
+    exp:  Math.floor(Date.now() / 1000) + 8 * 3600,   // 8 h
+  })).toString('base64url');
+  const sig = crypto.createHmac('sha256', secret)
+    .update(`${header}.${payload}`).digest('base64url');
+  return `${header}.${payload}.${sig}`;
+}
 
-  if (!res.ok) {
-    const errText = await res.text();
-    throw new Error(`Email delivery failed (Resend ${res.status}): ${errText}`);
+function verifyAdminToken(token: string): { email: string } {
+  const parts = token.split('.');
+  if (parts.length !== 3) throw Object.assign(new Error('Malformed admin token'), { status: 401 });
+  const [header, payload, sig] = parts;
+  const secret   = getJwtSecret();
+  const expected = crypto.createHmac('sha256', secret)
+    .update(`${header}.${payload}`).digest('base64url');
+  // Constant-time compare to prevent timing attacks
+  const sigBuf  = Buffer.from(sig,      'base64url');
+  const expBuf  = Buffer.from(expected, 'base64url');
+  const safe    = sigBuf.length === expBuf.length
+    ? crypto.timingSafeEqual(sigBuf, expBuf)
+    : false;
+  if (!safe) throw Object.assign(new Error('Invalid admin token'), { status: 401 });
+  const data = JSON.parse(Buffer.from(payload, 'base64url').toString('utf8'));
+  if (data.exp < Math.floor(Date.now() / 1000)) throw Object.assign(new Error('Admin token expired'), { status: 401 });
+  if (data.role !== 'platform_admin') throw Object.assign(new Error('Invalid token role'), { status: 401 });
+  return { email: data.sub };
+}
+
+// ---------------------------------------------------------------------------
+// Auth middleware — verifies custom admin JWT + checks platform_admins table
+// ---------------------------------------------------------------------------
+async function requireAdmin(authHeader: string | undefined): Promise<{ email: string }> {
+  if (!authHeader?.startsWith('Bearer ')) {
+    throw Object.assign(new Error('Missing Authorization header'), { status: 401 });
   }
+  const token = authHeader.slice(7);
+  const { email } = verifyAdminToken(token);       // throws if invalid / expired
+
+  const sb = getAdminClient();
+  const { data: row } = await sb
+    .from('platform_admins').select('is_active').eq('email', email).maybeSingle();
+  if (!row?.is_active) throw Object.assign(new Error('Admin account inactive'), { status: 403 });
+
+  return { email };
 }
 
 // ---------------------------------------------------------------------------
-// Pre-auth action: request_admin_magic_link
-// No JWT — the only check is that the email is an active platform admin.
-// We always return the same success response to avoid leaking admin emails.
+// Pre-auth: admin_login  (bootstrap — only works when table is empty)
+// ---------------------------------------------------------------------------
+async function handleAdminLogin(body: any): Promise<object> {
+  const email    = (body.email    ?? '').trim().toLowerCase();
+  const password = (body.password ?? '').trim();
+  if (!email || !password) throw Object.assign(new Error('email and password are required'), { status: 400 });
+
+  const sb = getAdminClient();
+
+  // Only allowed when the table is empty
+  const { count } = await sb
+    .from('platform_admins').select('id', { count: 'exact', head: true });
+
+  if ((count ?? 0) > 0) {
+    throw Object.assign(
+      new Error('Admin accounts already exist — use the magic link to sign in.'),
+      { status: 403 }
+    );
+  }
+
+  // Verify against .env credentials
+  const envEmail    = (process.env.PLATFORM_ADMIN_EMAIL    ?? '').toLowerCase();
+  const envPassword =  process.env.PLATFORM_ADMIN_PASSWORD ?? '';
+
+  if (!envEmail || !envPassword) {
+    throw Object.assign(
+      new Error('PLATFORM_ADMIN_EMAIL and PLATFORM_ADMIN_PASSWORD must be set in environment variables'),
+      { status: 500 }
+    );
+  }
+
+  const emailMatch = email === envEmail;
+  // Constant-time password compare to prevent timing attacks
+  const pwMatch = password.length === envPassword.length
+    && crypto.timingSafeEqual(Buffer.from(password), Buffer.from(envPassword));
+
+  if (!emailMatch || !pwMatch) {
+    throw Object.assign(new Error('Invalid credentials'), { status: 401 });
+  }
+
+  // Seed the first admin row
+  await sb.from('platform_admins').insert({ email, created_by: null });
+  console.info('[admin] Bootstrap: first platform admin seeded:', email);
+
+  return { token: signAdminToken(email), email };
+}
+
+// ---------------------------------------------------------------------------
+// Pre-auth: request_admin_magic_link  (normal mode — table has rows)
 // ---------------------------------------------------------------------------
 async function handleRequestAdminMagicLink(body: any): Promise<object> {
   const email = (body.email ?? '').trim().toLowerCase();
@@ -175,22 +159,16 @@ async function handleRequestAdminMagicLink(body: any): Promise<object> {
 
   const sb = getAdminClient();
 
-  // Check email is an active platform admin
+  // Check email is an active platform admin (silent success if not — don't leak)
   const { data: adminRow } = await sb
-    .from('platform_admins')
-    .select('id, is_active')
-    .eq('email', email)
-    .maybeSingle();
+    .from('platform_admins').select('id, is_active').eq('email', email).maybeSingle();
 
-  // Silently succeed for non-admin emails (don't leak whether it exists)
   if (!adminRow?.is_active) {
-    console.info(`[admin] magic-link requested for non-admin email: ${email}`);
-    return { sent: true };
+    console.info('[admin] magic-link requested for non-admin email:', email);
+    return { sent: true };   // silent — don't reveal whether this is an admin
   }
 
-  // Generate magic link server-side using the service-role key.
-  // This bypasses Supabase's redirect-URL allowlist — the link goes
-  // directly to /admin regardless of what is configured in the dashboard.
+  // Generate magic link server-side — bypasses Supabase redirect-URL allowlist
   const { data: linkData, error: linkError } = await sb.auth.admin.generateLink({
     type: 'magiclink',
     email,
@@ -204,99 +182,46 @@ async function handleRequestAdminMagicLink(body: any): Promise<object> {
 
   const magicLink = linkData.properties.action_link;
 
-  if (isDev) {
-    // Development: no Resend key — log link to console and return it
-    // so the developer can use it directly from the UI.
-    console.info(`\n[admin] ✉️  MAGIC LINK (dev mode — no RESEND_API_KEY set):\n${magicLink}\n`);
+  if (!resendApiKey) {
+    // Dev mode — return link directly (shown in UI)
+    console.info(`\n[admin] ✉️  MAGIC LINK (dev — no RESEND_API_KEY):\n${magicLink}\n`);
     return { sent: true, dev_link: magicLink };
   }
 
-  // Production: send custom admin-branded email
   await sendAdminMagicLinkEmail(email, magicLink);
   return { sent: true };
 }
 
 // ---------------------------------------------------------------------------
-// Post-auth action: verify_admin
-// Called after the magic link is clicked and Supabase has authenticated.
-// Confirms the user is an active platform admin; seeds first admin if needed.
+// Pre-auth: verify_admin  (called after magic link redirect; exchanges
+//           Supabase session for a signed admin JWT)
 // ---------------------------------------------------------------------------
-async function handleVerifyAdmin(
-  authHeader: string | undefined
-): Promise<object> {
+async function handleVerifyAdmin(authHeader: string | undefined): Promise<object> {
   if (!authHeader?.startsWith('Bearer ')) {
     throw Object.assign(new Error('Missing Authorization header'), { status: 401 });
   }
-  const token = authHeader.slice(7);
+  const supabaseToken = authHeader.slice(7);
 
   const sb = getAdminClient();
-  const { data: userData, error: userErr } = await sb.auth.getUser(token);
-  if (userErr || !userData.user) {
-    throw Object.assign(new Error('Invalid or expired token'), { status: 401 });
-  }
+  const { data: userData, error } = await sb.auth.getUser(supabaseToken);
+  if (error || !userData.user) throw Object.assign(new Error('Invalid Supabase token'), { status: 401 });
 
   const email = (userData.user.email ?? '').toLowerCase();
+  const { data: row } = await sb
+    .from('platform_admins').select('id, is_active').eq('email', email).maybeSingle();
+  if (!row?.is_active) throw Object.assign(new Error('Not an active platform admin'), { status: 403 });
 
-  // Seed the first admin row if table is empty and env var matches
-  const { count } = await sb
-    .from('platform_admins')
-    .select('id', { count: 'exact', head: true });
+  // Sign out of Supabase — we use our own token from here
+  await sb.auth.admin.signOut(supabaseToken);
 
-  const firstAdminEmail = (process.env.PLATFORM_ADMIN_EMAIL ?? '').toLowerCase();
-  if ((count ?? 0) === 0 && firstAdminEmail && email === firstAdminEmail) {
-    await sb.from('platform_admins').insert({ email, created_by: null });
-    console.info('[admin] First platform admin seeded:', email);
-  }
-
-  // Verify active admin
-  const { data: adminRow } = await sb
-    .from('platform_admins')
-    .select('id, is_active')
-    .eq('email', email)
-    .maybeSingle();
-
-  if (!adminRow?.is_active) {
-    throw Object.assign(new Error('Not an active platform admin'), { status: 403 });
-  }
-
-  return { ok: true, email, adminId: adminRow.id };
+  return { token: signAdminToken(email), email };
 }
 
 // ---------------------------------------------------------------------------
-// Auth middleware for post-auth actions
-// ---------------------------------------------------------------------------
-async function verifyAdminJwt(
-  authHeader: string | undefined
-): Promise<{ userId: string; email: string }> {
-  if (!authHeader?.startsWith('Bearer ')) {
-    throw Object.assign(new Error('Missing or malformed Authorization header'), { status: 401 });
-  }
-  const token = authHeader.slice(7);
-  const sb = getAdminClient();
-
-  const { data, error } = await sb.auth.getUser(token);
-  if (error || !data.user) {
-    throw Object.assign(new Error('Invalid or expired token'), { status: 401 });
-  }
-
-  const email = (data.user.email ?? '').toLowerCase();
-  const { data: adminRow, error: adminErr } = await sb
-    .from('platform_admins')
-    .select('id, is_active')
-    .eq('email', email)
-    .maybeSingle();
-
-  if (adminErr) throw Object.assign(new Error('DB error checking admin status'), { status: 500 });
-  if (!adminRow?.is_active) throw Object.assign(new Error('Not a platform admin'), { status: 403 });
-
-  return { userId: data.user.id, email };
-}
-
-// ---------------------------------------------------------------------------
-// Post-auth action: admin_dashboard
+// Post-auth: admin_dashboard
 // ---------------------------------------------------------------------------
 async function handleAdminDashboard(): Promise<object> {
-  const sb = getAdminClient();
+  const sb    = getAdminClient();
   const today = new Date(); today.setHours(0, 0, 0, 0);
 
   const [orgsRes, membersRes, aiTodayRes, aiErrorsRes] = await Promise.all([
@@ -318,24 +243,80 @@ async function handleAdminDashboard(): Promise<object> {
 }
 
 // ---------------------------------------------------------------------------
+// Email helper — custom admin-branded HTML via Resend
+// ---------------------------------------------------------------------------
+async function sendAdminMagicLinkEmail(toEmail: string, magicLink: string): Promise<void> {
+  const html = `<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"/><title>Aeternum Ally Admin Access</title></head>
+<body style="margin:0;padding:0;background:#020617;font-family:Inter,'Helvetica Neue',Arial,sans-serif;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background:#020617;padding:48px 16px;">
+<tr><td align="center">
+<table width="100%" style="max-width:480px;background:#0f172a;border:1px solid #1e293b;border-radius:16px;overflow:hidden;">
+  <tr><td style="background:#14532d;padding:24px 32px;text-align:center;">
+    <span style="color:#fff;font-size:18px;font-weight:700;">🛡️ Aeternum Ally</span><br/>
+    <span style="color:#86efac;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;">Platform Admin Portal</span>
+  </td></tr>
+  <tr><td style="padding:32px;">
+    <p style="margin:0 0 8px;color:#94a3b8;font-size:12px;font-weight:600;letter-spacing:1px;text-transform:uppercase;">Secure Sign-In Link</p>
+    <h1 style="margin:0 0 16px;color:#f1f5f9;font-size:20px;font-weight:700;">Your admin access link</h1>
+    <p style="margin:0 0 24px;color:#94a3b8;font-size:15px;line-height:1.6;">
+      Click below to sign in to the <strong style="color:#e2e8f0;">Platform Admin Portal</strong>.
+      Valid for <strong style="color:#e2e8f0;">60 minutes</strong>, single use.
+    </p>
+    <table cellpadding="0" cellspacing="0" style="margin:0 0 24px;">
+      <tr><td style="background:#16a34a;border-radius:10px;">
+        <a href="${magicLink}" style="display:inline-block;padding:14px 28px;color:#fff;font-size:15px;font-weight:600;text-decoration:none;">Sign in to Admin Portal →</a>
+      </td></tr>
+    </table>
+    <table cellpadding="0" cellspacing="0" style="background:#1e293b;border:1px solid #334155;border-radius:10px;width:100%;">
+      <tr><td style="padding:16px 20px;">
+        <p style="margin:0 0 4px;color:#fbbf24;font-size:12px;font-weight:600;text-transform:uppercase;">⚠️ Security Notice</p>
+        <p style="margin:0;color:#94a3b8;font-size:13px;line-height:1.5;">
+          This link grants <strong style="color:#e2e8f0;">platform-level access</strong> to all companies and data.
+          If you did not request this, ignore this email — it expires automatically.
+        </p>
+      </td></tr>
+    </table>
+  </td></tr>
+  <tr><td style="padding:0 32px 24px;"><p style="margin:0;color:#475569;font-size:11px;word-break:break-all;font-family:monospace;">${magicLink}</p></td></tr>
+  <tr><td style="padding:16px 32px;border-top:1px solid #1e293b;text-align:center;">
+    <p style="margin:0;color:#334155;font-size:12px;">Aeternum Ally · Platform Administration · Do not reply</p>
+  </td></tr>
+</table>
+</td></tr></table>
+</body></html>`;
+
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${resendApiKey}` },
+    body: JSON.stringify({
+      from:    `Aeternum Ally Admin <${fromEmail}>`,
+      to:      [toEmail],
+      subject: '🛡️ Your Aeternum Ally Admin Access Link',
+      html,
+    }),
+  });
+
+  if (!res.ok) throw new Error(`Resend error ${res.status}: ${await res.text()}`);
+}
+
+// ---------------------------------------------------------------------------
 // Main handler
 // ---------------------------------------------------------------------------
 export const handler: Handler = async (event) => {
-  const corsHeaders = {
-    'Access-Control-Allow-Origin': '*',
+  const cors = {
+    'Access-Control-Allow-Origin':  '*',
     'Access-Control-Allow-Headers': 'Content-Type, Authorization',
     'Access-Control-Allow-Methods': 'POST, OPTIONS',
   };
 
-  if (event.httpMethod === 'OPTIONS') return { statusCode: 204, headers: corsHeaders, body: '' };
-  if (event.httpMethod !== 'POST') {
-    return { statusCode: 405, headers: corsHeaders, body: JSON.stringify({ error: 'Method not allowed' }) };
-  }
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 204, headers: cors, body: '' };
+  if (event.httpMethod !== 'POST')
+    return { statusCode: 405, headers: cors, body: JSON.stringify({ error: 'Method not allowed' }) };
 
   let body: any = {};
-  try { body = JSON.parse(event.body ?? '{}'); } catch {
-    return { statusCode: 400, headers: corsHeaders, body: JSON.stringify({ error: 'Invalid JSON' }) };
-  }
+  try { body = JSON.parse(event.body ?? '{}'); }
+  catch { return { statusCode: 400, headers: cors, body: JSON.stringify({ error: 'Invalid JSON' }) }; }
 
   const { action } = body;
   const authHeader = event.headers['authorization'] ?? event.headers['Authorization'];
@@ -343,34 +324,35 @@ export const handler: Handler = async (event) => {
   try {
     let result: object;
 
-    // Pre-auth actions — no JWT needed
-    if (action === 'request_admin_magic_link') {
+    // ── Pre-auth actions (no token required) ───────────────────────────────
+    if (action === 'admin_login') {
+      result = await handleAdminLogin(body);
+
+    } else if (action === 'request_admin_magic_link') {
       result = await handleRequestAdminMagicLink(body);
 
     } else if (action === 'verify_admin') {
       result = await handleVerifyAdmin(authHeader);
 
     } else {
-      // All other actions require a verified admin JWT
-      await verifyAdminJwt(authHeader);
+      // ── Post-auth actions (admin JWT required) ──────────────────────────
+      await requireAdmin(authHeader);
 
       switch (action) {
-        case 'admin_dashboard':
-          result = await handleAdminDashboard();
-          break;
+        case 'admin_dashboard': result = await handleAdminDashboard(); break;
         default:
-          return { statusCode: 400, headers: corsHeaders, body: JSON.stringify({ error: `Unknown action: ${action}` }) };
+          return { statusCode: 400, headers: cors, body: JSON.stringify({ error: `Unknown action: ${action}` }) };
       }
     }
 
     return {
       statusCode: 200,
-      headers: { ...corsHeaders, 'Content-Type': 'application/json' },
+      headers: { ...cors, 'Content-Type': 'application/json' },
       body: JSON.stringify(result),
     };
   } catch (err: any) {
     const status = err?.status ?? 500;
     console.error(`[admin] action=${action} error:`, err?.message ?? err);
-    return { statusCode: status, headers: corsHeaders, body: JSON.stringify({ error: err?.message ?? 'Internal server error' }) };
+    return { statusCode: status, headers: cors, body: JSON.stringify({ error: err?.message ?? 'Internal server error' }) };
   }
 };

--- a/netlify/functions/admin.ts
+++ b/netlify/functions/admin.ts
@@ -2,22 +2,29 @@
  * admin.ts — Platform Admin API
  *
  * ALL admin operations route through here.
- * Every request is authenticated: the caller must supply a valid Supabase JWT
- * whose owner is an active row in platform_admins.
  *
- * Actions available in this file (issue #72 — Foundation):
- *   verify_admin       — verify JWT + check platform_admins; seeds first admin if table empty
- *   admin_dashboard    — summary counts: companies, users, ai calls today
+ * Pre-auth actions (no JWT required):
+ *   request_admin_magic_link  — generate a server-side magic link (bypasses
+ *                               Supabase redirect-URL allowlist) and send a
+ *                               custom admin-branded email via Resend.
+ *
+ * Post-auth actions (valid admin JWT required):
+ *   verify_admin       — validate JWT + check platform_admins; seed first admin
+ *   admin_dashboard    — platform-wide summary counts
  */
 
 import { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
 
 // ---------------------------------------------------------------------------
-// Supabase service-role client (server-only, never sent to browser)
+// Config
 // ---------------------------------------------------------------------------
 const supabaseUrl    = process.env.SUPABASE_URL ?? process.env.VITE_SUPABASE_URL ?? '';
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+const appUrl         = process.env.VITE_APP_URL ?? 'http://localhost:8888';
+const resendApiKey   = process.env.RESEND_API_KEY ?? '';
+const fromEmail      = process.env.RESEND_FROM_EMAIL ?? 'noreply@aeternum-ally.com';
+const isDev          = !resendApiKey;
 
 function getAdminClient() {
   if (!supabaseUrl || !serviceRoleKey) {
@@ -29,7 +36,234 @@ function getAdminClient() {
 }
 
 // ---------------------------------------------------------------------------
-// Auth middleware — verifies JWT and checks platform_admins table
+// Email — custom admin-branded HTML via Resend REST API
+// ---------------------------------------------------------------------------
+
+function buildAdminEmailHtml(magicLink: string): string {
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Aeternum Ally — Admin Access</title>
+</head>
+<body style="margin:0;padding:0;background:#020617;font-family:Inter,'Helvetica Neue',Arial,sans-serif;">
+  <table width="100%" cellpadding="0" cellspacing="0" style="background:#020617;padding:48px 16px;">
+    <tr>
+      <td align="center">
+        <table width="100%" style="max-width:480px;background:#0f172a;border:1px solid #1e293b;border-radius:16px;overflow:hidden;">
+
+          <!-- Header -->
+          <tr>
+            <td style="background:#14532d;padding:28px 32px;text-align:center;">
+              <table cellpadding="0" cellspacing="0" style="margin:0 auto;">
+                <tr>
+                  <td style="background:#15803d;border-radius:12px;width:48px;height:48px;text-align:center;vertical-align:middle;">
+                    <span style="font-size:24px;line-height:48px;">🛡️</span>
+                  </td>
+                  <td style="padding-left:12px;text-align:left;">
+                    <div style="color:#ffffff;font-size:18px;font-weight:700;letter-spacing:-0.3px;">Aeternum Ally</div>
+                    <div style="color:#86efac;font-size:12px;font-weight:500;letter-spacing:0.5px;text-transform:uppercase;">Platform Admin Portal</div>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Body -->
+          <tr>
+            <td style="padding:32px;">
+              <p style="margin:0 0 8px;color:#94a3b8;font-size:12px;font-weight:600;letter-spacing:1px;text-transform:uppercase;">
+                Secure Sign-In Link
+              </p>
+              <h1 style="margin:0 0 16px;color:#f1f5f9;font-size:22px;font-weight:700;line-height:1.3;">
+                Your admin access link is ready
+              </h1>
+              <p style="margin:0 0 24px;color:#94a3b8;font-size:15px;line-height:1.6;">
+                Click the button below to sign in to the <strong style="color:#e2e8f0;">Platform Admin Portal</strong>.
+                This link is valid for <strong style="color:#e2e8f0;">60 minutes</strong> and can only be used once.
+              </p>
+
+              <!-- CTA -->
+              <table cellpadding="0" cellspacing="0" style="margin:0 0 24px;">
+                <tr>
+                  <td style="background:#16a34a;border-radius:10px;">
+                    <a href="${magicLink}"
+                       style="display:inline-block;padding:14px 28px;color:#ffffff;font-size:15px;font-weight:600;text-decoration:none;letter-spacing:-0.1px;">
+                      Sign in to Admin Portal →
+                    </a>
+                  </td>
+                </tr>
+              </table>
+
+              <!-- Security notice -->
+              <table cellpadding="0" cellspacing="0" style="background:#1e293b;border:1px solid #334155;border-radius:10px;width:100%;">
+                <tr>
+                  <td style="padding:16px 20px;">
+                    <p style="margin:0 0 6px;color:#fbbf24;font-size:12px;font-weight:600;letter-spacing:0.5px;text-transform:uppercase;">
+                      ⚠️ Security Notice
+                    </p>
+                    <p style="margin:0;color:#94a3b8;font-size:13px;line-height:1.5;">
+                      This link grants <strong style="color:#e2e8f0;">platform-level admin access</strong> to all companies and data.
+                      If you did not request this link, please ignore this email — it will expire automatically.
+                    </p>
+                  </td>
+                </tr>
+              </table>
+            </td>
+          </tr>
+
+          <!-- Link fallback -->
+          <tr>
+            <td style="padding:0 32px 24px;">
+              <p style="margin:0 0 6px;color:#475569;font-size:12px;">
+                Button not working? Copy and paste this URL into your browser:
+              </p>
+              <p style="margin:0;font-size:11px;color:#64748b;word-break:break-all;font-family:monospace;">
+                ${magicLink}
+              </p>
+            </td>
+          </tr>
+
+          <!-- Footer -->
+          <tr>
+            <td style="padding:20px 32px;border-top:1px solid #1e293b;text-align:center;">
+              <p style="margin:0;color:#334155;font-size:12px;">
+                Aeternum Ally · Platform Administration<br/>
+                This is an automated message — do not reply.
+              </p>
+            </td>
+          </tr>
+
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`;
+}
+
+async function sendAdminMagicLinkEmail(toEmail: string, magicLink: string): Promise<void> {
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${resendApiKey}`,
+    },
+    body: JSON.stringify({
+      from: `Aeternum Ally Admin <${fromEmail}>`,
+      to: [toEmail],
+      subject: '🛡️ Your Aeternum Ally Admin Access Link',
+      html: buildAdminEmailHtml(magicLink),
+    }),
+  });
+
+  if (!res.ok) {
+    const errText = await res.text();
+    throw new Error(`Email delivery failed (Resend ${res.status}): ${errText}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pre-auth action: request_admin_magic_link
+// No JWT — the only check is that the email is an active platform admin.
+// We always return the same success response to avoid leaking admin emails.
+// ---------------------------------------------------------------------------
+async function handleRequestAdminMagicLink(body: any): Promise<object> {
+  const email = (body.email ?? '').trim().toLowerCase();
+  if (!email) throw Object.assign(new Error('email is required'), { status: 400 });
+
+  const sb = getAdminClient();
+
+  // Check email is an active platform admin
+  const { data: adminRow } = await sb
+    .from('platform_admins')
+    .select('id, is_active')
+    .eq('email', email)
+    .maybeSingle();
+
+  // Silently succeed for non-admin emails (don't leak whether it exists)
+  if (!adminRow?.is_active) {
+    console.info(`[admin] magic-link requested for non-admin email: ${email}`);
+    return { sent: true };
+  }
+
+  // Generate magic link server-side using the service-role key.
+  // This bypasses Supabase's redirect-URL allowlist — the link goes
+  // directly to /admin regardless of what is configured in the dashboard.
+  const { data: linkData, error: linkError } = await sb.auth.admin.generateLink({
+    type: 'magiclink',
+    email,
+    options: { redirectTo: `${appUrl}/admin` },
+  });
+
+  if (linkError || !linkData?.properties?.action_link) {
+    console.error('[admin] generateLink failed:', linkError?.message);
+    throw Object.assign(new Error('Failed to generate sign-in link'), { status: 500 });
+  }
+
+  const magicLink = linkData.properties.action_link;
+
+  if (isDev) {
+    // Development: no Resend key — log link to console and return it
+    // so the developer can use it directly from the UI.
+    console.info(`\n[admin] ✉️  MAGIC LINK (dev mode — no RESEND_API_KEY set):\n${magicLink}\n`);
+    return { sent: true, dev_link: magicLink };
+  }
+
+  // Production: send custom admin-branded email
+  await sendAdminMagicLinkEmail(email, magicLink);
+  return { sent: true };
+}
+
+// ---------------------------------------------------------------------------
+// Post-auth action: verify_admin
+// Called after the magic link is clicked and Supabase has authenticated.
+// Confirms the user is an active platform admin; seeds first admin if needed.
+// ---------------------------------------------------------------------------
+async function handleVerifyAdmin(
+  authHeader: string | undefined
+): Promise<object> {
+  if (!authHeader?.startsWith('Bearer ')) {
+    throw Object.assign(new Error('Missing Authorization header'), { status: 401 });
+  }
+  const token = authHeader.slice(7);
+
+  const sb = getAdminClient();
+  const { data: userData, error: userErr } = await sb.auth.getUser(token);
+  if (userErr || !userData.user) {
+    throw Object.assign(new Error('Invalid or expired token'), { status: 401 });
+  }
+
+  const email = (userData.user.email ?? '').toLowerCase();
+
+  // Seed the first admin row if table is empty and env var matches
+  const { count } = await sb
+    .from('platform_admins')
+    .select('id', { count: 'exact', head: true });
+
+  const firstAdminEmail = (process.env.PLATFORM_ADMIN_EMAIL ?? '').toLowerCase();
+  if ((count ?? 0) === 0 && firstAdminEmail && email === firstAdminEmail) {
+    await sb.from('platform_admins').insert({ email, created_by: null });
+    console.info('[admin] First platform admin seeded:', email);
+  }
+
+  // Verify active admin
+  const { data: adminRow } = await sb
+    .from('platform_admins')
+    .select('id, is_active')
+    .eq('email', email)
+    .maybeSingle();
+
+  if (!adminRow?.is_active) {
+    throw Object.assign(new Error('Not an active platform admin'), { status: 403 });
+  }
+
+  return { ok: true, email, adminId: adminRow.id };
+}
+
+// ---------------------------------------------------------------------------
+// Auth middleware for post-auth actions
 // ---------------------------------------------------------------------------
 async function verifyAdminJwt(
   authHeader: string | undefined
@@ -38,112 +272,48 @@ async function verifyAdminJwt(
     throw Object.assign(new Error('Missing or malformed Authorization header'), { status: 401 });
   }
   const token = authHeader.slice(7);
-
-  // Verify the Supabase JWT by calling getUser (uses service-role client)
   const sb = getAdminClient();
+
   const { data, error } = await sb.auth.getUser(token);
   if (error || !data.user) {
     throw Object.assign(new Error('Invalid or expired token'), { status: 401 });
   }
 
-  const email = data.user.email ?? '';
-  const userId = data.user.id;
-
-  // Check the platform_admins table
+  const email = (data.user.email ?? '').toLowerCase();
   const { data: adminRow, error: adminErr } = await sb
     .from('platform_admins')
     .select('id, is_active')
     .eq('email', email)
     .maybeSingle();
 
-  if (adminErr) {
-    throw Object.assign(new Error('DB error checking admin status'), { status: 500 });
-  }
-  if (!adminRow || !adminRow.is_active) {
-    throw Object.assign(new Error('Not a platform admin'), { status: 403 });
-  }
+  if (adminErr) throw Object.assign(new Error('DB error checking admin status'), { status: 500 });
+  if (!adminRow?.is_active) throw Object.assign(new Error('Not a platform admin'), { status: 403 });
 
-  return { userId, email };
+  return { userId: data.user.id, email };
 }
 
 // ---------------------------------------------------------------------------
-// Action handlers
+// Post-auth action: admin_dashboard
 // ---------------------------------------------------------------------------
-
-/** verify_admin — called right after Supabase login to confirm admin access.
- *  Also seeds the first admin row from PLATFORM_ADMIN_EMAIL if table is empty.
- */
-async function handleVerifyAdmin(
-  body: any,
-  authHeader: string | undefined
-): Promise<object> {
+async function handleAdminDashboard(): Promise<object> {
   const sb = getAdminClient();
-  const token = (authHeader ?? '').replace('Bearer ', '');
-
-  if (!token) throw Object.assign(new Error('Missing token'), { status: 401 });
-
-  // Resolve the calling user from the JWT
-  const { data: userData, error: userErr } = await sb.auth.getUser(token);
-  if (userErr || !userData.user) {
-    throw Object.assign(new Error('Invalid token'), { status: 401 });
-  }
-  const email = userData.user.email ?? '';
-
-  // Seed first admin if table is empty and env var matches
-  const { count } = await sb
-    .from('platform_admins')
-    .select('id', { count: 'exact', head: true });
-
-  const firstAdminEmail = process.env.PLATFORM_ADMIN_EMAIL ?? '';
-
-  if ((count ?? 0) === 0 && firstAdminEmail && email.toLowerCase() === firstAdminEmail.toLowerCase()) {
-    await sb.from('platform_admins').insert({ email, created_by: null });
-    console.info('[admin] First platform admin seeded:', email);
-  }
-
-  // Now check access
-  const { data: adminRow } = await sb
-    .from('platform_admins')
-    .select('id, is_active')
-    .eq('email', email)
-    .maybeSingle();
-
-  if (!adminRow || !adminRow.is_active) {
-    throw Object.assign(new Error('Not an active platform admin'), { status: 403 });
-  }
-
-  return { ok: true, email, adminId: adminRow.id };
-}
-
-/** admin_dashboard — platform-wide summary counts */
-async function handleAdminDashboard(adminEmail: string): Promise<object> {
-  const sb = getAdminClient();
-
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
+  const today = new Date(); today.setHours(0, 0, 0, 0);
 
   const [orgsRes, membersRes, aiTodayRes, aiErrorsRes] = await Promise.all([
-    sb.from('organizations').select('id, is_active', { count: 'exact' }),
+    sb.from('organizations').select('id, is_active'),
     sb.from('org_members').select('id', { count: 'exact', head: true }),
-    sb.from('ai_usage_log')
-      .select('id', { count: 'exact', head: true })
-      .gte('created_at', today.toISOString()),
-    sb.from('ai_usage_log')
-      .select('id', { count: 'exact', head: true })
-      .not('error', 'is', null),
+    sb.from('ai_usage_log').select('id', { count: 'exact', head: true }).gte('created_at', today.toISOString()),
+    sb.from('ai_usage_log').select('id', { count: 'exact', head: true }).not('error', 'is', null),
   ]);
 
   const orgs = orgsRes.data ?? [];
-  const activeOrgs   = orgs.filter((o: any) => o.is_active !== false).length;
-  const inactiveOrgs = orgs.filter((o: any) => o.is_active === false).length;
-
   return {
-    totalCompanies:   orgs.length,
-    activeCompanies:  activeOrgs,
-    inactiveCompanies: inactiveOrgs,
-    totalUsers:       membersRes.count ?? 0,
-    aiCallsToday:     aiTodayRes.count ?? 0,
-    aiErrorsTotal:    aiErrorsRes.count ?? 0,
+    totalCompanies:    orgs.length,
+    activeCompanies:   orgs.filter((o: any) => o.is_active !== false).length,
+    inactiveCompanies: orgs.filter((o: any) => o.is_active === false).length,
+    totalUsers:        membersRes.count ?? 0,
+    aiCallsToday:      aiTodayRes.count ?? 0,
+    aiErrorsTotal:     aiErrorsRes.count ?? 0,
   };
 }
 
@@ -157,17 +327,13 @@ export const handler: Handler = async (event) => {
     'Access-Control-Allow-Methods': 'POST, OPTIONS',
   };
 
-  if (event.httpMethod === 'OPTIONS') {
-    return { statusCode: 204, headers: corsHeaders, body: '' };
-  }
+  if (event.httpMethod === 'OPTIONS') return { statusCode: 204, headers: corsHeaders, body: '' };
   if (event.httpMethod !== 'POST') {
     return { statusCode: 405, headers: corsHeaders, body: JSON.stringify({ error: 'Method not allowed' }) };
   }
 
   let body: any = {};
-  try {
-    body = JSON.parse(event.body ?? '{}');
-  } catch {
+  try { body = JSON.parse(event.body ?? '{}'); } catch {
     return { statusCode: 400, headers: corsHeaders, body: JSON.stringify({ error: 'Invalid JSON' }) };
   }
 
@@ -177,23 +343,23 @@ export const handler: Handler = async (event) => {
   try {
     let result: object;
 
-    if (action === 'verify_admin') {
-      // verify_admin does its own JWT parsing (handles seeding)
-      result = await handleVerifyAdmin(body, authHeader);
+    // Pre-auth actions — no JWT needed
+    if (action === 'request_admin_magic_link') {
+      result = await handleRequestAdminMagicLink(body);
+
+    } else if (action === 'verify_admin') {
+      result = await handleVerifyAdmin(authHeader);
+
     } else {
-      // All other actions require a verified admin
-      const { email } = await verifyAdminJwt(authHeader);
+      // All other actions require a verified admin JWT
+      await verifyAdminJwt(authHeader);
 
       switch (action) {
         case 'admin_dashboard':
-          result = await handleAdminDashboard(email);
+          result = await handleAdminDashboard();
           break;
         default:
-          return {
-            statusCode: 400,
-            headers: corsHeaders,
-            body: JSON.stringify({ error: `Unknown action: ${action}` }),
-          };
+          return { statusCode: 400, headers: corsHeaders, body: JSON.stringify({ error: `Unknown action: ${action}` }) };
       }
     }
 
@@ -205,10 +371,6 @@ export const handler: Handler = async (event) => {
   } catch (err: any) {
     const status = err?.status ?? 500;
     console.error(`[admin] action=${action} error:`, err?.message ?? err);
-    return {
-      statusCode: status,
-      headers: corsHeaders,
-      body: JSON.stringify({ error: err?.message ?? 'Internal server error' }),
-    };
+    return { statusCode: status, headers: corsHeaders, body: JSON.stringify({ error: err?.message ?? 'Internal server error' }) };
   }
 };

--- a/supabase/migrations/014_platform_admins.sql
+++ b/supabase/migrations/014_platform_admins.sql
@@ -1,0 +1,19 @@
+-- Migration 014: platform_admins table
+-- Stores Platform Admin accounts (separate from tenant users / org_members).
+-- RLS is NOT enabled — all access goes through the Netlify admin.ts function
+-- using the service-role key.  No tenant-side code ever touches this table.
+
+CREATE TABLE IF NOT EXISTS public.platform_admins (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  email       text        NOT NULL UNIQUE,
+  is_active   boolean     NOT NULL DEFAULT true,
+  created_by  uuid        REFERENCES public.platform_admins(id) ON DELETE SET NULL,
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+-- Index for fast email lookups on every admin request
+CREATE INDEX IF NOT EXISTS idx_platform_admins_email ON public.platform_admins(email);
+
+-- Note: the first admin row is seeded at runtime by admin.ts when
+-- PLATFORM_ADMIN_EMAIL is set and the table is empty.
+-- No seed SQL here so the email stays out of version control.


### PR DESCRIPTION
Closes #72

## Summary
- **/admin route** — `index.tsx` detects `/admin` path and loads `AdminApp` instead of the tenant `App`
- **SPA redirects** — `netlify.toml` now serves `index.html` for both `/*` and `/admin/*`
- **platform_admins table** — migration `014`, service-role only, no RLS
- **Netlify function `admin.ts`** — JWT auth middleware + `verify_admin` + `admin_dashboard` actions
- **First admin seeding** — `PLATFORM_ADMIN_EMAIL` env var seeds the first row on first login when table is empty
- **AdminLoginScreen** — dark-themed login form with Supabase Auth + admin check
- **AdminShell** — sidebar (Dashboard, Companies, AI Usage, Admin Users) + breadcrumb header
- **AdminDashboard** — stat cards: total/active/inactive companies, members, AI calls today, total errors

## Required before deploy
1. Run `supabase/migrations/014_platform_admins.sql`
2. Set `PLATFORM_ADMIN_EMAIL=<your-admin-email>` in Netlify env vars (server-only, no VITE_ prefix)
3. Create that email's account in Supabase Auth (Dashboard → Authentication → Users → Invite)
4. Visit `https://your-domain.com/admin` and sign in — first login auto-seeds the admin row

## Stub sections
Companies, AI Usage, Admin Users nav items show "coming soon" placeholders — implemented in issues #73–#77.

## Test plan
- [x] Visiting `/admin` shows the admin login screen (not the tenant app)
- [ ] Signing in with a non-admin Supabase account returns a 403 error message
- [ ] Signing in with the PLATFORM_ADMIN_EMAIL account succeeds and shows the admin shell
- [x] Dashboard stat cards load correctly
- [ ] Session persists across page refresh (localStorage); expires after ~55 min
- [ ] Sign out clears session and returns to login screen
- [x] "Back to Tenant App" link works
- [ ] Mobile sidebar opens/closes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)