### PR TITLE
fix: correct magic link redirect URL (APP_URL + trailing slash)

### DIFF
--- a/netlify/functions/admin.ts
+++ b/netlify/functions/admin.ts
@@ -31,7 +31,7 @@ import crypto from 'crypto';
 // ---------------------------------------------------------------------------
 const supabaseUrl    = process.env.SUPABASE_URL    ?? process.env.VITE_SUPABASE_URL ?? '';
 const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
-const appUrl         = process.env.VITE_APP_URL    ?? 'http://localhost:8888';
+const appUrl         = (process.env.APP_URL ?? process.env.VITE_APP_URL ?? 'http://localhost:8888').replace(/\/$/, '');
 const resendApiKey   = process.env.RESEND_API_KEY  ?? '';
 const fromEmail      = process.env.RESEND_FROM_EMAIL ?? 'noreply@aeternumally.com';
 


### PR DESCRIPTION
## Summary
- Prefer `APP_URL` (server-only env var) over `VITE_APP_URL` when building the `redirectTo` URL for admin magic links
- Strip trailing slash with `.replace(/\/$/, '')` so the redirect target is `https://demo.aeternumally.com/admin` not `https://demo.aeternumally.com//admin`

## Root cause
`VITE_APP_URL` was used server-side but may not be set in Netlify's function environment. A trailing slash on the value also produced a double-slash in the redirect path. The magic link email was sending `redirect_to=https://demo.aeternumally.com/` (site root) instead of `.../admin`.

## Required Supabase config change
After merging, add the following URL to **Supabase → Authentication → URL Configuration → Redirect URLs**:
```
https://demo.aeternumally.com/admin
```
Without this, Supabase will ignore the `redirectTo` parameter and fall back to the site URL even with the admin API.

## Required Netlify env var
Set `APP_URL=https://demo.aeternumally.com` in Netlify environment variables (server-side, no `VITE_` prefix needed).

## Test plan
- [ ] Request magic link from `/admin` login screen
- [ ] Check email — link should contain `redirect_to=https://demo.aeternumally.com/admin`
- [ ] Click link → should land on `/admin` (not site root `/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)