### PR TITLE
feat: add Identification No and Asset No columns to Carbon template

### DIFF
--- a/components/CarbonDashboard.tsx
+++ b/components/CarbonDashboard.tsx
@@ -794,19 +794,36 @@ const BulkUploadModal: React.FC<{
   const [result, setResult] = useState<{ success: number; failed: number } | null>(null);
 
   const downloadTemplate = () => {
-    const rows = sources.map(s => ({
-      'Source Name': s.source_name,
-      'Source ID': s.id,
-      'Scope': s.scope,
-      'Unit': s.unit,
-      'Factor (kgCO₂e/unit)': s.emission_factor_value ?? '',
-      'Period Start (YYYY-MM-DD)': '',
-      'Period End (YYYY-MM-DD)': '',
-      'Activity Data': '',
-      'Notes': '',
-    }));
-    const ws = XLSX.utils.json_to_sheet(rows);
-    ws['!cols'] = [{ wch: 25 }, { wch: 36 }, { wch: 8 }, { wch: 8 }, { wch: 20 }, { wch: 22 }, { wch: 22 }, { wch: 16 }, { wch: 30 }];
+    const headers = [
+      'Source Name',
+      'Source ID',
+      'Scope',
+      'Unit',
+      'Factor (kgCO₂e/unit)',
+      'Identification No',
+      'Asset No',
+      'Period Start (YYYY-MM-DD)',
+      'Period End (YYYY-MM-DD)',
+      'Activity Data',
+      'Notes'
+    ];
+    
+    const data = sources.map(s => [
+      s.source_name,
+      s.id,
+      s.scope,
+      s.unit,
+      s.emission_factor_value ?? '',
+      s.identification_number ?? '',
+      s.asset_number ?? '',
+      '',
+      '',
+      '',
+      ''
+    ]);
+    
+    const ws = XLSX.utils.aoa_to_sheet([headers, ...data]);
+    ws['!cols'] = [{ wch: 25 }, { wch: 36 }, { wch: 8 }, { wch: 8 }, { wch: 20 }, { wch: 20 }, { wch: 20 }, { wch: 22 }, { wch: 22 }, { wch: 16 }, { wch: 30 }];
     const wb = XLSX.utils.book_new();
     XLSX.utils.book_append_sheet(wb, ws, 'Emissions');
     XLSX.writeFile(wb, `carbon-bulk-template-${new Date().toISOString().slice(0, 10)}.xlsx`);


### PR DESCRIPTION
## Description
Adds two more columns to the bulk upload template: `Identification No` and `Asset No`. These columns are for user reference to make it easier to fill in the data.

## Changes
- Updated `downloadTemplate` in `CarbonDashboard.tsx` to include `'Identification No'` and `'Asset No'` in headers.
- Updated the data mapping to include `s.identification_number` and `s.asset_number`.
- Switched to `aoa_to_sheet` (carrying over the fix from the unmerged PR or applying it here directly since it was missing in this branch's base).

## Verification
- Ran `npm run build` successfully.