### PR TITLE
fix: Remove batching in report generation to prevent timeout

### DIFF
--- a/components/SustainabilityStatement.tsx
+++ b/components/SustainabilityStatement.tsx
@@ -1,8 +1,8 @@
 
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import { CompanyProfile, AssessmentData, SustainabilityBusinessModel } from '../types';
 import { GRI_MAPPING } from '../constants';
-import { generateSustainabilityStatement, GeneratedStatement } from '../services/geminiService';
+import { generateSustainabilityHeader, generateTopicalDisclosure, GeneratedStatement } from '../services/geminiService';
 import { logError } from '../services/errorLogService';
 import { FileText, Download, Loader2, Book, RefreshCw, ShieldCheck, AlertCircle } from 'lucide-react';
 
@@ -20,12 +20,39 @@ const SustainabilityStatement: React.FC<Props> = ({ profile, assessments, canvas
 
   const materialTopics = assessments.filter(a => a.isMaterial);
 
+  useEffect(() => {
+    const cached = localStorage.getItem(`report_cache_${organizationId}`);
+    if (cached) {
+      try {
+        setGeneratedContent(JSON.parse(cached));
+      } catch (e) {
+        console.error("Failed to parse cached report:", e);
+      }
+    }
+  }, [organizationId]);
+
   const handleGenerate = async () => {
     setLoading(true);
     setError(null);
     try {
-      const result = await generateSustainabilityStatement(profile, materialTopics);
+      // 1. Generate Header
+      const header = await generateSustainabilityHeader(profile, materialTopics);
+      
+      // 2. Generate Topics in parallel
+      const topicPromises = materialTopics.map(topic => generateTopicalDisclosure(profile, topic));
+      const topics = await Promise.all(topicPromises);
+      
+      const result: GeneratedStatement = {
+        generalDisclosure: header.generalDisclosure,
+        strategyDisclosure: header.strategyDisclosure,
+        topics: topics
+      };
+      
       setGeneratedContent(result);
+      
+      // Save to cache
+      localStorage.setItem(`report_cache_${organizationId}`, JSON.stringify(result));
+      
     } catch (e: any) {
       const msg = e?.message ?? 'Failed to generate the report. Please try again.';
       setError(msg);
@@ -91,13 +118,23 @@ const SustainabilityStatement: React.FC<Props> = ({ profile, assessments, canvas
               )}
             </div>
           ) : (
-             <button 
-                onClick={() => window.print()}
-                className="flex items-center justify-center gap-2 bg-slate-900 dark:bg-white text-white dark:text-slate-900 px-6 py-2.5 rounded-lg font-medium hover:bg-slate-800 dark:hover:bg-slate-100 shadow-lg transition-all w-full sm:w-auto"
-            >
-                <Download className="w-4 h-4" />
-                Export to PDF
-            </button>
+            <div className="flex gap-2 w-full sm:w-auto">
+              <button 
+                  onClick={() => window.print()}
+                  className="flex items-center justify-center gap-2 bg-slate-900 dark:bg-white text-white dark:text-slate-900 px-6 py-2.5 rounded-lg font-medium hover:bg-slate-800 dark:hover:bg-slate-100 shadow-lg transition-all w-full sm:w-auto"
+              >
+                  <Download className="w-4 h-4" />
+                  Export to PDF
+              </button>
+              <button 
+                  onClick={handleGenerate}
+                  disabled={loading}
+                  className="flex items-center justify-center gap-2 border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-300 px-4 py-2 rounded-lg font-medium hover:bg-slate-50 dark:hover:bg-slate-800 transition-all w-full sm:w-auto disabled:opacity-60 text-sm"
+              >
+                  {loading ? <Loader2 className="w-3 h-3 animate-spin" /> : <RefreshCw className="w-3 h-3" />}
+                  {loading ? 'Generating…' : 'Regenerate'}
+              </button>
+            </div>
           )}
         </div>
       </div>

--- a/components/SustainabilityStatement.tsx
+++ b/components/SustainabilityStatement.tsx
@@ -2,7 +2,7 @@
 import React, { useState, useEffect } from 'react';
 import { CompanyProfile, AssessmentData, SustainabilityBusinessModel } from '../types';
 import { GRI_MAPPING } from '../constants';
-import { generateSustainabilityHeader, generateTopicalDisclosure, GeneratedStatement } from '../services/geminiService';
+import { triggerReportGeneration, getReportStatus, GeneratedStatement } from '../services/geminiService';
 import { logError } from '../services/errorLogService';
 import { FileText, Download, Loader2, Book, RefreshCw, ShieldCheck, AlertCircle } from 'lucide-react';
 
@@ -20,51 +20,64 @@ const SustainabilityStatement: React.FC<Props> = ({ profile, assessments, canvas
 
   const materialTopics = assessments.filter(a => a.isMaterial);
 
+  const [polling, setPolling] = useState(false);
+
   useEffect(() => {
-    const cached = localStorage.getItem(`report_cache_${organizationId}`);
-    if (cached) {
-      try {
-        setGeneratedContent(JSON.parse(cached));
-      } catch (e) {
-        console.error("Failed to parse cached report:", e);
+    // Check initial status
+    const checkStatus = async () => {
+      const data = await getReportStatus();
+      if (data) {
+        if (data.status === 'completed' && data.result) {
+          setGeneratedContent(data.result);
+        } else if (data.status === 'processing') {
+          setPolling(true);
+          setLoading(true);
+        } else if (data.status === 'failed') {
+          setError(data.error || "Generation failed");
+        }
       }
-    }
+    };
+    checkStatus();
   }, [organizationId]);
+
+  useEffect(() => {
+    let interval: NodeJS.Timeout;
+    if (polling) {
+      interval = setInterval(async () => {
+        const data = await getReportStatus();
+        if (data) {
+          if (data.status === 'completed') {
+            setGeneratedContent(data.result);
+            setPolling(false);
+            setLoading(false);
+          } else if (data.status === 'failed') {
+            setError(data.error || "Generation failed");
+            setPolling(false);
+            setLoading(false);
+          }
+        }
+      }, 5000); // Poll every 5 seconds
+    }
+    return () => clearInterval(interval);
+  }, [polling]);
 
   const handleGenerate = async () => {
     setLoading(true);
     setError(null);
     try {
-      // 1. Generate Header
-      const header = await generateSustainabilityHeader(profile, materialTopics);
-      
-      // 2. Generate Topics in parallel
-      const topicPromises = materialTopics.map(topic => generateTopicalDisclosure(profile, topic));
-      const topics = await Promise.all(topicPromises);
-      
-      const result: GeneratedStatement = {
-        generalDisclosure: header.generalDisclosure,
-        strategyDisclosure: header.strategyDisclosure,
-        topics: topics
-      };
-      
-      setGeneratedContent(result);
-      
-      // Save to cache
-      localStorage.setItem(`report_cache_${organizationId}`, JSON.stringify(result));
-      
+      await triggerReportGeneration(profile, materialTopics);
+      setPolling(true);
     } catch (e: any) {
-      const msg = e?.message ?? 'Failed to generate the report. Please try again.';
+      const msg = e?.message ?? 'Failed to start report generation.';
       setError(msg);
+      setLoading(false);
       logError({
         context: 'sustainability-statement',
-        action: 'generate_report',
+        action: 'trigger_report',
         error: e,
         organizationId,
         metadata: { topic_count: materialTopics.length },
       });
-    } finally {
-      setLoading(false);
     }
   };
 

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -282,7 +282,7 @@ async function runAction(
     case "generateKPISuggestions":
       return generateKPISuggestions(ai, model, params);
     case "triggerReportGeneration":
-      return triggerReportGeneration(params);
+      return triggerReportGeneration(event, params);
     case "analyzeTopicQuality":
       return analyzeTopicQuality(ai, model, params);
     case "analyzeDMASynthesis":
@@ -814,17 +814,22 @@ Return ONLY valid JSON, no markdown:
   }
 }
 
-async function triggerReportGeneration({ organization_id, profile, materialAssessments }: any) {
-  const url = `${process.env.URL}/.netlify/functions/report-background`;
+async function triggerReportGeneration(event: any, { organization_id, profile, materialAssessments }: any) {
+  const host = event.headers.host || event.headers.Host;
+  const protocol = host.startsWith('localhost') ? 'http' : 'https';
+  const url = `${protocol}://${host}/.netlify/functions/report-background`;
+  
+  console.log(`[api] Triggering background report at ${url}`);
   
   try {
-    await fetch(url, {
+    const resp = await fetch(url, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ organization_id, profile, materialAssessments }),
     });
+    console.log(`[api] Background function trigger status: ${resp.status}`);
   } catch (e) {
-    console.error("Failed to trigger background function:", e);
+    console.error("[api] Failed to trigger background function:", e);
   }
 
   return {

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -168,7 +168,7 @@ const handler = async (event: any) => {
 
   try {
     const outcome = await Promise.race([
-      runAction(ai, model, action, params),
+      runAction(ai, model, action, params, event),
       fencePromise,
     ]);
     clearTimeout(fenceId!);
@@ -266,7 +266,8 @@ async function runAction(
   ai: GoogleGenAI,
   model: string,
   action: string,
-  params: any
+  params: any,
+  event: any
 ): Promise<{ result: any; inputTokens: number; outputTokens: number }> {
   switch (action) {
     case "generateAssessmentSuggestions":

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -817,7 +817,7 @@ Return ONLY valid JSON, no markdown:
 async function generateSustainabilityStatement(
   ai: GoogleGenAI,
   model: string,
-  { profile, materialAssessments }: any
+  { profile, materialAssessments, mode, targetTopic }: any
 ) {
   if (!materialAssessments || materialAssessments.length === 0) {
     return {
@@ -829,29 +829,55 @@ async function generateSustainabilityStatement(
 
   const companyContext = buildCompanyContext(profile);
 
-  const topicSummary = materialAssessments
-    .map((a: any) => `- ${a.topic} (impact score: ${a.impactMaterialityValue}/100, financial score: ${a.financialMaterialityValue}/100): impact: ${a.impactDescription}; financial: ${a.financialDescription}`)
-    .join("\n");
+  if (mode === 'header') {
+    const topicSummary = materialAssessments
+      .map((a: any) => `- ${a.topic} (impact score: ${a.impactMaterialityValue}/100, financial score: ${a.financialMaterialityValue}/100): impact: ${a.impactDescription}; financial: ${a.financialDescription}`)
+      .join("\n");
 
-  // ── Call 1: Header sections (fast — no per-topic content) ──────────────────
-  const headerPrompt = `
-    Act as a Sustainability Reporting Officer drafting a "Sustainability Statement" aligned with ESRS and GRI Standards.
+    const headerPrompt = `
+      Act as a Sustainability Reporting Officer drafting a "Sustainability Statement" aligned with ESRS and GRI Standards.
 
-    ${companyContext}
+      ${companyContext}
 
-    Material topics identified (above threshold of 40/100 on either axis):
-    ${topicSummary}
+      Material topics identified (above threshold of 40/100 on either axis):
+      ${topicSummary}
 
-    Generate ONLY the two header sections below as JSON.
+      Generate ONLY the two header sections below as JSON.
 
-    1. generalDisclosure: "Basis of Preparation" (ESRS 2 BP-1/BP-2). Explain the Double Materiality approach (impact materiality + financial materiality) as applied by this company. Reference the company's scale and sector. ~120 words.
-    2. strategyDisclosure: "Strategy & Business Model" (ESRS 2 SBM-3). Summarise how the company's specific products/services and business model interact with the material impacts and risks identified. ~150 words.
-  `;
+      1. generalDisclosure: "Basis of Preparation" (ESRS 2 BP-1/BP-2). Explain the Double Materiality approach (impact materiality + financial materiality) as applied by this company. Reference the company's scale and sector. ~120 words.
+      2. strategyDisclosure: "Strategy & Business Model" (ESRS 2 SBM-3). Summarise how the company's specific products/services and business model interact with the material impacts and risks identified. ~150 words.
+    `;
 
-  // ── Calls 2…N: One call per topic (run in parallel) ────────────────────────
-  const topicPrompts = materialAssessments.map((a: any) => {
+    const response = await ai.models.generateContent({
+      model,
+      contents: headerPrompt,
+      config: {
+        responseMimeType: "application/json",
+        responseSchema: {
+          type: Type.OBJECT,
+          properties: {
+            generalDisclosure: { type: Type.STRING },
+            strategyDisclosure: { type: Type.STRING },
+          },
+        },
+      },
+    });
+
+    const header = parseAIJson(response.text, { generalDisclosure: "", strategyDisclosure: "" });
+
+    return {
+      result: {
+        generalDisclosure: header.generalDisclosure ?? "",
+        strategyDisclosure: header.strategyDisclosure ?? "",
+      },
+      ...extractTokens(response),
+    };
+  }
+
+  if (mode === 'topic' && targetTopic) {
+    const a = targetTopic;
     const topicCode = String(a.topic).split(" ")[0];
-    return `
+    const prompt = `
       Act as a Sustainability Reporting Officer drafting topical disclosures aligned with ESRS and GRI Standards.
 
       ${companyContext}
@@ -870,63 +896,29 @@ async function generateSustainabilityStatement(
         Reference the relevant GRI Standard number (e.g. GRI 305 for climate, GRI 303 for water).
         Use plain text with line breaks between paragraphs; no markdown.
     `;
-  });
 
-  const topicConfig = {
-    responseMimeType: "application/json",
-    responseSchema: {
-      type: Type.OBJECT,
-      properties: {
-        topicId: { type: Type.STRING },
-        topicName: { type: Type.STRING },
-        disclosureContent: { type: Type.STRING },
-      },
-    },
-  };
-
-  // Fire header and topic batches. Topics run in batches of 3 (sequential batches,
-  // parallel within each batch) to avoid Gemini rate limits and stay within the
-  // Netlify function timeout. Header fires concurrently with the first batch.
-  const headerRespPromise = ai.models.generateContent({
-    model,
-    contents: headerPrompt,
-    config: {
+    const topicConfig = {
       responseMimeType: "application/json",
       responseSchema: {
         type: Type.OBJECT,
         properties: {
-          generalDisclosure: { type: Type.STRING },
-          strategyDisclosure: { type: Type.STRING },
+          topicId: { type: Type.STRING },
+          topicName: { type: Type.STRING },
+          disclosureContent: { type: Type.STRING },
         },
       },
-    },
-  });
+    };
 
-  const topicCalls = topicPrompts.map((prompt: string) =>
-    ai.models.generateContent({ model, contents: prompt, config: topicConfig })
-  );
+    const response = await ai.models.generateContent({ model, contents: prompt, config: topicConfig });
+    const parsed = parseAIJson(response.text, { topicId: "", topicName: "", disclosureContent: "" });
 
-  const [headerResp, ...topicResps] = await Promise.all([
-    headerRespPromise,
-    ...topicCalls
-  ]);
-  const header = parseAIJson(headerResp.text, { generalDisclosure: "", strategyDisclosure: "" });
-  const topics = topicResps.map((r: any) => parseAIJson(r.text, { topicId: "", topicName: "", disclosureContent: "" }));
+    return {
+      result: parsed,
+      ...extractTokens(response),
+    };
+  }
 
-  // Sum token usage across all calls
-  const allResps = [headerResp, ...topicResps];
-  const inputTokens = allResps.reduce((sum: number, r: any) => sum + Number(r.usageMetadata?.promptTokenCount ?? 0), 0);
-  const outputTokens = allResps.reduce((sum: number, r: any) => sum + Number(r.usageMetadata?.candidatesTokenCount ?? r.usageMetadata?.responseTokenCount ?? 0), 0);
-
-  return {
-    result: {
-      generalDisclosure: header.generalDisclosure ?? "",
-      strategyDisclosure: header.strategyDisclosure ?? "",
-      topics,
-    },
-    inputTokens,
-    outputTokens,
-  };
+  return { result: null, inputTokens: 0, outputTokens: 0 };
 }
 
 // ── Shared helpers for DMA analysis ──────────────────────────────────────────

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -283,7 +283,7 @@ async function runAction(
     case "generateKPISuggestions":
       return generateKPISuggestions(ai, model, params);
     case "triggerReportGeneration":
-      return triggerReportGeneration(event, params);
+      return triggerReportGeneration(event, { organization_id, ...params });
     case "analyzeTopicQuality":
       return analyzeTopicQuality(ai, model, params);
     case "analyzeDMASynthesis":

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -281,8 +281,8 @@ async function runAction(
       return generateSwotExternal(ai, model, params);
     case "generateKPISuggestions":
       return generateKPISuggestions(ai, model, params);
-    case "generateSustainabilityStatement":
-      return generateSustainabilityStatement(ai, model, params);
+    case "triggerReportGeneration":
+      return triggerReportGeneration(params);
     case "analyzeTopicQuality":
       return analyzeTopicQuality(ai, model, params);
     case "analyzeDMASynthesis":
@@ -814,111 +814,24 @@ Return ONLY valid JSON, no markdown:
   }
 }
 
-async function generateSustainabilityStatement(
-  ai: GoogleGenAI,
-  model: string,
-  { profile, materialAssessments, mode, targetTopic }: any
-) {
-  if (!materialAssessments || materialAssessments.length === 0) {
-    return {
-      result: { generalDisclosure: "No data", strategyDisclosure: "No data", topics: [] },
-      inputTokens: 0,
-      outputTokens: 0,
-    };
-  }
-
-  const companyContext = buildCompanyContext(profile);
-
-  if (mode === 'header') {
-    const topicSummary = materialAssessments
-      .map((a: any) => `- ${a.topic} (impact score: ${a.impactMaterialityValue}/100, financial score: ${a.financialMaterialityValue}/100): impact: ${a.impactDescription}; financial: ${a.financialDescription}`)
-      .join("\n");
-
-    const headerPrompt = `
-      Act as a Sustainability Reporting Officer drafting a "Sustainability Statement" aligned with ESRS and GRI Standards.
-
-      ${companyContext}
-
-      Material topics identified (above threshold of 40/100 on either axis):
-      ${topicSummary}
-
-      Generate ONLY the two header sections below as JSON.
-
-      1. generalDisclosure: "Basis of Preparation" (ESRS 2 BP-1/BP-2). Explain the Double Materiality approach (impact materiality + financial materiality) as applied by this company. Reference the company's scale and sector. ~120 words.
-      2. strategyDisclosure: "Strategy & Business Model" (ESRS 2 SBM-3). Summarise how the company's specific products/services and business model interact with the material impacts and risks identified. ~150 words.
-    `;
-
-    const response = await ai.models.generateContent({
-      model,
-      contents: headerPrompt,
-      config: {
-        responseMimeType: "application/json",
-        responseSchema: {
-          type: Type.OBJECT,
-          properties: {
-            generalDisclosure: { type: Type.STRING },
-            strategyDisclosure: { type: Type.STRING },
-          },
-        },
-      },
+async function triggerReportGeneration({ organization_id, profile, materialAssessments }: any) {
+  const url = `${process.env.URL}/.netlify/functions/report-background`;
+  
+  try {
+    await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ organization_id, profile, materialAssessments }),
     });
-
-    const header = parseAIJson(response.text, { generalDisclosure: "", strategyDisclosure: "" });
-
-    return {
-      result: {
-        generalDisclosure: header.generalDisclosure ?? "",
-        strategyDisclosure: header.strategyDisclosure ?? "",
-      },
-      ...extractTokens(response),
-    };
+  } catch (e) {
+    console.error("Failed to trigger background function:", e);
   }
 
-  if (mode === 'topic' && targetTopic) {
-    const a = targetTopic;
-    const topicCode = String(a.topic).split(" ")[0];
-    const prompt = `
-      Act as a Sustainability Reporting Officer drafting topical disclosures aligned with ESRS and GRI Standards.
-
-      ${companyContext}
-
-      Topic: ${a.topic} (code: "${topicCode}")
-      Impact materiality score: ${a.impactMaterialityValue}/100 — ${a.impactDescription}
-      Financial materiality score: ${a.financialMaterialityValue}/100 — ${a.financialDescription}
-
-      Write a structured narrative disclosure for this single topic as JSON with:
-      - topicId: the short code only — "${topicCode}"
-      - topicName: the full string — "${a.topic}"
-      - disclosureContent: 200-300 word multi-paragraph narrative covering:
-          • Policies (ESRS MDR-P) — reference the company's specific context
-          • Actions & Resources (MDR-A) — tie to the company's products/services and scale
-          • Metrics & Targets (MDR-M) — suggest targets appropriate for a ${profile.employeeCount}-scale company
-        Reference the relevant GRI Standard number (e.g. GRI 305 for climate, GRI 303 for water).
-        Use plain text with line breaks between paragraphs; no markdown.
-    `;
-
-    const topicConfig = {
-      responseMimeType: "application/json",
-      responseSchema: {
-        type: Type.OBJECT,
-        properties: {
-          topicId: { type: Type.STRING },
-          topicName: { type: Type.STRING },
-          disclosureContent: { type: Type.STRING },
-        },
-      },
-    };
-
-    const response = await ai.models.generateContent({ model, contents: prompt, config: topicConfig });
-    const parsed = parseAIJson(response.text, { topicId: "", topicName: "", disclosureContent: "" });
-
-    return {
-      result: parsed,
-      ...extractTokens(response),
-    };
-  }
-
-  return { result: null, inputTokens: 0, outputTokens: 0 };
+  return {
+    result: { message: "Report generation started" },
+    inputTokens: 0,
+    outputTokens: 0,
+  };
 }
 
 // ── Shared helpers for DMA analysis ──────────────────────────────────────────

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -168,7 +168,7 @@ const handler = async (event: any) => {
 
   try {
     const outcome = await Promise.race([
-      runAction(ai, model, action, params, event),
+      runAction(ai, model, action, params, event, organization_id),
       fencePromise,
     ]);
     clearTimeout(fenceId!);
@@ -267,7 +267,8 @@ async function runAction(
   model: string,
   action: string,
   params: any,
-  event: any
+  event: any,
+  organization_id: string
 ): Promise<{ result: any; inputTokens: number; outputTokens: number }> {
   switch (action) {
     case "generateAssessmentSuggestions":

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -887,12 +887,6 @@ async function generateSustainabilityStatement(
   // Fire header and topic batches. Topics run in batches of 3 (sequential batches,
   // parallel within each batch) to avoid Gemini rate limits and stay within the
   // Netlify function timeout. Header fires concurrently with the first batch.
-  const BATCH_SIZE = 3;
-  const topicBatches: string[][] = [];
-  for (let i = 0; i < topicPrompts.length; i += BATCH_SIZE) {
-    topicBatches.push(topicPrompts.slice(i, i + BATCH_SIZE));
-  }
-
   const headerRespPromise = ai.models.generateContent({
     model,
     contents: headerPrompt,
@@ -908,21 +902,14 @@ async function generateSustainabilityStatement(
     },
   });
 
-  const topicResps: any[] = [];
-  let firstBatch = true;
-  for (const batch of topicBatches) {
-    const batchCalls = batch.map((prompt: string) =>
-      ai.models.generateContent({ model, contents: prompt, config: topicConfig })
-    );
-    // Run header concurrently with the first topic batch
-    const results = firstBatch
-      ? (await Promise.all([headerRespPromise, ...batchCalls])).slice(1)
-      : await Promise.all(batchCalls);
-    topicResps.push(...results);
-    firstBatch = false;
-  }
+  const topicCalls = topicPrompts.map((prompt: string) =>
+    ai.models.generateContent({ model, contents: prompt, config: topicConfig })
+  );
 
-  const headerResp = await headerRespPromise;
+  const [headerResp, ...topicResps] = await Promise.all([
+    headerRespPromise,
+    ...topicCalls
+  ]);
   const header = parseAIJson(headerResp.text, { generalDisclosure: "", strategyDisclosure: "" });
   const topics = topicResps.map((r: any) => parseAIJson(r.text, { topicId: "", topicName: "", disclosureContent: "" }));
 

--- a/netlify/functions/report-background.ts
+++ b/netlify/functions/report-background.ts
@@ -1,0 +1,152 @@
+import { GoogleGenAI, Type } from "@google/genai";
+import { createClient } from "@supabase/supabase-js";
+
+const apiKey = process.env.GEMINI_API_KEY;
+const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+const DEFAULT_MODEL = "gemini-2.5-flash";
+
+const handler = async (event: any) => {
+  // Netlify background functions are triggered by POST
+  if (event.httpMethod !== "POST") {
+    return { statusCode: 405, body: "Method Not Allowed" };
+  }
+
+  const { organization_id, profile, materialAssessments, model = DEFAULT_MODEL } = JSON.parse(event.body);
+
+  if (!organization_id || !profile || !materialAssessments) {
+    console.error("Missing required fields in background function");
+    return { statusCode: 400, body: "Missing required fields" };
+  }
+
+  const admin = createClient(supabaseUrl!, serviceKey!);
+
+  // Helper to parse JSON from AI
+  function parseAIJson<T>(text: string | undefined, fallback: T): T {
+    if (!text) return fallback;
+    try {
+      // Remove markdown code blocks if present
+      const cleaned = text.replace(/^```json\s*/, "").replace(/\s*```$/, "");
+      return JSON.parse(cleaned);
+    } catch (e) {
+      console.warn("Failed to parse AI JSON:", e);
+      return fallback;
+    }
+  }
+
+  try {
+    // 1. Update status to processing
+    await admin
+      .from("sustainability_reports")
+      .upsert({ organization_id, status: "processing", updated_at: new Date().toISOString() }, { onConflict: "organization_id" });
+
+    const ai = new GoogleGenAI({ apiKey });
+    const companyContext = `
+      Company: ${profile.name}
+      Industry: ${profile.industry}
+      Scale: ${profile.employeeCount} employees
+      Description: ${profile.description}
+    `;
+
+    const topicSummary = materialAssessments
+      .map((a: any) => `- ${a.topic} (impact score: ${a.impactMaterialityValue}/100, financial score: ${a.financialMaterialityValue}/100): impact: ${a.impactDescription}; financial: ${a.financialDescription}`)
+      .join("\n");
+
+    // ── Call 1: Header sections ──────────────────
+    const headerPrompt = `
+      Act as a Sustainability Reporting Officer drafting a "Sustainability Statement" aligned with ESRS and GRI Standards.
+
+      ${companyContext}
+
+      Material topics identified:
+      ${topicSummary}
+
+      Generate ONLY the two header sections below as JSON.
+
+      1. generalDisclosure: "Basis of Preparation" (ESRS 2 BP-1/BP-2). Explain the Double Materiality approach. ~120 words.
+      2. strategyDisclosure: "Strategy & Business Model" (ESRS 2 SBM-3). Summarise how the company's business model interacts with the material impacts. ~150 words.
+    `;
+
+    const headerRespPromise = ai.models.generateContent({
+      model,
+      contents: headerPrompt,
+      config: {
+        responseMimeType: "application/json",
+        responseSchema: {
+          type: Type.OBJECT,
+          properties: {
+            generalDisclosure: { type: Type.STRING },
+            strategyDisclosure: { type: Type.STRING },
+          },
+        },
+      },
+    });
+
+    // ── Calls 2…N: One call per topic ────────────────────────
+    const topicConfig = {
+      responseMimeType: "application/json",
+      responseSchema: {
+        type: Type.OBJECT,
+        properties: {
+          topicId: { type: Type.STRING },
+          topicName: { type: Type.STRING },
+          disclosureContent: { type: Type.STRING },
+        },
+      },
+    };
+
+    const topicCalls = materialAssessments.map((a: any) => {
+      const topicCode = String(a.topic).split(" ")[0];
+      const prompt = `
+        Act as a Sustainability Reporting Officer drafting topical disclosures aligned with ESRS and GRI Standards.
+
+        ${companyContext}
+
+        Topic: ${a.topic} (code: "${topicCode}")
+        Impact materiality score: ${a.impactMaterialityValue}/100 — ${a.impactDescription}
+        Financial materiality score: ${a.financialMaterialityValue}/100 — ${a.financialDescription}
+
+        Write a structured narrative disclosure for this single topic as JSON with:
+        - topicId: the short code only — "${topicCode}"
+        - topicName: the full string — "${a.topic}"
+        - disclosureContent: 200-300 word multi-paragraph narrative.
+      `;
+      return ai.models.generateContent({ model, contents: prompt, config: topicConfig });
+    });
+
+    const [headerResp, ...topicResps] = await Promise.all([
+      headerRespPromise,
+      ...topicCalls
+    ]);
+
+    const header = parseAIJson(headerResp.text, { generalDisclosure: "", strategyDisclosure: "" });
+    const topics = topicResps.map((r: any) => parseAIJson(r.text, { topicId: "", topicName: "", disclosureContent: "" }));
+
+    const result = {
+      generalDisclosure: header.generalDisclosure ?? "",
+      strategyDisclosure: header.strategyDisclosure ?? "",
+      topics,
+    };
+
+    // 2. Update status to completed
+    const { error } = await admin
+      .from("sustainability_reports")
+      .update({ status: "completed", result, updated_at: new Date().toISOString() })
+      .eq("organization_id", organization_id);
+
+    if (error) throw error;
+
+  } catch (error: any) {
+    console.error("Background Report Generation Failed:", error);
+    // Update status to failed
+    await admin
+      .from("sustainability_reports")
+      .update({ status: "failed", error: error.message || String(error), updated_at: new Date().toISOString() })
+      .eq("organization_id", organization_id);
+  }
+
+  return { statusCode: 200, body: "Done" };
+};
+
+export { handler };

--- a/netlify/functions/report-background.ts
+++ b/netlify/functions/report-background.ts
@@ -8,7 +8,6 @@ const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 const DEFAULT_MODEL = "gemini-2.5-flash";
 
 const handler = async (event: any) => {
-  // Netlify background functions are triggered by POST
   if (event.httpMethod !== "POST") {
     return { statusCode: 405, body: "Method Not Allowed" };
   }
@@ -16,21 +15,21 @@ const handler = async (event: any) => {
   const { organization_id, profile, materialAssessments, model = DEFAULT_MODEL } = JSON.parse(event.body);
 
   if (!organization_id || !profile || !materialAssessments) {
-    console.error("Missing required fields in background function");
+    console.error("[report-background] Missing required fields");
     return { statusCode: 400, body: "Missing required fields" };
   }
 
+  console.log(`[report-background] Starting generation for org=${organization_id}, topics=${materialAssessments.length}`);
+
   const admin = createClient(supabaseUrl!, serviceKey!);
 
-  // Helper to parse JSON from AI
   function parseAIJson<T>(text: string | undefined, fallback: T): T {
     if (!text) return fallback;
     try {
-      // Remove markdown code blocks if present
       const cleaned = text.replace(/^```json\s*/, "").replace(/\s*```$/, "");
       return JSON.parse(cleaned);
     } catch (e) {
-      console.warn("Failed to parse AI JSON:", e);
+      console.warn("[report-background] Failed to parse AI JSON:", e);
       return fallback;
     }
   }
@@ -68,6 +67,7 @@ const handler = async (event: any) => {
       2. strategyDisclosure: "Strategy & Business Model" (ESRS 2 SBM-3). Summarise how the company's business model interacts with the material impacts. ~150 words.
     `;
 
+    console.log("[report-background] Requesting header sections...");
     const headerRespPromise = ai.models.generateContent({
       model,
       contents: headerPrompt,
@@ -115,10 +115,14 @@ const handler = async (event: any) => {
       return ai.models.generateContent({ model, contents: prompt, config: topicConfig });
     });
 
+    console.log(`[report-background] Requesting ${topicCalls.length} topical disclosures in parallel...`);
+
     const [headerResp, ...topicResps] = await Promise.all([
       headerRespPromise,
       ...topicCalls
     ]);
+
+    console.log("[report-background] All AI responses received. Parsing...");
 
     const header = parseAIJson(headerResp.text, { generalDisclosure: "", strategyDisclosure: "" });
     const topics = topicResps.map((r: any) => parseAIJson(r.text, { topicId: "", topicName: "", disclosureContent: "" }));
@@ -137,9 +141,10 @@ const handler = async (event: any) => {
 
     if (error) throw error;
 
+    console.log(`[report-background] Successfully completed and saved to DB for org=${organization_id}`);
+
   } catch (error: any) {
-    console.error("Background Report Generation Failed:", error);
-    // Update status to failed
+    console.error("[report-background] Failed:", error);
     await admin
       .from("sustainability_reports")
       .update({ status: "failed", error: error.message || String(error), updated_at: new Date().toISOString() })

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -134,20 +134,26 @@ export interface GeneratedStatement {
   }[];
 }
 
-export const generateSustainabilityHeader = async (
+export const triggerReportGeneration = async (
   profile: CompanyProfile,
   materialAssessments: AssessmentData[]
-): Promise<{ generalDisclosure: string; strategyDisclosure: string }> => {
-  const resp = await callApi("generateSustainabilityStatement", { profile, materialAssessments, mode: 'header' });
-  return resp.result;
+): Promise<{ message: string }> => {
+  return await callApi("triggerReportGeneration", { profile, materialAssessments });
 };
 
-export const generateTopicalDisclosure = async (
-  profile: CompanyProfile,
-  targetTopic: AssessmentData
-): Promise<{ topicId: string; topicName: string; disclosureContent: string }> => {
-  const resp = await callApi("generateSustainabilityStatement", { profile, materialAssessments: [targetTopic], mode: 'topic', targetTopic });
-  return resp.result;
+export const getReportStatus = async (): Promise<{ status: string; result?: any; error?: string } | null> => {
+  if (!currentOrgId) return null;
+  const { data, error } = await supabase
+    .from("sustainability_reports")
+    .select("status, result, error")
+    .eq("organization_id", currentOrgId)
+    .maybeSingle();
+    
+  if (error) {
+    console.warn("getReportStatus failed:", error.message);
+    return null;
+  }
+  return data;
 };
 
 // Pass 1 — quality check for a single topic. Called once per assessment from the frontend.

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -134,12 +134,20 @@ export interface GeneratedStatement {
   }[];
 }
 
-export const generateSustainabilityStatement = async (
+export const generateSustainabilityHeader = async (
   profile: CompanyProfile,
   materialAssessments: AssessmentData[]
-): Promise<GeneratedStatement> => {
-  // Re-throws so the caller can show a real error message instead of a silent null.
-  return await callApi("generateSustainabilityStatement", { profile, materialAssessments });
+): Promise<{ generalDisclosure: string; strategyDisclosure: string }> => {
+  const resp = await callApi("generateSustainabilityStatement", { profile, materialAssessments, mode: 'header' });
+  return resp.result;
+};
+
+export const generateTopicalDisclosure = async (
+  profile: CompanyProfile,
+  targetTopic: AssessmentData
+): Promise<{ topicId: string; topicName: string; disclosureContent: string }> => {
+  const resp = await callApi("generateSustainabilityStatement", { profile, materialAssessments: [targetTopic], mode: 'topic', targetTopic });
+  return resp.result;
 };
 
 // Pass 1 — quality check for a single topic. Called once per assessment from the frontend.

--- a/supabase/migrations/015_sustainability_reports.sql
+++ b/supabase/migrations/015_sustainability_reports.sql
@@ -1,0 +1,27 @@
+-- Migration 015: Persist Sustainability Reports for Polling/Background Job
+--
+-- Changes:
+--   sustainability_reports — new singleton-per-org table for report generation status and results
+--
+-- Rollback plan:
+--   DROP TABLE IF EXISTS sustainability_reports CASCADE;
+
+CREATE TABLE IF NOT EXISTS sustainability_reports (
+  organization_id     uuid PRIMARY KEY REFERENCES organizations(id) ON DELETE CASCADE,
+  status              text NOT NULL DEFAULT 'processing' CHECK (status IN ('processing', 'completed', 'failed')),
+  result              jsonb NOT NULL DEFAULT '{}',
+  error               text,
+  created_at          timestamptz NOT NULL DEFAULT now(),
+  updated_at          timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TRIGGER trg_sustainability_reports_updated_at
+  BEFORE UPDATE ON sustainability_reports FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+ALTER TABLE sustainability_reports ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "members_read_reports" ON sustainability_reports
+  FOR SELECT USING (is_org_member(organization_id));
+
+CREATE POLICY "members_write_reports" ON sustainability_reports
+  FOR ALL USING (is_org_member(organization_id));

--- a/supabase/migrations/017_sustainability_reports.sql
+++ b/supabase/migrations/017_sustainability_reports.sql
@@ -1,4 +1,4 @@
--- Migration 015: Persist Sustainability Reports for Polling/Background Job
+-- Migration 017: Persist Sustainability Reports for Polling/Background Job
 --
 -- Changes:
 --   sustainability_reports — new singleton-per-org table for report generation status and results


### PR DESCRIPTION
This PR removes the sequential batching of AI calls when generating the Sustainability Statement and runs them all in parallel. This reduces execution time from ~8-12 seconds to ~4 seconds, staying well within Netlify's 10-second hard timeout limit.