### PR TITLE
feat: add Start Here onboarding guidance feature

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -98,7 +98,7 @@ const App: React.FC = () => {
   }, [organization?.id]);
 
   // UI state
-  const [view, setView] = useState<'start_here' | 'start_here_esg' | 'start_here_carbon' | 'start_here_stakeholder' | 'overview' | 'profile' | 'dm_dashboard' | 'canvas' | 'swot' | 'kpi' | 'assess' | 'report' | 'insight_hub' | 'tasks' | 'carbon_wizard' | 'carbon_dashboard' | 'settings' | 'user_profile'>('overview');
+  const [view, setView] = useState<'start_here' | 'start_here_esg' | 'start_here_carbon' | 'start_here_stakeholder' | 'overview' | 'profile' | 'dm_dashboard' | 'canvas' | 'swot' | 'kpi' | 'assess' | 'report' | 'insight_hub' | 'tasks' | 'carbon_wizard' | 'carbon_dashboard' | 'settings' | 'user_profile'>('start_here');
   const [userDropdownOpen, setUserDropdownOpen] = useState(false);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);

--- a/App.tsx
+++ b/App.tsx
@@ -16,6 +16,8 @@ import UserProfilePage from './components/UserProfilePage';
 import PerformanceDashboard from './components/PerformanceDashboard';
 import SustainabilityStatement from './components/SustainabilityStatement';
 import MaterialTopicsList from './components/MaterialTopicsList';
+import StartHere from './components/StartHere';
+import type { StartHerePathId } from './components/StartHere';
 import AllyAssistant from './components/AllyAssistant';
 import AuthScreen from './components/AuthScreen';
 import ResetPasswordModal from './components/ResetPasswordModal';
@@ -33,7 +35,7 @@ import {
 } from './services/dbService';
 import { setOrganizationContext } from './services/geminiService';
 import { supabase } from './lib/supabaseClient';
-import { Plus, FileText, BarChart3, CheckCircle, AlertTriangle, Grid, Moon, Sun, Target, Home, ChevronRight, ChevronDown, Building2, Menu, X, TrendingUp, ChevronsLeft, ChevronsRight, LogOut, Loader2, ListChecks, Zap, Leaf, Settings, UserCircle, ChevronUp, ScatterChart } from 'lucide-react';
+import { Plus, FileText, BarChart3, CheckCircle, AlertTriangle, Grid, Moon, Sun, Target, Home, ChevronRight, ChevronDown, Building2, Menu, X, TrendingUp, ChevronsLeft, ChevronsRight, LogOut, Loader2, ListChecks, Zap, Leaf, Settings, UserCircle, ChevronUp, ScatterChart, Compass } from 'lucide-react';
 import type { InsightHubResponse, QualityCheck } from './types';
 
 const DEFAULT_PROFILE: CompanyProfile = {
@@ -95,7 +97,7 @@ const App: React.FC = () => {
   }, [organization?.id]);
 
   // UI state
-  const [view, setView] = useState<'overview' | 'profile' | 'dm_dashboard' | 'canvas' | 'swot' | 'kpi' | 'assess' | 'report' | 'insight_hub' | 'tasks' | 'carbon_wizard' | 'carbon_dashboard' | 'settings' | 'user_profile'>('overview');
+  const [view, setView] = useState<'start_here' | 'start_here_esg' | 'start_here_carbon' | 'start_here_stakeholder' | 'overview' | 'profile' | 'dm_dashboard' | 'canvas' | 'swot' | 'kpi' | 'assess' | 'report' | 'insight_hub' | 'tasks' | 'carbon_wizard' | 'carbon_dashboard' | 'settings' | 'user_profile'>('overview');
   const [userDropdownOpen, setUserDropdownOpen] = useState(false);
   const [isFormOpen, setIsFormOpen] = useState(false);
   const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
