### PR TITLE
feat: add DMA Guide AI message

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -524,7 +524,7 @@ const App: React.FC = () => {
                     <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 md:gap-6">
                       <StatCard title="Assessments Completed" value={assessments.length.toString()} icon={<FileText className="text-blue-500" />} description="Total ESRS topics assessed across all categories" />
                       <StatCard title="Material Topics Identified" value={materialTopics.length.toString()} icon={<AlertTriangle className="text-amber-500" />} description="Topics scoring ≥ 40 on financial or impact materiality" />
-                      <StatCard title="High Impact Risks" value={assessments.filter(a => a.financialMaterialityValue > 60).length.toString()} icon={<CheckCircle className="text-esg-500" />} description="Topics with financial materiality score > 60 (orange dots on matrix)" />
+                      <StatCard title="High Impact Risks" value={assessments.filter(a => a.financialMaterialityValue > 60).length.toString()} icon={<CheckCircle className="text-esg-500" />} description="Topics with financial materiality score > 60 (green dots on matrix)" />
                     </div>
                     <div className="space-y-6">
                       <MaterialityMatrix data={assessments} />

--- a/App.tsx
+++ b/App.tsx
@@ -6,6 +6,7 @@ import TaskManagement from './components/TaskManagement';
 import CarbonWizard from './components/CarbonWizard';
 import CarbonDashboard from './components/CarbonDashboard';
 import MaterialityMatrix from './components/MaterialityMatrix';
+import DMAGuide from './components/DMAGuide';
 import BusinessModelCanvas from './components/BusinessModelCanvas';
 import SwotAnalysisWizard from './components/SwotAnalysisWizard';
 import DataCompletenessDashboard from './components/DataCompletenessDashboard';
@@ -526,8 +527,15 @@ const App: React.FC = () => {
                       <StatCard title="Material Topics Identified" value={materialTopics.length.toString()} icon={<AlertTriangle className="text-amber-500" />} description="Topics scoring ≥ 40 on financial or impact materiality" />
                       <StatCard title="High Impact Risks" value={assessments.filter(a => a.financialMaterialityValue > 60).length.toString()} icon={<CheckCircle className="text-esg-500" />} description="Topics with financial materiality score > 60 (green dots on matrix)" />
                     </div>
-                    <div className="space-y-6">
-                      <MaterialityMatrix data={assessments} />
+                    <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                      <div className="lg:col-span-2">
+                        <MaterialityMatrix data={assessments} />
+                      </div>
+                      <div className="lg:col-span-1">
+                        <DMAGuide profile={profile.data} />
+                      </div>
+                    </div>
+                    <div className="mt-6">
                       <MaterialTopicsList assessments={assessments} onEdit={handleEditAssessment} onDelete={handleDeleteAssessment} orgId={organization?.id} currentUserId={user?.id} />
                     </div>
                   </div>

--- a/components/DMAGuide.tsx
+++ b/components/DMAGuide.tsx
@@ -10,7 +10,7 @@ interface Props {
 const DMAGuide: React.FC<Props> = ({ profile }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [guide, setGuide] = useState<{ message: string; topics: { topic: string; reason: string }[] } | null>(null);
+  const [guide, setGuide] = useState<{ message: string; topics: { topic: string; reason: string; esrs_ref: string }[] } | null>(null);
 
   useEffect(() => {
     const fetchGuide = async () => {
@@ -64,7 +64,12 @@ const DMAGuide: React.FC<Props> = ({ profile }) => {
             <p className="text-xs font-semibold text-slate-400 uppercase tracking-wider">Top 3 Recommended Topics</p>
             {guide.topics.map((t, i) => (
               <div key={i} className="bg-slate-50 dark:bg-slate-900/50 p-3 rounded-lg border border-slate-100 dark:border-slate-800">
-                <p className="text-sm font-semibold text-slate-800 dark:text-white mb-1">{t.topic}</p>
+                <div className="flex items-center justify-between gap-2 mb-1">
+                  <p className="text-sm font-semibold text-slate-800 dark:text-white">{t.topic}</p>
+                  <span className="text-xs px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-700 text-slate-500 dark:text-slate-400 font-mono flex-shrink-0">
+                    {t.esrs_ref}
+                  </span>
+                </div>
                 <p className="text-xs text-slate-500 dark:text-slate-400">{t.reason}</p>
               </div>
             ))}

--- a/components/DMAGuide.tsx
+++ b/components/DMAGuide.tsx
@@ -1,0 +1,78 @@
+import React, { useState, useEffect } from 'react';
+import { getDMAGuide } from '../services/geminiService';
+import { CompanyProfile } from '../types';
+import { Sparkles, AlertTriangle, Loader2 } from 'lucide-react';
+
+interface Props {
+  profile: CompanyProfile;
+}
+
+const DMAGuide: React.FC<Props> = ({ profile }) => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [guide, setGuide] = useState<{ message: string; topics: { topic: string; reason: string }[] } | null>(null);
+
+  useEffect(() => {
+    const fetchGuide = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const data = await getDMAGuide(profile);
+        setGuide(data);
+      } catch (err: any) {
+        setError(err.message || 'Failed to load DMA Guide');
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchGuide();
+  }, [profile]);
+
+  if (loading) {
+    return (
+      <div className="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 p-5 flex flex-col items-center justify-center min-h-[300px]">
+        <Loader2 className="w-8 h-8 text-esg-500 animate-spin mb-3" />
+        <p className="text-sm text-slate-500 dark:text-slate-400">Consulting AI for DMA Guide...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-white dark:bg-slate-800 rounded-xl border border-red-200 dark:border-red-800 p-5 flex flex-col items-center justify-center min-h-[300px]">
+        <AlertTriangle className="w-8 h-8 text-red-500 mb-3" />
+        <p className="text-sm text-red-600 dark:text-red-400 mb-2">Failed to load DMA Guide</p>
+        <p className="text-xs text-slate-500 dark:text-slate-400 text-center">{error}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="bg-white dark:bg-slate-800 rounded-xl border border-slate-200 dark:border-slate-700 p-5 h-full">
+      <div className="flex items-center gap-2 mb-4">
+        <Sparkles className="w-5 h-5 text-esg-500" />
+        <h3 className="font-bold text-slate-800 dark:text-white text-sm">AI DMA Guide</h3>
+      </div>
+      
+      {guide && (
+        <div className="space-y-4">
+          <p className="text-sm text-slate-600 dark:text-slate-300 leading-relaxed">
+            {guide.message}
+          </p>
+          
+          <div className="space-y-3">
+            <p className="text-xs font-semibold text-slate-400 uppercase tracking-wider">Top 3 Recommended Topics</p>
+            {guide.topics.map((t, i) => (
+              <div key={i} className="bg-slate-50 dark:bg-slate-900/50 p-3 rounded-lg border border-slate-100 dark:border-slate-800">
+                <p className="text-sm font-semibold text-slate-800 dark:text-white mb-1">{t.topic}</p>
+                <p className="text-xs text-slate-500 dark:text-slate-400">{t.reason}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DMAGuide;

--- a/components/TaskManagement.tsx
+++ b/components/TaskManagement.tsx
@@ -678,6 +678,9 @@ const ManagerTab: React.FC<ManagerProps> = ({
     setTasks(prev => prev.map(t => t.id === updated.id ? updated : t));
   };
 
+  // The current user's member row id (for "pick up")
+  const currentMemberId = members.find(m => m.user_id === currentUserId)?.id ?? null;
+
   // Pick up = assign to self using this user's member row id
   const handlePickUp = (task: Task) => {
     if (!currentMemberId) return;
@@ -710,9 +713,6 @@ const ManagerTab: React.FC<ManagerProps> = ({
     memberByMemberId(memberId)?.email ?? (memberId ? '…' : null);
   const assignedByName = (userId: string | null) =>
     memberByUserId(userId)?.email ?? null;
-
-  // The current user's member row id (for "pick up")
-  const currentMemberId = members.find(m => m.user_id === currentUserId)?.id ?? null;
 
   if (loading) {
     return (

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -1525,7 +1525,7 @@ Company Context:
 ${companyCtx}
 
 Provide a short guide message and the top 3 topics.
-Each topic must have a reason why it is a focus area.
+Each topic must have a reason why it is a focus area, and the related ESRS standard (e.g. "ESRS E1", "ESRS S1").
 Keep the total response short and precise. The explanation for all 3 topics combined should not exceed 100 words.
 `;
 
@@ -1544,9 +1544,10 @@ Keep the total response short and precise. The explanation for all 3 topics comb
               type: Type.OBJECT,
               properties: {
                 topic: { type: Type.STRING },
-                reason: { type: Type.STRING }
+                reason: { type: Type.STRING },
+                esrs_ref: { type: Type.STRING }
               },
-              required: ["topic", "reason"]
+              required: ["topic", "reason", "esrs_ref"]
             }
           }
         },

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -303,6 +303,8 @@ async function runAction(
       return analyzeDMAQuality(ai, model, params);
     case "generateTasks":
       return generateTasks(ai, model, params);
+    case "generateDMAGuide":
+      return generateDMAGuide(ai, model, params);
     default:
       throw new Error(`Unknown action: ${action}`);
   }
@@ -1498,6 +1500,66 @@ Return ONLY a valid JSON array of task objects. No markdown, no backticks, no ex
   const { inputTokens, outputTokens } = extractTokens(response);
 
   return { result: tasks, inputTokens, outputTokens };
+}
+
+async function generateDMAGuide(
+  ai: GoogleGenAI,
+  model: string,
+  { profile }: { profile: any }
+) {
+  const companyName = profile.name || "this company";
+  const companyCtx = `
+Company Name: ${companyName}
+Industry: ${profile.industry || "Not specified"}
+ISIC Code: ${profile.isicCode || "Not specified"}
+Description: ${profile.description || "Not specified"}
+Employees: ${profile.employees || "Not specified"}
+Revenue: ${profile.revenue || "Not specified"}
+`;
+
+  const prompt = `
+You are an ESRS/CSRD sustainability expert.
+Based on the following company context, suggest the top 3 Double Materiality Assessment (DMA) topics that this company should focus on.
+
+Company Context:
+${companyCtx}
+
+Provide a short guide message and the top 3 topics.
+Each topic must have a reason why it is a focus area.
+Keep the total response short and precise. The explanation for all 3 topics combined should not exceed 100 words.
+`;
+
+  const response = await ai.models.generateContent({
+    model,
+    contents: prompt,
+    config: {
+      responseMimeType: "application/json",
+      responseSchema: {
+        type: Type.OBJECT,
+        properties: {
+          message: { type: Type.STRING },
+          topics: {
+            type: Type.ARRAY,
+            items: {
+              type: Type.OBJECT,
+              properties: {
+                topic: { type: Type.STRING },
+                reason: { type: Type.STRING }
+              },
+              required: ["topic", "reason"]
+            }
+          }
+        },
+        required: ["message", "topics"]
+      },
+      ...noThinkingConfig(model),
+    },
+  });
+
+  const result = parseAIJson<any>(response.text, { message: "", topics: [] });
+  const { inputTokens, outputTokens } = extractTokens(response);
+
+  return { result, inputTokens, outputTokens };
 }
 
 export { handler };

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -57,7 +57,7 @@ function errorMessage(error: unknown): string {
 
 export const getDMAGuide = async (
   profile: CompanyProfile
-): Promise<{ message: string; topics: { topic: string; reason: string }[] }> => {
+): Promise<{ message: string; topics: { topic: string; reason: string; esrs_ref: string }[] }> => {
   return callApi("generateDMAGuide", { profile });
 };
 

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -55,6 +55,12 @@ function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : "An unexpected error occurred. Please try again.";
 }
 
+export const getDMAGuide = async (
+  profile: CompanyProfile
+): Promise<{ message: string; topics: { topic: string; reason: string }[] }> => {
+  return callApi("generateDMAGuide", { profile });
+};
+
 // Re-throws on error — caller must catch and show an error state.
 export const generateAssessmentSuggestions = async (
   profile: CompanyProfile,


### PR DESCRIPTION
## Description
Adds a "DMA Guide" message from AI to the DMA dashboard. It looks at the company context and suggests the top 3 DMA topics the company should have. It is placed on the right side of the DMA Matrix.

## Changes
- Backend: Added `generateDMAGuide` action in `api.ts`.
- Frontend Service: Added `getDMAGuide` in `geminiService.ts`.
- Component: Created `DMAGuide.tsx`.
- Layout: Updated `App.tsx` to use a grid for Matrix and Guide.

## Verification
- Ran `npm run build` successfully.