### PR TITLE
feat(#90): AI Usage by Month + AI Calls by Feature charts on Dashboard

### DIFF
--- a/components/admin/AdminDashboard.tsx
+++ b/components/admin/AdminDashboard.tsx
@@ -1,6 +1,16 @@
-import React, { useState, useEffect } from 'react';
-import { Building2, Users, Zap, AlertTriangle, Loader2, RefreshCw, TrendingUp, ShieldOff } from 'lucide-react';
+import React, { useState, useEffect, useCallback } from 'react';
+import {
+  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip,
+  ResponsiveContainer, Legend,
+} from 'recharts';
+import {
+  Building2, Users, Zap, AlertTriangle, Loader2,
+  RefreshCw, TrendingUp, ShieldOff,
+} from 'lucide-react';
 
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
 interface DashboardStats {
   totalCompanies:    number;
   activeCompanies:   number;
@@ -10,10 +20,228 @@ interface DashboardStats {
   aiErrorsTotal:     number;
 }
 
-interface Props {
-  adminToken: string;
+interface MonthRow {
+  month:    string;  // YYYY-MM
+  byok:     number;
+  platform: number;
+  total:    number;
 }
 
+interface ActionSeries {
+  action: string;
+  data:   number[];  // length 12
+}
+
+interface Props { adminToken: string; }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+async function callAdmin(action: string, token: string, body?: object) {
+  const res = await fetch('/.netlify/functions/admin', {
+    method:  'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
+    body:    JSON.stringify({ action, ...body }),
+  });
+  const json = await res.json();
+  if (!res.ok) throw new Error(json.error ?? `Request failed (${res.status})`);
+  return json;
+}
+
+const MONTH_LABELS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+const monthLabel = (ym: string) => {
+  const m = parseInt(ym.split('-')[1], 10) - 1;
+  return MONTH_LABELS[m] ?? ym;
+};
+
+// Colour palette for feature series (up to 10 actions)
+const ACTION_COLORS = [
+  '#16a34a','#7c3aed','#2563eb','#d97706','#dc2626',
+  '#0891b2','#9333ea','#65a30d','#c2410c','#475569',
+];
+
+const currentYear = new Date().getFullYear();
+const YEAR_OPTIONS = Array.from({ length: 4 }, (_, i) => currentYear - i);
+
+// ---------------------------------------------------------------------------
+// Year selector
+// ---------------------------------------------------------------------------
+const YearSelect: React.FC<{ value: number; onChange: (y: number) => void }> = ({ value, onChange }) => (
+  <select
+    value={value}
+    onChange={e => onChange(Number(e.target.value))}
+    className="text-xs font-medium bg-slate-100 dark:bg-slate-700 text-slate-600 dark:text-slate-300 border border-slate-200 dark:border-slate-600 rounded-lg px-2 py-1 cursor-pointer focus:outline-none focus:ring-2 focus:ring-esg-500"
+  >
+    {YEAR_OPTIONS.map(y => <option key={y} value={y}>{y}</option>)}
+  </select>
+);
+
+// ---------------------------------------------------------------------------
+// Chart card wrapper
+// ---------------------------------------------------------------------------
+const ChartCard: React.FC<{
+  title: string;
+  year: number;
+  onYearChange: (y: number) => void;
+  loading: boolean;
+  error: string;
+  children: React.ReactNode;
+}> = ({ title, year, onYearChange, loading, error, children }) => (
+  <div className="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 p-5 flex flex-col min-h-[260px]">
+    <div className="flex items-center justify-between mb-4">
+      <p className="text-sm font-semibold text-slate-700 dark:text-slate-200">{title}</p>
+      <YearSelect value={year} onChange={onYearChange} />
+    </div>
+
+    {loading ? (
+      <div className="flex-1 flex items-center justify-center gap-2 text-slate-400">
+        <Loader2 className="w-4 h-4 animate-spin" />
+        <span className="text-xs">Loading…</span>
+      </div>
+    ) : error ? (
+      <div className="flex-1 flex items-center justify-center text-xs text-red-400 text-center px-4">
+        {error}
+      </div>
+    ) : (
+      children
+    )}
+  </div>
+);
+
+// ---------------------------------------------------------------------------
+// Block 1: AI Usage by Month (platform vs BYOK)
+// ---------------------------------------------------------------------------
+const AIUsageByMonthChart: React.FC<{ adminToken: string }> = ({ adminToken }) => {
+  const [year,    setYear]    = useState(currentYear);
+  const [rows,    setRows]    = useState<MonthRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error,   setError]   = useState('');
+
+  const load = useCallback(async (y: number) => {
+    setLoading(true); setError('');
+    try {
+      const json = await callAdmin('admin_ai_usage_by_month', adminToken, { year: y });
+      setRows(json.months ?? []);
+    } catch (err: any) {
+      setError(err?.message ?? 'Failed to load');
+    } finally {
+      setLoading(false);
+    }
+  }, [adminToken]);
+
+  useEffect(() => { load(year); }, [year, load]);
+
+  const chartData = rows.map(r => ({ name: monthLabel(r.month), platform: r.platform, byok: r.byok }));
+  const isEmpty   = rows.every(r => r.total === 0);
+
+  return (
+    <ChartCard title="AI Usage by Month" year={year} onYearChange={y => { setYear(y); }} loading={loading} error={error}>
+      {isEmpty ? (
+        <div className="flex-1 flex flex-col items-center justify-center text-slate-400 gap-2">
+          <Zap className="w-6 h-6 opacity-30" />
+          <p className="text-xs">No AI calls in {year}</p>
+        </div>
+      ) : (
+        <ResponsiveContainer width="100%" height={180}>
+          <BarChart data={chartData} margin={{ top: 4, right: 4, left: -22, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#334155" strokeOpacity={0.3} />
+            <XAxis dataKey="name" tick={{ fontSize: 10, fill: '#94a3b8' }} />
+            <YAxis tick={{ fontSize: 10, fill: '#94a3b8' }} allowDecimals={false} />
+            <Tooltip
+              contentStyle={{ background: '#1e293b', border: '1px solid #334155', borderRadius: 8, fontSize: 11 }}
+              labelStyle={{ color: '#f1f5f9', fontWeight: 600 }}
+            />
+            <Legend wrapperStyle={{ fontSize: 11, color: '#94a3b8' }} />
+            <Bar dataKey="platform" name="Platform" stackId="a" fill="#16a34a" />
+            <Bar dataKey="byok"     name="BYOK"     stackId="a" fill="#7c3aed" radius={[3,3,0,0]} />
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+    </ChartCard>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Block 2: AI Calls by Feature by Month
+// ---------------------------------------------------------------------------
+const AICallsByFeatureChart: React.FC<{ adminToken: string }> = ({ adminToken }) => {
+  const [year,    setYear]    = useState(currentYear);
+  const [months,  setMonths]  = useState<string[]>([]);
+  const [series,  setSeries]  = useState<ActionSeries[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error,   setError]   = useState('');
+
+  const load = useCallback(async (y: number) => {
+    setLoading(true); setError('');
+    try {
+      const json = await callAdmin('admin_ai_usage_by_action_by_month', adminToken, { year: y });
+      setMonths(json.months ?? []);
+      setSeries(json.series ?? []);
+    } catch (err: any) {
+      setError(err?.message ?? 'Failed to load');
+    } finally {
+      setLoading(false);
+    }
+  }, [adminToken]);
+
+  useEffect(() => { load(year); }, [year, load]);
+
+  // Reshape: one row per month, one key per action
+  const chartData = (months.length > 0 ? months : Array.from({ length: 12 }, (_, i) =>
+    `${year}-${String(i + 1).padStart(2, '0')}`
+  )).map((m, mIdx) => {
+    const row: Record<string, string | number> = { name: monthLabel(m) };
+    series.forEach(s => { row[s.action] = s.data[mIdx] ?? 0; });
+    return row;
+  });
+
+  const isEmpty = series.length === 0 || series.every(s => s.data.every(n => n === 0));
+
+  // Shorten action names for legend/tooltip (strip common prefix patterns)
+  const shortName = (a: string) => a.replace(/_/g, ' ').replace(/^(generate|suggest|analyse|analyze|assess|create|get)\s/, '');
+
+  return (
+    <ChartCard title="AI Calls by Feature by Month" year={year} onYearChange={y => { setYear(y); }} loading={loading} error={error}>
+      {isEmpty ? (
+        <div className="flex-1 flex flex-col items-center justify-center text-slate-400 gap-2">
+          <Zap className="w-6 h-6 opacity-30" />
+          <p className="text-xs">No AI calls in {year}</p>
+        </div>
+      ) : (
+        <ResponsiveContainer width="100%" height={180}>
+          <BarChart data={chartData} margin={{ top: 4, right: 4, left: -22, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#334155" strokeOpacity={0.3} />
+            <XAxis dataKey="name" tick={{ fontSize: 10, fill: '#94a3b8' }} />
+            <YAxis tick={{ fontSize: 10, fill: '#94a3b8' }} allowDecimals={false} />
+            <Tooltip
+              contentStyle={{ background: '#1e293b', border: '1px solid #334155', borderRadius: 8, fontSize: 11 }}
+              labelStyle={{ color: '#f1f5f9', fontWeight: 600 }}
+              formatter={(value: number, name: string) => [value, shortName(name)]}
+            />
+            <Legend
+              wrapperStyle={{ fontSize: 10, color: '#94a3b8' }}
+              formatter={(value: string) => shortName(value)}
+            />
+            {series.map((s, i) => (
+              <Bar
+                key={s.action}
+                dataKey={s.action}
+                name={s.action}
+                stackId="a"
+                fill={ACTION_COLORS[i % ACTION_COLORS.length]}
+                radius={i === series.length - 1 ? [3,3,0,0] : undefined}
+              />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+      )}
+    </ChartCard>
+  );
+};
+
+// ---------------------------------------------------------------------------
+// Main dashboard
+// ---------------------------------------------------------------------------
 const AdminDashboard: React.FC<Props> = ({ adminToken }) => {
   const [stats, setStats]     = useState<DashboardStats | null>(null);
   const [loading, setLoading] = useState(true);
@@ -23,16 +251,7 @@ const AdminDashboard: React.FC<Props> = ({ adminToken }) => {
     setLoading(true);
     setError('');
     try {
-      const res = await fetch('/.netlify/functions/admin', {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${adminToken}`,
-        },
-        body: JSON.stringify({ action: 'admin_dashboard' }),
-      });
-      const json = await res.json();
-      if (!res.ok) throw new Error(json.error ?? 'Failed to load stats');
+      const json = await callAdmin('admin_dashboard', adminToken);
       setStats(json);
     } catch (err: any) {
       setError(err?.message ?? 'Error loading dashboard');
@@ -45,7 +264,7 @@ const AdminDashboard: React.FC<Props> = ({ adminToken }) => {
 
   return (
     <div className="space-y-6 animate-in fade-in duration-500">
-      {/* Header row */}
+      {/* Header */}
       <div className="flex items-center justify-between">
         <div>
           <h1 className="text-2xl font-bold text-slate-800 dark:text-white">Platform Overview</h1>
@@ -116,10 +335,10 @@ const AdminDashboard: React.FC<Props> = ({ adminToken }) => {
             />
           </div>
 
-          {/* Placeholder panels for future issues */}
+          {/* Chart panels */}
           <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
-            <PlaceholderPanel title="AI Usage by Month" issueRef="#77" />
-            <PlaceholderPanel title="Top Active Companies" issueRef="#74" />
+            <AIUsageByMonthChart    adminToken={adminToken} />
+            <AICallsByFeatureChart  adminToken={adminToken} />
           </div>
         </>
       ) : null}
@@ -128,9 +347,8 @@ const AdminDashboard: React.FC<Props> = ({ adminToken }) => {
 };
 
 // ---------------------------------------------------------------------------
-// Sub-components
+// StatCard
 // ---------------------------------------------------------------------------
-
 const COLORS: Record<string, string> = {
   blue:   'bg-blue-50 dark:bg-blue-900/20 border-blue-100 dark:border-blue-800',
   violet: 'bg-violet-50 dark:bg-violet-900/20 border-violet-100 dark:border-violet-800',
@@ -155,13 +373,6 @@ const StatCard: React.FC<{
       <p className="text-2xl font-bold text-slate-800 dark:text-white mt-0.5">{value.toLocaleString()}</p>
       <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5 truncate">{sub}</p>
     </div>
-  </div>
-);
-
-const PlaceholderPanel: React.FC<{ title: string; issueRef: string }> = ({ title, issueRef }) => (
-  <div className="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 p-6 flex flex-col items-center justify-center min-h-[180px] text-center">
-    <p className="text-sm font-medium text-slate-500 dark:text-slate-400">{title}</p>
-    <p className="text-xs text-slate-400 dark:text-slate-500 mt-1">Coming in issue {issueRef}</p>
   </div>
 );
 

--- a/netlify/functions/admin.ts
+++ b/netlify/functions/admin.ts
@@ -405,36 +405,82 @@ async function handleAdminAIUsageSummary(): Promise<object> {
 }
 
 // ---------------------------------------------------------------------------
-// Post-auth: admin_ai_usage_by_month  (last 12 months, stacked by quota_type)
+// Post-auth: admin_ai_usage_by_month  (12 months of a given year, stacked by quota_type)
+// Optional body param: year (number, defaults to current year)
 // ---------------------------------------------------------------------------
-async function handleAdminAIUsageByMonth(): Promise<object> {
-  const sb    = getAdminClient();
-  const since = new Date();
-  since.setMonth(since.getMonth() - 11);
-  since.setDate(1);
-  since.setHours(0, 0, 0, 0);
+async function handleAdminAIUsageByMonth(year?: number): Promise<object> {
+  const sb        = getAdminClient();
+  const targetYear = year ?? new Date().getFullYear();
+  const since      = new Date(targetYear, 0, 1, 0, 0, 0, 0);   // Jan 1
+  const until      = new Date(targetYear + 1, 0, 1, 0, 0, 0, 0); // Jan 1 next year
 
-  const rows = await fetchAIUsage(sb, since.toISOString());
+  let q = sb.from('ai_usage_log')
+    .select('quota_type, created_at')
+    .gte('created_at', since.toISOString())
+    .lt('created_at', until.toISOString());
+  const { data, error } = await q;
+  if (error) throw Object.assign(new Error(error.message), { status: 500 });
+  const rows = data ?? [];
 
-  // Build map: YYYY-MM → { byok, platform, total }
+  // Build 12-slot map: YYYY-MM → { byok, platform, total }
   const map: Record<string, { month: string; byok: number; platform: number; total: number }> = {};
-
-  for (let i = 0; i < 12; i++) {
-    const d = new Date(since);
-    d.setMonth(d.getMonth() + i);
-    const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}`;
-    map[key] = { month: key, byok: 0, platform: 0, total: 0 };
+  for (let m = 0; m < 12; m++) {
+    const key = `${targetYear}-${String(m + 1).padStart(2, '0')}`;
+    map[key]  = { month: key, byok: 0, platform: 0, total: 0 };
   }
 
   for (const r of rows) {
-    const key = r.created_at.slice(0, 7);
+    const key = (r.created_at as string).slice(0, 7);
     if (!map[key]) continue;
     map[key].total += 1;
     if (r.quota_type === 'byok') map[key].byok += 1;
     else                          map[key].platform += 1;
   }
 
-  return { months: Object.values(map) };
+  return { year: targetYear, months: Object.values(map) };
+}
+
+// ---------------------------------------------------------------------------
+// Post-auth: admin_ai_usage_by_action_by_month
+// Returns call counts grouped by action × month for a given year.
+// Response: { year, months: string[], series: { action, data: number[] }[] }
+// Optional body param: year (number, defaults to current year)
+// ---------------------------------------------------------------------------
+async function handleAdminAIUsageByActionByMonth(year?: number): Promise<object> {
+  const sb         = getAdminClient();
+  const targetYear = year ?? new Date().getFullYear();
+  const since      = new Date(targetYear, 0, 1, 0, 0, 0, 0);
+  const until      = new Date(targetYear + 1, 0, 1, 0, 0, 0, 0);
+
+  const { data, error } = await sb.from('ai_usage_log')
+    .select('action, created_at')
+    .gte('created_at', since.toISOString())
+    .lt('created_at', until.toISOString());
+  if (error) throw Object.assign(new Error(error.message), { status: 500 });
+  const rows = data ?? [];
+
+  // month keys Jan..Dec
+  const monthKeys = Array.from({ length: 12 }, (_, i) =>
+    `${targetYear}-${String(i + 1).padStart(2, '0')}`);
+
+  // action → monthIndex → count
+  const actionMap: Record<string, number[]> = {};
+  for (const r of rows) {
+    const action = (r.action as string) ?? 'unknown';
+    const mIdx   = monthKeys.indexOf((r.created_at as string).slice(0, 7));
+    if (mIdx === -1) continue;
+    if (!actionMap[action]) actionMap[action] = new Array(12).fill(0);
+    actionMap[action][mIdx] += 1;
+  }
+
+  // Sort series by total calls descending, cap at top 10 to keep chart readable
+  const series = Object.entries(actionMap)
+    .map(([action, data]) => ({ action, data, total: data.reduce((s, n) => s + n, 0) }))
+    .sort((a, b) => b.total - a.total)
+    .slice(0, 10)
+    .map(({ action, data }) => ({ action, data }));
+
+  return { year: targetYear, months: monthKeys, series };
 }
 
 // ---------------------------------------------------------------------------
@@ -1100,10 +1146,11 @@ export const handler: Handler = async (event) => {
       switch (action) {
         case 'admin_dashboard':    result = await handleAdminDashboard();                        break;
         case 'company_stats':           result = await handleCompanyStats(body);               break;
-        case 'admin_ai_usage_summary':  result = await handleAdminAIUsageSummary();            break;
-        case 'admin_ai_usage_by_month': result = await handleAdminAIUsageByMonth();            break;
-        case 'admin_ai_usage_by_action':result = await handleAdminAIUsageByAction();           break;
-        case 'admin_ai_top_orgs':       result = await handleAdminAITopOrgs();                 break;
+        case 'admin_ai_usage_summary':          result = await handleAdminAIUsageSummary();                           break;
+        case 'admin_ai_usage_by_month':         result = await handleAdminAIUsageByMonth(body.year);                  break;
+        case 'admin_ai_usage_by_action':        result = await handleAdminAIUsageByAction();                          break;
+        case 'admin_ai_usage_by_action_by_month': result = await handleAdminAIUsageByActionByMonth(body.year);        break;
+        case 'admin_ai_top_orgs':               result = await handleAdminAITopOrgs();                                break;
         case 'export_company_data':     result = await handleExportCompanyData(body);          break;
         case 'create_company':          result = await handleCreateCompany(body);              break;
         case 'list_companies':          result = await handleListCompanies();                   break;


### PR DESCRIPTION
Closes #90

## Summary
- Replaces both placeholder panels on the Admin Dashboard with live charts
- Both panels have an **independent year selector** (current year default, last 4 years available)

### Block 1 — AI Usage by Month
Stacked bar chart: **Platform** (green) + **BYOK** (purple) calls per month for the selected year.

### Block 2 — AI Calls by Feature by Month
Stacked bar chart showing calls per AI action (feature) per month for the selected year. Shows top-10 actions by total call count to keep the chart readable. Action names are shortened in the legend/tooltip.

## Backend changes
| Action | Change |
|---|---|
| `admin_ai_usage_by_month` | Now accepts optional `year` body param; returns full 12-month window for that year (was: rolling last-12-months) |
| `admin_ai_usage_by_action_by_month` | **New action** — returns `{ year, months[], series[{ action, data[] }] }` |

## Test plan
- [ ] Dashboard loads — both chart panels appear instead of "Coming soon" placeholders
- [ ] Charts show correct data for current year
- [ ] Changing year dropdown updates that chart independently
- [ ] Empty state (Zap icon + message) shown for years with no data
- [ ] Dark mode styling matches rest of admin portal

🤖 Generated with [Claude Code](https://claude.com/claude-code)