@@ -296,6 +298,7 @@ const App: React.FC = () => {
 
           <nav className="flex-1 p-2 sm:p-4 space-y-6 overflow-y-auto overflow-x-hidden">
             <div className="space-y-1">
+              <NavItem active={view === 'start_here' || view === 'start_here_esg' || view === 'start_here_carbon' || view === 'start_here_stakeholder'} collapsed={isSidebarCollapsed} onClick={() => setView('start_here')} icon={<Compass />} label="Start Here" />
               <NavItem active={view === 'overview'} collapsed={isSidebarCollapsed} onClick={() => setView('overview')} icon={<Home />} label="Overview" />
             </div>
 
@@ -348,6 +351,7 @@ const App: React.FC = () => {
               </button>
               <div className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400 whitespace-nowrap overflow-hidden">
                 <span className="font-medium text-slate-800 dark:text-white hidden sm:inline">
+                  {(view === 'start_here' || view === 'start_here_esg' || view === 'start_here_carbon' || view === 'start_here_stakeholder') && 'Start Here'}
                   {view === 'overview' && 'Overview'}
                   {(view === 'profile' || view === 'canvas' || view === 'swot' || view === 'kpi') && 'My Business'}
                   {(view === 'dm_dashboard' || view === 'assess' || view === 'report' || view === 'insight_hub') && 'Double Materiality'}
@@ -358,6 +362,10 @@ const App: React.FC = () => {
                 </span>
                 <ChevronRight className="w-4 h-4 hidden sm:block" />
                 <span className="truncate">
+                  {view === 'start_here' && 'Choose Your Path'}
+                  {view === 'start_here_esg' && 'ESG Readiness'}
+                  {view === 'start_here_carbon' && 'Carbon Starter'}
+                  {view === 'start_here_stakeholder' && 'Stakeholder Request Readiness'}
                   {view === 'overview' && 'System Status'}
                   {view === 'profile' && 'Company Profile'}
                   {view === 'canvas' && 'Business Model Canvas'}
@@ -467,6 +475,19 @@ const App: React.FC = () => {
               </div>
             ) : (
               <>
+                {view === 'start_here' && (
+                  <StartHere onSelectPath={(path: StartHerePathId) => setView(path)} />
+                )}
+
+                {(view === 'start_here_esg' || view === 'start_here_carbon' || view === 'start_here_stakeholder') && (
+                  <div className="animate-in fade-in duration-500 flex flex-col items-center justify-center min-h-[400px] gap-4 text-center">
+                    <p className="text-slate-500 dark:text-slate-400 text-sm">Path detail coming soon…</p>
+                    <button onClick={() => setView('start_here')} className="text-sm text-esg-600 dark:text-esg-400 hover:underline">
+                      ← Back to Start Here
+                    </button>
+                  </div>
+                )}
+
                 {view === 'overview' && (
                   <DataCompletenessDashboard
                     bmcData={canvas.data}

--- a/App.tsx
+++ b/App.tsx
@@ -18,6 +18,7 @@ import SustainabilityStatement from './components/SustainabilityStatement';
 import MaterialTopicsList from './components/MaterialTopicsList';
 import StartHere from './components/StartHere';
 import type { StartHerePathId } from './components/StartHere';
+import StartHerePath from './components/StartHerePath';
 import AllyAssistant from './components/AllyAssistant';
 import AuthScreen from './components/AuthScreen';
 import ResetPasswordModal from './components/ResetPasswordModal';
@@ -480,12 +481,11 @@ const App: React.FC = () => {
                 )}
 
                 {(view === 'start_here_esg' || view === 'start_here_carbon' || view === 'start_here_stakeholder') && (
-                  <div className="animate-in fade-in duration-500 flex flex-col items-center justify-center min-h-[400px] gap-4 text-center">
-                    <p className="text-slate-500 dark:text-slate-400 text-sm">Path detail coming soon…</p>
-                    <button onClick={() => setView('start_here')} className="text-sm text-esg-600 dark:text-esg-400 hover:underline">
-                      ← Back to Start Here
-                    </button>
-                  </div>
+                  <StartHerePath
+                    pathId={view}
+                    onBack={() => setView('start_here')}
+                    onNavigate={(v) => setView(v)}
+                  />
                 )}
 
                 {view === 'overview' && (

--- a/components/StartHere.tsx
+++ b/components/StartHere.tsx
@@ -1,0 +1,175 @@
+import React from 'react';
+import { Clock, ChevronRight, TrendingUp, Leaf, Globe } from 'lucide-react';
+
+export type StartHerePathId = 'start_here_esg' | 'start_here_carbon' | 'start_here_stakeholder';
+
+interface StartHereProps {
+  onSelectPath: (path: StartHerePathId) => void;
+}
+
+const PATHS = [
+  {
+    id: 'start_here_esg' as StartHerePathId,
+    icon: <TrendingUp className="w-6 h-6" />,
+    color: 'esg',
+    title: 'ESG Readiness',
+    description: 'For SMEs starting their sustainability journey and looking for a structured place to begin.',
+    bestFor: [
+      'SMEs new to sustainability',
+      'Companies without a dedicated ESG team',
+      'Organizations building initial sustainability structure',
+    ],
+    estimatedTime: '60–90 minutes',
+    outcomes: [
+      'Sustainability strategy baseline',
+      'Risks and opportunities overview',
+      'Initial materiality understanding',
+      'KPI structure',
+      'Suggested sustainability tasks',
+    ],
+    cta: 'Start ESG Readiness',
+  },
+  {
+    id: 'start_here_carbon' as StartHerePathId,
+    icon: <Leaf className="w-6 h-6" />,
+    color: 'green',
+    title: 'Carbon Starter',
+    description: 'For organizations beginning Scope 1 and Scope 2 carbon tracking.',
+    bestFor: [
+      'SMEs asked about emissions',
+      'Companies starting carbon tracking',
+      'Organizations preparing for future carbon reporting',
+    ],
+    estimatedTime: '45–60 minutes',
+    outcomes: [
+      'Basic Scope 1 and Scope 2 tracking',
+      'Monthly emissions records',
+      'Carbon activity overview',
+      'Initial emissions hotspot visibility',
+    ],
+    cta: 'Start Carbon Starter',
+  },
+  {
+    id: 'start_here_stakeholder' as StartHerePathId,
+    icon: <Globe className="w-6 h-6" />,
+    color: 'blue',
+    title: 'Stakeholder Request Readiness',
+    description: 'For suppliers and SMEs responding to sustainability-related requests from customers, investors, or business partners.',
+    bestFor: [
+      'Suppliers',
+      'Exporters',
+      'SMEs receiving ESG information requests',
+      'Companies preparing sustainability evidence',
+    ],
+    estimatedTime: '45–90 minutes',
+    outcomes: [
+      'Structured sustainability information',
+      'Relevant KPI overview',
+      'Evidence links attached to records',
+      'Better visibility of missing information',
+    ],
+    cta: 'Start Stakeholder Readiness',
+  },
+] as const;
+
+const COLOR_MAP = {
+  esg: {
+    iconBg: 'bg-esg-50 dark:bg-esg-900/30',
+    iconText: 'text-esg-600 dark:text-esg-400',
+    badge: 'bg-esg-50 text-esg-700 dark:bg-esg-900/40 dark:text-esg-300 border border-esg-100 dark:border-esg-800',
+    button: 'bg-esg-600 hover:bg-esg-700 focus-visible:ring-esg-500 text-white',
+    cardHover: 'hover:border-esg-200 dark:hover:border-esg-800',
+  },
+  green: {
+    iconBg: 'bg-green-50 dark:bg-green-900/30',
+    iconText: 'text-green-600 dark:text-green-400',
+    badge: 'bg-green-50 text-green-700 dark:bg-green-900/40 dark:text-green-300 border border-green-100 dark:border-green-800',
+    button: 'bg-green-600 hover:bg-green-700 focus-visible:ring-green-500 text-white',
+    cardHover: 'hover:border-green-200 dark:hover:border-green-800',
+  },
+  blue: {
+    iconBg: 'bg-blue-50 dark:bg-blue-900/30',
+    iconText: 'text-blue-600 dark:text-blue-400',
+    badge: 'bg-blue-50 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300 border border-blue-100 dark:border-blue-800',
+    button: 'bg-blue-600 hover:bg-blue-700 focus-visible:ring-blue-500 text-white',
+    cardHover: 'hover:border-blue-200 dark:hover:border-blue-800',
+  },
+};
+
+const StartHere: React.FC<StartHereProps> = ({ onSelectPath }) => (
+  <div className="animate-in fade-in duration-500 space-y-8 max-w-6xl mx-auto">
+    {/* Header */}
+    <div className="text-center space-y-3 pt-2 pb-2">
+      <h1 className="text-3xl md:text-4xl font-bold text-slate-800 dark:text-white">Start Here</h1>
+      <p className="text-lg text-slate-500 dark:text-slate-400 max-w-2xl mx-auto leading-relaxed">
+        Choose the sustainability path that best matches your current business need.
+      </p>
+    </div>
+
+    {/* Path cards */}
+    <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+      {PATHS.map((path) => {
+        const c = COLOR_MAP[path.color];
+        return (
+          <div
+            key={path.id}
+            className={`bg-white dark:bg-slate-800 rounded-2xl border border-slate-200 dark:border-slate-700 ${c.cardHover} p-6 flex flex-col gap-5 shadow-sm hover:shadow-md transition-all duration-200`}
+          >
+            {/* Icon + title */}
+            <div className="flex items-start gap-4">
+              <div className={`w-12 h-12 rounded-xl flex items-center justify-center flex-shrink-0 ${c.iconBg}`}>
+                <span className={c.iconText}>{path.icon}</span>
+              </div>
+              <div>
+                <h2 className="text-lg font-bold text-slate-800 dark:text-white leading-tight">{path.title}</h2>
+                <p className="text-sm text-slate-500 dark:text-slate-400 mt-1 leading-relaxed">{path.description}</p>
+              </div>
+            </div>
+
+            {/* Best for */}
+            <div>
+              <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-2">Best for</p>
+              <ul className="space-y-1.5">
+                {path.bestFor.map((item) => (
+                  <li key={item} className="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-300">
+                    <span className="w-1.5 h-1.5 rounded-full bg-slate-300 dark:bg-slate-500 flex-shrink-0" />
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </div>
+
+            {/* Estimated time */}
+            <div className="flex items-center gap-2">
+              <Clock className="w-4 h-4 text-slate-400 flex-shrink-0" />
+              <span className="text-sm text-slate-500 dark:text-slate-400">{path.estimatedTime}</span>
+            </div>
+
+            {/* Expected outcomes */}
+            <div className="flex-1">
+              <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-2">Expected outcomes</p>
+              <div className="flex flex-wrap gap-1.5">
+                {path.outcomes.map((outcome) => (
+                  <span key={outcome} className={`text-xs px-2.5 py-1 rounded-full font-medium ${c.badge}`}>
+                    {outcome}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            {/* CTA */}
+            <button
+              onClick={() => onSelectPath(path.id)}
+              className={`w-full flex items-center justify-center gap-2 px-4 py-2.5 rounded-xl font-semibold text-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 ${c.button}`}
+            >
+              {path.cta}
+              <ChevronRight className="w-4 h-4" />
+            </button>
+          </div>
+        );
+      })}
+    </div>
+  </div>
+);
+
+export default StartHere;

--- a/components/StartHere.tsx
+++ b/components/StartHere.tsx
@@ -32,7 +32,7 @@ const PATHS = [
   {
     id: 'start_here_carbon' as StartHerePathId,
     icon: <Leaf className="w-6 h-6" />,
-    color: 'green',
+    color: 'amber',
     title: 'Carbon Starter',
     description: 'For organizations beginning Scope 1 and Scope 2 carbon tracking.',
     bestFor: [
@@ -80,12 +80,12 @@ const COLOR_MAP = {
     button: 'bg-esg-600 hover:bg-esg-700 focus-visible:ring-esg-500 text-white',
     cardHover: 'hover:border-esg-200 dark:hover:border-esg-800',
   },
-  green: {
-    iconBg: 'bg-green-50 dark:bg-green-900/30',
-    iconText: 'text-green-600 dark:text-green-400',
-    badge: 'bg-green-50 text-green-700 dark:bg-green-900/40 dark:text-green-300 border border-green-100 dark:border-green-800',
-    button: 'bg-green-600 hover:bg-green-700 focus-visible:ring-green-500 text-white',
-    cardHover: 'hover:border-green-200 dark:hover:border-green-800',
+  amber: {
+    iconBg: 'bg-amber-50 dark:bg-amber-900/30',
+    iconText: 'text-amber-600 dark:text-amber-400',
+    badge: 'bg-amber-50 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300 border border-amber-100 dark:border-amber-800',
+    button: 'bg-amber-500 hover:bg-amber-600 focus-visible:ring-amber-400 text-white',
+    cardHover: 'hover:border-amber-200 dark:hover:border-amber-800',
   },
   blue: {
     iconBg: 'bg-blue-50 dark:bg-blue-900/30',

--- a/components/StartHerePath.tsx
+++ b/components/StartHerePath.tsx
@@ -16,7 +16,7 @@ interface Step {
 interface PathConfig {
   id: StartHerePathId;
   icon: React.ReactNode;
-  color: 'esg' | 'green' | 'blue';
+  color: 'esg' | 'amber' | 'blue';
   title: string;
   description: string;
   steps: Step[];
@@ -77,7 +77,7 @@ const PATHS: PathConfig[] = [
   {
     id: 'start_here_carbon',
     icon: <Leaf className="w-5 h-5" />,
-    color: 'green',
+    color: 'amber',
     title: 'Carbon Starter',
     description: 'Set up Scope 1 and Scope 2 carbon tracking step by step. Start small and build from there.',
     steps: [
@@ -174,13 +174,13 @@ const COLOR_MAP = {
     button: 'bg-esg-600 hover:bg-esg-700 text-white',
     optionalBadge: 'bg-esg-50 text-esg-600 dark:bg-esg-900/30 dark:text-esg-400 border border-esg-200 dark:border-esg-700',
   },
-  green: {
-    iconBg: 'bg-green-50 dark:bg-green-900/30',
-    iconText: 'text-green-600 dark:text-green-400',
-    stepCircle: 'bg-green-600 text-white',
-    stepLine: 'bg-green-200 dark:bg-green-800',
-    button: 'bg-green-600 hover:bg-green-700 text-white',
-    optionalBadge: 'bg-green-50 text-green-600 dark:bg-green-900/30 dark:text-green-400 border border-green-200 dark:border-green-700',
+  amber: {
+    iconBg: 'bg-amber-50 dark:bg-amber-900/30',
+    iconText: 'text-amber-600 dark:text-amber-400',
+    stepCircle: 'bg-amber-500 text-white',
+    stepLine: 'bg-amber-200 dark:bg-amber-800',
+    button: 'bg-amber-500 hover:bg-amber-600 text-white',
+    optionalBadge: 'bg-amber-50 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400 border border-amber-200 dark:border-amber-700',
   },
   blue: {
     iconBg: 'bg-blue-50 dark:bg-blue-900/30',

--- a/components/StartHerePath.tsx
+++ b/components/StartHerePath.tsx
@@ -1,0 +1,278 @@
+import React from 'react';
+import { ArrowLeft, ExternalLink, TrendingUp, Leaf, Globe } from 'lucide-react';
+import type { StartHerePathId } from './StartHere';
+
+type AppView = 'profile' | 'canvas' | 'swot' | 'dm_dashboard' | 'kpi' | 'tasks' | 'carbon_wizard' | 'carbon_dashboard' | 'insight_hub';
+
+interface Step {
+  number: number;
+  title: string;
+  description: string;
+  targetView: AppView;
+  buttonLabel: string;
+  optional?: boolean;
+}
+
+interface PathConfig {
+  id: StartHerePathId;
+  icon: React.ReactNode;
+  color: 'esg' | 'green' | 'blue';
+  title: string;
+  description: string;
+  steps: Step[];
+}
+
+const PATHS: PathConfig[] = [
+  {
+    id: 'start_here_esg',
+    icon: <TrendingUp className="w-5 h-5" />,
+    color: 'esg',
+    title: 'ESG Readiness',
+    description: 'Follow these steps to build your sustainability foundation. Each module builds on the previous one.',
+    steps: [
+      {
+        number: 1,
+        title: 'Company Profile',
+        description: 'Define the business context and company information used across the platform.',
+        targetView: 'profile',
+        buttonLabel: 'Open Company Profile',
+      },
+      {
+        number: 2,
+        title: 'Sustainability Business Model Canvas',
+        description: 'Connect sustainability thinking to the organisation\'s business model.',
+        targetView: 'canvas',
+        buttonLabel: 'Open Business Model',
+      },
+      {
+        number: 3,
+        title: 'SWOT Analysis',
+        description: 'Identify sustainability-related risks, opportunities, strengths, and weaknesses.',
+        targetView: 'swot',
+        buttonLabel: 'Open SWOT',
+      },
+      {
+        number: 4,
+        title: 'Double Materiality Assessment (DMA)',
+        description: 'Assess sustainability topics from impact and financial materiality perspectives.',
+        targetView: 'dm_dashboard',
+        buttonLabel: 'Open DMA',
+      },
+      {
+        number: 5,
+        title: 'KPI',
+        description: 'Define measurable sustainability indicators connected to material topics.',
+        targetView: 'kpi',
+        buttonLabel: 'Open KPI',
+      },
+      {
+        number: 6,
+        title: 'Task Generator',
+        description: 'Generate suggested sustainability tasks based on KPI and DMA information.',
+        targetView: 'tasks',
+        buttonLabel: 'Open Tasks',
+      },
+    ],
+  },
+  {
+    id: 'start_here_carbon',
+    icon: <Leaf className="w-5 h-5" />,
+    color: 'green',
+    title: 'Carbon Starter',
+    description: 'Set up Scope 1 and Scope 2 carbon tracking step by step. Start small and build from there.',
+    steps: [
+      {
+        number: 1,
+        title: 'Company Profile',
+        description: 'Set up the business context used for carbon tracking.',
+        targetView: 'profile',
+        buttonLabel: 'Open Company Profile',
+      },
+      {
+        number: 2,
+        title: 'Carbon Setup',
+        description: 'Configure emission tracking categories and carbon settings.',
+        targetView: 'carbon_wizard',
+        buttonLabel: 'Open Carbon Setup',
+      },
+      {
+        number: 3,
+        title: 'Carbon Entries',
+        description: 'Record monthly fuel, electricity, and activity data.',
+        targetView: 'carbon_wizard',
+        buttonLabel: 'Open Carbon Entries',
+      },
+      {
+        number: 4,
+        title: 'Carbon Dashboard',
+        description: 'Review emissions trends and identify major emission sources.',
+        targetView: 'carbon_dashboard',
+        buttonLabel: 'Open Carbon Dashboard',
+      },
+      {
+        number: 5,
+        title: 'Create Carbon-related KPI',
+        description: 'Connect carbon activities to measurable sustainability KPIs.',
+        targetView: 'kpi',
+        buttonLabel: 'Open KPI',
+        optional: true,
+      },
+    ],
+  },
+  {
+    id: 'start_here_stakeholder',
+    icon: <Globe className="w-5 h-5" />,
+    color: 'blue',
+    title: 'Stakeholder Request Readiness',
+    description: 'Organise your sustainability information so you can respond to requests with confidence.',
+    steps: [
+      {
+        number: 1,
+        title: 'Company Profile',
+        description: 'Set up organisational information used across sustainability records.',
+        targetView: 'profile',
+        buttonLabel: 'Open Company Profile',
+      },
+      {
+        number: 2,
+        title: 'Double Materiality Assessment (DMA)',
+        description: 'Identify material sustainability topics relevant to stakeholders.',
+        targetView: 'dm_dashboard',
+        buttonLabel: 'Open DMA',
+      },
+      {
+        number: 3,
+        title: 'KPI',
+        description: 'Organise measurable sustainability information.',
+        targetView: 'kpi',
+        buttonLabel: 'Open KPI',
+      },
+      {
+        number: 4,
+        title: 'Attach Evidence URLs',
+        description: 'Attach document links and supporting evidence to KPI, Task, and Carbon records.',
+        targetView: 'kpi',
+        buttonLabel: 'Open KPI & Evidence',
+      },
+      {
+        number: 5,
+        title: 'Review Open Gaps',
+        description: 'Identify areas where sustainability information is incomplete or missing.',
+        targetView: 'insight_hub',
+        buttonLabel: 'Open Insight Hub',
+      },
+    ],
+  },
+];
+
+const COLOR_MAP = {
+  esg: {
+    iconBg: 'bg-esg-50 dark:bg-esg-900/30',
+    iconText: 'text-esg-600 dark:text-esg-400',
+    stepCircle: 'bg-esg-600 text-white',
+    stepLine: 'bg-esg-200 dark:bg-esg-800',
+    button: 'bg-esg-600 hover:bg-esg-700 text-white',
+    optionalBadge: 'bg-esg-50 text-esg-600 dark:bg-esg-900/30 dark:text-esg-400 border border-esg-200 dark:border-esg-700',
+  },
+  green: {
+    iconBg: 'bg-green-50 dark:bg-green-900/30',
+    iconText: 'text-green-600 dark:text-green-400',
+    stepCircle: 'bg-green-600 text-white',
+    stepLine: 'bg-green-200 dark:bg-green-800',
+    button: 'bg-green-600 hover:bg-green-700 text-white',
+    optionalBadge: 'bg-green-50 text-green-600 dark:bg-green-900/30 dark:text-green-400 border border-green-200 dark:border-green-700',
+  },
+  blue: {
+    iconBg: 'bg-blue-50 dark:bg-blue-900/30',
+    iconText: 'text-blue-600 dark:text-blue-400',
+    stepCircle: 'bg-blue-600 text-white',
+    stepLine: 'bg-blue-200 dark:bg-blue-800',
+    button: 'bg-blue-600 hover:bg-blue-700 text-white',
+    optionalBadge: 'bg-blue-50 text-blue-600 dark:bg-blue-900/30 dark:text-blue-400 border border-blue-200 dark:border-blue-700',
+  },
+};
+
+interface StartHerePathProps {
+  pathId: StartHerePathId;
+  onBack: () => void;
+  onNavigate: (view: AppView) => void;
+}
+
+const StartHerePath: React.FC<StartHerePathProps> = ({ pathId, onBack, onNavigate }) => {
+  const config = PATHS.find(p => p.id === pathId);
+  if (!config) return null;
+
+  const c = COLOR_MAP[config.color];
+
+  return (
+    <div className="animate-in fade-in duration-500 max-w-2xl mx-auto space-y-8">
+      {/* Back */}
+      <button
+        onClick={onBack}
+        className="flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400 hover:text-slate-800 dark:hover:text-white transition-colors"
+      >
+        <ArrowLeft className="w-4 h-4" />
+        Back to Start Here
+      </button>
+
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <div className={`w-12 h-12 rounded-xl flex items-center justify-center flex-shrink-0 ${c.iconBg}`}>
+          <span className={c.iconText}>{config.icon}</span>
+        </div>
+        <div>
+          <h1 className="text-2xl font-bold text-slate-800 dark:text-white">{config.title}</h1>
+          <p className="text-sm text-slate-500 dark:text-slate-400 mt-0.5 leading-relaxed">{config.description}</p>
+        </div>
+      </div>
+
+      {/* Steps */}
+      <div className="space-y-0">
+        {config.steps.map((step, index) => {
+          const isLast = index === config.steps.length - 1;
+          return (
+            <div key={step.number} className="flex gap-4">
+              {/* Timeline column */}
+              <div className="flex flex-col items-center flex-shrink-0 w-10">
+                <div className={`w-8 h-8 rounded-full flex items-center justify-center text-sm font-bold flex-shrink-0 ${step.optional ? 'bg-slate-200 dark:bg-slate-700 text-slate-500 dark:text-slate-400' : c.stepCircle}`}>
+                  {step.number}
+                </div>
+                {!isLast && (
+                  <div className={`w-0.5 flex-1 my-1 min-h-[2rem] ${step.optional ? 'bg-slate-200 dark:bg-slate-700' : c.stepLine}`} />
+                )}
+              </div>
+
+              {/* Content */}
+              <div className={`flex-1 pb-6 ${isLast ? '' : ''}`}>
+                <div className={`bg-white dark:bg-slate-800 rounded-xl border p-5 shadow-sm ${step.optional ? 'border-dashed border-slate-200 dark:border-slate-700' : 'border-slate-200 dark:border-slate-700'}`}>
+                  <div className="flex items-start justify-between gap-3 flex-wrap">
+                    <div className="space-y-1 flex-1 min-w-0">
+                      <div className="flex items-center gap-2 flex-wrap">
+                        <h3 className="font-semibold text-slate-800 dark:text-white">{step.title}</h3>
+                        {step.optional && (
+                          <span className={`text-xs px-2 py-0.5 rounded-full font-medium ${c.optionalBadge}`}>
+                            Optional
+                          </span>
+                        )}
+                      </div>
+                      <p className="text-sm text-slate-500 dark:text-slate-400 leading-relaxed">{step.description}</p>
+                    </div>
+                    <button
+                      onClick={() => onNavigate(step.targetView)}
+                      className={`flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-sm font-medium transition-colors flex-shrink-0 ${c.button}`}
+                    >
+                      {step.buttonLabel}
+                      <ExternalLink className="w-3.5 h-3.5" />
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};
+
+export default StartHerePath;


### PR DESCRIPTION
## Summary

Adds a lightweight **Start Here** onboarding layer to reduce new-user confusion. No backend changes, no DB changes — pure navigation and orientation.

- New **Start Here** item in the sidebar (top of nav, above Overview)
- Landing page with 3 sustainability journey cards (ESG Readiness, Carbon Starter, Stakeholder Request Readiness)
- Each card shows: Best For list, estimated time, and expected outcome badges
- Clicking a card opens a step-by-step checklist that links directly to existing modules

## New files

| File | Purpose |
|---|---|
| `components/StartHere.tsx` | Main landing page — 3 path cards |
| `components/StartHerePath.tsx` | Reusable step-checklist — renders all 3 path detail pages |

## App.tsx changes

- Added `Compass` icon + `Start Here` `NavItem` above Overview
- Extended view union type with `start_here`, `start_here_esg`, `start_here_carbon`, `start_here_stakeholder`
- Added breadcrumb labels and render cases for all new views

## Closes

- #116 — Start Here nav + landing page
- #117 — ESG Readiness path (6 steps)
- #118 — Carbon Starter path (4 steps + 1 optional)
- #119 — Stakeholder Request Readiness path (5 steps)

## Test plan

- [ ] "Start Here" appears at the top of the sidebar
- [ ] Landing page shows 3 cards with correct content, time estimates, and outcomes
- [ ] Each card CTA navigates to its path detail page
- [ ] Each step's button navigates to the correct existing module
- [ ] Optional step in Carbon Starter is visually distinct (dashed border + Optional badge)
- [ ] Back button returns to the Start Here landing page
- [ ] Dark mode works on all new pages
- [ ] Mobile layout stacks cards to 1 column

🤖 Generated with [Claude Code](https://claude.com/claude-code)