### PR TITLE
feat(admin): per-company statistics + email delivery fixes (#78)

### DIFF
--- a/components/admin/AdminLoginScreen.tsx
+++ b/components/admin/AdminLoginScreen.tsx
@@ -12,10 +12,11 @@ const AdminLoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
   const [mode, setMode]         = useState<Mode>('password');
   const [email, setEmail]       = useState('');
   const [password, setPassword] = useState('');
-  const [showPw, setShowPw]     = useState(false);
-  const [stage, setStage]       = useState<Stage>('input');
-  const [errorMsg, setError]    = useState('');
-  const [devLink, setDevLink]   = useState<string | null>(null);
+  const [showPw, setShowPw]       = useState(false);
+  const [stage, setStage]         = useState<Stage>('input');
+  const [errorMsg, setError]      = useState('');
+  const [devLink, setDevLink]     = useState<string | null>(null);
+  const [emailErr, setEmailErr]   = useState<string | null>(null);
 
   // ── Password login (bootstrap: table must be empty) ──────────────────────
   const handlePasswordLogin = async (e: React.FormEvent) => {
@@ -70,8 +71,9 @@ const AdminLoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
       const json = await res.json();
       if (!res.ok) throw new Error(json.error ?? 'Failed to send link');
 
-      // Dev mode: server returns the link directly when RESEND_API_KEY is not set
+      // dev_link is returned when Resend is not set OR when email sending fails
       if (json.dev_link) setDevLink(json.dev_link);
+      if (json.email_error) setEmailErr(json.email_error);
 
       setStage('sent');
     } catch (err: any) {
@@ -80,7 +82,7 @@ const AdminLoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
     }
   };
 
-  const handleReset = () => { setStage('input'); setError(''); setDevLink(null); };
+  const handleReset = () => { setStage('input'); setError(''); setDevLink(null); setEmailErr(null); };
 
   const switchMode = (m: Mode) => { setMode(m); handleReset(); };
 
@@ -108,10 +110,12 @@ const AdminLoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
             {devLink && (
               <div className="bg-amber-950/40 border border-amber-700/50 rounded-lg p-3 space-y-2">
                 <p className="text-xs font-semibold text-amber-400 uppercase tracking-wide">
-                  ⚠️ Dev mode — no RESEND_API_KEY set
+                  ⚠️ {emailErr ? 'Email delivery failed' : 'Dev mode — no RESEND_API_KEY set'}
                 </p>
                 <p className="text-xs text-amber-300/70">
-                  No email was sent. Use the link below to sign in:
+                  {emailErr
+                    ? `Email could not be sent (${emailErr}). Use the link below to sign in:`
+                    : 'No email was sent. Use the link below to sign in:'}
                 </p>
                 <a
                   href={devLink}

--- a/netlify/functions/admin.ts
+++ b/netlify/functions/admin.ts
@@ -33,7 +33,7 @@ const supabaseUrl    = process.env.SUPABASE_URL    ?? process.env.VITE_SUPABASE_
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
 const appUrl         = process.env.VITE_APP_URL    ?? 'http://localhost:8888';
 const resendApiKey   = process.env.RESEND_API_KEY  ?? '';
-const fromEmail      = process.env.RESEND_FROM_EMAIL ?? 'noreply@aeternum-ally.com';
+const fromEmail      = process.env.RESEND_FROM_EMAIL ?? 'noreply@aeternumally.com';
 
 function getAdminClient() {
   if (!supabaseUrl || !serviceRoleKey) throw new Error('Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');

--- a/netlify/functions/admin.ts
+++ b/netlify/functions/admin.ts
@@ -188,8 +188,15 @@ async function handleRequestAdminMagicLink(body: any): Promise<object> {
     return { sent: true, dev_link: magicLink };
   }
 
-  await sendAdminMagicLinkEmail(email, magicLink);
-  return { sent: true };
+  try {
+    await sendAdminMagicLinkEmail(email, magicLink);
+    return { sent: true };
+  } catch (emailErr: any) {
+    // Email sending failed (e.g. domain not verified in Resend).
+    // Fall back to returning the link directly so the admin is never locked out.
+    console.error('[admin] Resend failed, returning dev_link fallback:', emailErr?.message);
+    return { sent: true, dev_link: magicLink, email_error: emailErr?.message };
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -646,7 +653,12 @@ async function handleCreateCompany(body: any): Promise<object> {
     const magicLink = linkData?.properties?.action_link ?? null;
     if (magicLink) {
       if (resendApiKey) {
-        await sendOwnerInviteEmail(ownerEmail, magicLink, companyName);
+        try {
+          await sendOwnerInviteEmail(ownerEmail, magicLink, companyName);
+        } catch (emailErr: any) {
+          console.error('[admin] Owner invite email failed, using dev_link fallback:', emailErr?.message);
+          devLink = magicLink;
+        }
       } else {
         console.info(`\n[admin] ✉️  OWNER INVITE LINK (dev):\n${magicLink}\n`);
         devLink = magicLink;
@@ -839,15 +851,22 @@ async function handleAddAdmin(body: any, actorEmail: string): Promise<object> {
 
   const magicLink = linkData?.properties?.action_link ?? null;
 
-  // Send invitation email if Resend is configured
+  // Send invitation email if Resend is configured; fall back to dev_link on failure
+  let adminDevLink: string | undefined;
   if (resendApiKey && magicLink) {
-    await sendAdminInviteEmail(email, magicLink, actorEmail);
+    try {
+      await sendAdminInviteEmail(email, magicLink, actorEmail);
+    } catch (emailErr: any) {
+      console.error('[admin] Admin invite email failed, using dev_link fallback:', emailErr?.message);
+      adminDevLink = magicLink;
+    }
   } else if (magicLink) {
     console.info(`\n[admin] ✉️  ADMIN INVITE LINK (dev — no RESEND_API_KEY):\n${magicLink}\n`);
+    adminDevLink = magicLink;
   }
 
   console.info('[admin] Added platform admin:', email, 'by:', actorEmail);
-  return { added: true, reactivated: false, email, dev_link: resendApiKey ? undefined : (magicLink ?? undefined) };
+  return { added: true, reactivated: false, email, dev_link: adminDevLink };
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **CompanyStatsPanel** — full per-company detail view accessible by clicking any company name in the Companies list:
  - **Users & Roles** — total members + donut chart + percentage bars per role
  - **Invitations** — Pending/Accepted/Expired breakdown + recent invitations table
  - **AI Usage** — total/BYOK/platform counts, monthly bar chart (last 12 months), per-action table
  - **AI Errors** — grouped by error message category with count + last seen date
  - Export button wired to CompanyExportModal
- **`company_stats` backend action** — single call returns all 4 sections for a given org_id
- **Email delivery fallback** — Resend errors (e.g. domain not verified) are caught gracefully; magic link is returned in the API response instead of throwing a 500, so admins are never locked out
- **Domain fix** — corrected `aeternum-ally.com` → `aeternumally.com` in the default `RESEND_FROM_EMAIL` fallback

## Test plan
- [ ] Click a company name in Companies tab → stats panel opens
- [ ] Back button returns to company list
- [ ] All 4 stat sections render (empty states shown gracefully for orgs with no data)
- [ ] Export button on stats panel works
- [ ] Magic link login works even when Resend domain is not yet verified

## Dependencies
Requires #72, #73, #74, #77 (all merged ✅)

🤖 Generated with [Claude Code](https://claude.com/claude-code)