### PR TITLE
fix: store admin JWT after magic link verification

### DIFF
--- a/AdminApp.tsx
+++ b/AdminApp.tsx
@@ -90,7 +90,7 @@ const AdminApp: React.FC = () => {
           window.history.replaceState(null, '', '/admin');
 
           const newSession: AdminSession = {
-            token:     sbSession.access_token,
+            token:     json.token,   // custom admin JWT returned by verify_admin
             email:     json.email,
             expiresAt: Date.now() + 55 * 60 * 1000,
           };


### PR DESCRIPTION
## Summary
- After a magic link callback, `AdminApp.tsx` was saving `sbSession.access_token` (a Supabase JWT) as the admin session token
- All admin API endpoints call `verifyAdminToken()` which expects a custom HMAC-signed JWT — so every request immediately failed with **"Invalid admin token"**
- Fixed to use `json.token` returned by the `verify_admin` action, which is the properly signed admin JWT

## Root cause
```ts
// Before (broken) — saves Supabase token, not admin JWT
token: sbSession.access_token,

// After (fixed) — saves the custom admin JWT from verify_admin response
token: json.token,
```

## Test plan
- [ ] Request a magic link from the admin login screen
- [ ] Click the link in the email → should land on `/admin`
- [ ] Admin shell loads without "Invalid admin token" error
- [ ] Dashboard, Companies, AI Usage, Admin Users panels all load correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)