### PR TITLE
chore(deps): harden remaining runtime dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@google/genai": "^1.30.0",
-        "@netlify/blobs": "^10.7.4",
+        "@netlify/blobs": "^10.7.13",
         "@supabase/supabase-js": "^2.45.0",
         "lucide-react": "^0.554.0",
         "react": "^19.2.0",
@@ -21,9 +21,9 @@
         "@netlify/functions": "^3.0.0",
         "@types/node": "^22.14.0",
         "@vitejs/plugin-react": "^5.0.0",
-        "netlify-cli": "^27.0.1",
+        "netlify-cli": "^27.1.1",
         "typescript": "~5.8.2",
-        "vite": "^6.2.0"
+        "vite": "^6.4.3"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2037,9 +2037,9 @@
       }
     },
     "node_modules/@netlify/api": {
-      "version": "15.1.0",
-      "resolved": "https://registry.npmjs.org/@netlify/api/-/api-15.1.0.tgz",
-      "integrity": "sha512-JhnBtwAzy6pMv0hepMZn8qWbU9a+aeujJ9roXU4lVmXaIBnfl6Icso2TyVJgVCqoLwGw122Yh0RW5KdvPDFpBA==",
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/@netlify/api/-/api-15.1.1.tgz",
+      "integrity": "sha512-5PW8Yo6DsKHtBdbXJUtGOmkuGrACFVjNKYoF1S1d1PdsZHg21Sa/GjoQAQEfhq5AQyXdT9g7pZpL1PsdvXc8XA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2079,13 +2079,13 @@
       "license": "Apache 2"
     },
     "node_modules/@netlify/blobs": {
-      "version": "10.7.10",
-      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-10.7.10.tgz",
-      "integrity": "sha512-q5U/Liqub1MYGiBHEoEgp93Z3XBTHKZ6NGp1YoWqCbGo+UgBDKJTk0/ypMavDz4H+iXHoVe3pq/JMGucX7aVkg==",
+      "version": "10.7.13",
+      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-10.7.13.tgz",
+      "integrity": "sha512-LJnmGtQQ2/NdTo0Cm+YP2xR1vtRle6V3kkzMrAOJgRm1SEFOJOcaAFQrth7RnbxCH/IzCM8QakTaCHHKY+K2qA==",
       "license": "MIT",
       "dependencies": {
-        "@netlify/dev-utils": "4.4.7",
-        "@netlify/otel": "^6.0.4",
+        "@netlify/dev-utils": "5.0.0",
+        "@netlify/otel": "^6.0.6",
         "@netlify/runtime-utils": "2.3.0"
       },
       "engines": {
@@ -2093,9 +2093,9 @@
       }
     },
     "node_modules/@netlify/blobs/node_modules/@netlify/dev-utils": {
-      "version": "4.4.7",
-      "resolved": "https://registry.npmjs.org/@netlify/dev-utils/-/dev-utils-4.4.7.tgz",
-      "integrity": "sha512-etfUY5SyraYG+i4msfVnWuFEkia6XLxeoe8Hh5uGO6QJ4OAQT4EmesXjulsI0/7EozMxdiANGnf2AAshn+2jpQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@netlify/dev-utils/-/dev-utils-5.0.0.tgz",
+      "integrity": "sha512-ICAsnvbJW9Dv9PGfmJGdjMBsX6uXdJxrA76QE3l3rnGKL5ZcyaA2cJZXacdEmE2ZmtkiVhEJogM15a9nK/ZxDw==",
       "license": "MIT",
       "dependencies": {
         "@whatwg-node/server": "^0.11.0",
@@ -2107,11 +2107,8 @@
         "dot-prop": "9.0.0",
         "empathic": "^2.0.0",
         "env-paths": "^3.0.0",
-        "image-size": "^2.0.2",
-        "js-image-generator": "^1.0.4",
         "parse-gitignore": "^2.0.0",
-        "semver": "^7.7.2",
-        "tmp-promise": "^3.0.3"
+        "semver": "^7.7.2"
       },
       "engines": {
         "node": "^18.14.0 || >=20"
@@ -2134,23 +2131,23 @@
       }
     },
     "node_modules/@netlify/build": {
-      "version": "36.2.3",
-      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-36.2.3.tgz",
-      "integrity": "sha512-KHGuD43RSTK5Z3r44ACUZQIkvM1jILMhY3cEQl/dZo/y1PVeAeO7PQwKzei4k7M5P6ucRFhAAQPr27gMR9gUZQ==",
+      "version": "36.3.5",
+      "resolved": "https://registry.npmjs.org/@netlify/build/-/build-36.3.5.tgz",
+      "integrity": "sha512-j0UcJvlNwh8nQ4TuYjGHLy1sS3AZp2UjsSVhZQLHKlC1LSbiMaHpEosVw6jyrW5NLLNkIrBUTA1FImlPIR6b8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@bugsnag/js": "^8.0.0",
         "@netlify/blobs": "^10.4.4",
-        "@netlify/cache-utils": "^7.1.0",
-        "@netlify/config": "^25.1.1",
-        "@netlify/edge-bundler": "16.0.0",
-        "@netlify/functions-utils": "^7.1.0",
+        "@netlify/cache-utils": "^7.1.1",
+        "@netlify/config": "^25.2.2",
+        "@netlify/edge-bundler": "16.0.3",
+        "@netlify/functions-utils": "^7.1.4",
         "@netlify/git-utils": "^7.1.0",
         "@netlify/opentelemetry-utils": "^3.1.0",
         "@netlify/plugins-list": "^6.81.6",
         "@netlify/run-utils": "^7.1.0",
-        "@netlify/zip-it-and-ship-it": "15.3.0",
+        "@netlify/zip-it-and-ship-it": "15.3.4",
         "@sindresorhus/slugify": "^2.0.0",
         "ansi-escapes": "^7.0.0",
         "ansis": "^4.1.0",
@@ -2190,7 +2187,7 @@
         "typescript": "^5.0.0",
         "yaml": "^2.8.0",
         "yargs": "^17.6.0",
-        "zod": "^3.25.76"
+        "zod": "^4.0.5"
       },
       "bin": {
         "netlify-build": "bin.js"
@@ -2209,9 +2206,9 @@
       }
     },
     "node_modules/@netlify/build-info": {
-      "version": "11.2.0",
-      "resolved": "https://registry.npmjs.org/@netlify/build-info/-/build-info-11.2.0.tgz",
-      "integrity": "sha512-NoH0Qjn/FqmVbwR7o/xliB/csl77KGCedisCEMDAyoNbiK1/b7tNDXj23QxL9z57K1i4VNIF/Z0NXzip8Pbsjg==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/@netlify/build-info/-/build-info-11.3.0.tgz",
+      "integrity": "sha512-xhoPqbfTSroUtFElUR6Wsw0+XlSihtLxvuaNQKv5+JTkvNqpBNIVPdo9drqwhh1eqlUeHJszfCGc1P6950yL0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2273,9 +2270,9 @@
       }
     },
     "node_modules/@netlify/build/node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2712,32 +2709,32 @@
       }
     },
     "node_modules/@netlify/build/node_modules/@netlify/serverless-functions-api": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@netlify/serverless-functions-api/-/serverless-functions-api-2.16.0.tgz",
-      "integrity": "sha512-yomP0pYRWPREiAuQbLghz9YbMb2+Mkmk1DMjyXVbIyrJ8QZhEtGcYQWAyl6cgki5CVqnOXvfIrRdLSf8bvxJCA==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@netlify/serverless-functions-api/-/serverless-functions-api-2.18.0.tgz",
+      "integrity": "sha512-Uo5XyMFZOinq6AonHu6dUOkLvVydn+SaldoVkB4yQSpDrtqYWi56CoA26IIOur1EMJqRdt6JIzjzIe4jpzYdhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@netlify/types": "^2.6.0"
+        "@netlify/types": "^2.8.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@netlify/build/node_modules/@netlify/zip-it-and-ship-it": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-15.3.0.tgz",
-      "integrity": "sha512-m8lUq1kbzwC3Npapp2dZVUM5PZuFJTimLPqeUdbEDnMF2VHlNJP+Of8BZC4gWFr0kI/X0Ip9/Ce5IBXeeC9AAg==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-15.3.4.tgz",
+      "integrity": "sha512-6j3BjHXWX+Wn10Mj9AGL9MkBsT7Aqidwy6y6b8x40WC594BYe6swfiM/HjBw0AtWbXTSTP1ap/wbMj4Gvx5FrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.22.5",
         "@babel/types": "^7.28.5",
         "@netlify/binary-info": "^1.0.0",
-        "@netlify/serverless-functions-api": "2.16.0",
+        "@netlify/serverless-functions-api": "2.18.0",
         "@opentelemetry/api": "~1.8.0",
         "@vercel/nft": "0.29.4",
-        "archiver": "^7.0.0",
+        "archiver": "^8.0.0",
         "common-path-prefix": "^3.0.0",
         "copy-file": "^11.0.0",
         "es-module-lexer": "^1.0.0",
@@ -2763,13 +2760,34 @@
         "unixify": "^1.0.0",
         "urlpattern-polyfill": "8.0.2",
         "yargs": "^17.0.0",
-        "zod": "^3.23.8"
+        "zod": "^4.0.5"
       },
       "bin": {
         "zip-it-and-ship-it": "bin.js"
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@netlify/build/node_modules/archiver": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-8.0.0.tgz",
+      "integrity": "sha512-fV1orZfsnPn9BaSByR/qE67rJCLJEy2Ox5bq7nJh+jquWaNh6Sfec75kJ2T6PtdGUbPQlrVoSVCEOa5SdiTQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "is-stream": "^4.0.0",
+        "lazystream": "^1.0.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^3.0.0",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^7.0.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@netlify/build/node_modules/balanced-match": {
@@ -2793,6 +2811,37 @@
       },
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/@netlify/build/node_modules/compress-commons": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-7.0.1.tgz",
+      "integrity": "sha512-g0S8KAD8qf4+V//pr3BfB1aBnARLXNz2Gx+jmHU0LEriUuoQUOPOulVquHKTJ8+EAIIO7fhseNDr9wK5Q9FKBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^7.0.1",
+        "is-stream": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@netlify/build/node_modules/crc32-stream": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-7.0.1.tgz",
+      "integrity": "sha512-IBWsY8xznyQrcHn8h4bC8/4ErNke5elzgG8GcqF4RFPw6aHkWWRc7Tgw6upjaTX/CT/yQgqYENkxYsTYN+hW2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@netlify/build/node_modules/esbuild": {
@@ -2876,6 +2925,22 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@netlify/build/node_modules/readdir-glob": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-3.0.0.tgz",
+      "integrity": "sha512-AhNB2KgKeVJr16nK9LLZbJNWnYoT23ZrumNKFDebHBdkC8KHSqWo871JAUhoWC/RtjEVdqNMFpM6qrwRbaUqpw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/yqnn"
+      }
+    },
     "node_modules/@netlify/build/node_modules/supports-hyperlinks": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/supports-hyperlinks/-/supports-hyperlinks-3.2.0.tgz",
@@ -2923,6 +2988,31 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@netlify/build/node_modules/zip-stream": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-7.0.5.tgz",
+      "integrity": "sha512-dSvYKdvLsAHCDqPOhIwk/q5CvuWtTB3Dgpoe0uVEFjTzIOAmsQpprX25InCvrvJsirEbu1OHyy67n/kAj1Sw/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "compress-commons": "^7.0.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@netlify/build/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@netlify/cache": {
       "version": "3.4.9",
       "resolved": "https://registry.npmjs.org/@netlify/cache/-/cache-3.4.9.tgz",
@@ -2937,15 +3027,13 @@
       }
     },
     "node_modules/@netlify/cache-utils": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@netlify/cache-utils/-/cache-utils-7.1.0.tgz",
-      "integrity": "sha512-yHJ7uoTH7l4IJKt4y6ogD2uQ6+C66Zxy8r4tVaHgqQM8OOE3U2nrzdGrLooWNX+BdpE0Cop0AibMVBFKVnpbkQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@netlify/cache-utils/-/cache-utils-7.1.1.tgz",
+      "integrity": "sha512-BYEjot6OdatabN8tCYgHhFfxsS9S4kUQlzMBbihbUUNPeqWPD27pem60r12DXYLl840kHQxbWu4k72s43yMRIw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cpy": "^11.0.0",
         "get-stream": "^9.0.0",
-        "globby": "^14.0.0",
         "junk": "^4.0.0",
         "locate-path": "^7.0.0",
         "move-file": "^3.0.0",
@@ -2973,14 +3061,14 @@
       }
     },
     "node_modules/@netlify/config": {
-      "version": "25.1.1",
-      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-25.1.1.tgz",
-      "integrity": "sha512-ppIKwtUklP9KiXKvSZ7bllCETPzuBTNVwyJ+wfBBzgJ3opEyibI3cFCipjPmF/9u/yh3UKN7a9m2Py2HaGBgjg==",
+      "version": "25.2.2",
+      "resolved": "https://registry.npmjs.org/@netlify/config/-/config-25.2.2.tgz",
+      "integrity": "sha512-THmWE1gDge+kko9Y2dWunCeQm5uIyDSnXnEgzgkweZ3ZlIGNlBsT78ntL1Bsi4rttCjlRLSlFv+CokCGKCyyKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@netlify/api": "^15.1.0",
-        "@netlify/headers-parser": "^10.1.0",
+        "@netlify/api": "^15.1.1",
+        "@netlify/headers-parser": "^10.1.1",
         "@netlify/redirect-parser": "^16.1.0",
         "chalk": "^5.0.0",
         "cron-parser": "^4.1.0",
@@ -2994,7 +3082,6 @@
         "indent-string": "^5.0.0",
         "is-plain-obj": "^4.0.0",
         "map-obj": "^5.0.0",
-        "omit.js": "^2.0.2",
         "p-locate": "^6.0.0",
         "path-type": "^6.0.0",
         "read-package-up": "^11.0.0",
@@ -3097,6 +3184,21 @@
         "node": "^14.16.0 || >=16.0.0"
       }
     },
+    "node_modules/@netlify/dev/node_modules/@netlify/blobs": {
+      "version": "10.7.10",
+      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-10.7.10.tgz",
+      "integrity": "sha512-q5U/Liqub1MYGiBHEoEgp93Z3XBTHKZ6NGp1YoWqCbGo+UgBDKJTk0/ypMavDz4H+iXHoVe3pq/JMGucX7aVkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@netlify/dev-utils": "4.4.7",
+        "@netlify/otel": "^6.0.4",
+        "@netlify/runtime-utils": "2.3.0"
+      },
+      "engines": {
+        "node": "^14.16.0 || >=16.0.0"
+      }
+    },
     "node_modules/@netlify/dev/node_modules/@netlify/dev-utils": {
       "version": "4.4.7",
       "resolved": "https://registry.npmjs.org/@netlify/dev-utils/-/dev-utils-4.4.7.tgz",
@@ -3141,9 +3243,9 @@
       }
     },
     "node_modules/@netlify/edge-bundler": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@netlify/edge-bundler/-/edge-bundler-16.0.0.tgz",
-      "integrity": "sha512-O0TQCKzzsOcjKx9uCYTkvnnEhr3En2TiALkgKFIC0ubrjG2ApdYfXfLmnDNRTKDWzVbzXPJKNClSNm/CcMiD4A==",
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/@netlify/edge-bundler/-/edge-bundler-16.0.3.tgz",
+      "integrity": "sha512-J1dOevPbPEsYw/sn5g2Kjri/oAe2AkgmS/jf75PBHEwgzkfFlRL3w+6/BaoIxlU6G0zu34jlLsleIdEUkSDM3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3154,16 +3256,12 @@
         "ajv-errors": "^3.0.0",
         "better-ajv-errors": "^1.2.0",
         "common-path-prefix": "^3.0.0",
-        "env-paths": "^3.0.0",
         "esbuild": "0.28.1",
         "execa": "^8.0.0",
         "find-up": "^7.0.0",
-        "get-port": "^7.0.0",
         "node-stream-zip": "^1.15.0",
         "p-retry": "^6.0.0",
-        "p-wait-for": "^5.0.0",
         "parse-imports": "^2.2.1",
-        "path-key": "^4.0.0",
         "semver": "^7.3.8",
         "tar": "^7.5.12",
         "tmp-promise": "^3.0.3",
@@ -3660,19 +3758,6 @@
       },
       "engines": {
         "node": ">=16.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@netlify/edge-bundler/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -4792,6 +4877,21 @@
         "node": ">=18"
       }
     },
+    "node_modules/@netlify/functions-dev/node_modules/@netlify/blobs": {
+      "version": "10.7.10",
+      "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-10.7.10.tgz",
+      "integrity": "sha512-q5U/Liqub1MYGiBHEoEgp93Z3XBTHKZ6NGp1YoWqCbGo+UgBDKJTk0/ypMavDz4H+iXHoVe3pq/JMGucX7aVkg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@netlify/dev-utils": "4.4.7",
+        "@netlify/otel": "^6.0.4",
+        "@netlify/runtime-utils": "2.3.0"
+      },
+      "engines": {
+        "node": "^14.16.0 || >=16.0.0"
+      }
+    },
     "node_modules/@netlify/functions-dev/node_modules/@netlify/dev-utils": {
       "version": "4.4.7",
       "resolved": "https://registry.npmjs.org/@netlify/dev-utils/-/dev-utils-4.4.7.tgz",
@@ -4991,13 +5091,13 @@
       }
     },
     "node_modules/@netlify/functions-utils": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-7.1.0.tgz",
-      "integrity": "sha512-ZQSnvE9xdI1EvBYFWAid+jNoQmjyUcuMgaAifJknF4fBte3qf07LcQLhM2lWuKipB9MsrMGPPXxxK8OO4Mk1Yw==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/@netlify/functions-utils/-/functions-utils-7.1.4.tgz",
+      "integrity": "sha512-Ou7nYWEsgh87Sd/jNsYPQxt9BPGtugJIQRECEL3l/PKUQoCFWQ3AQP3eQRIcf32VJ565gIDyWyW1tRsON+BFYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@netlify/zip-it-and-ship-it": "15.3.0",
+        "@netlify/zip-it-and-ship-it": "15.3.4",
         "cpy": "^11.0.0",
         "path-exists": "^5.0.0"
       },
@@ -5006,9 +5106,9 @@
       }
     },
     "node_modules/@netlify/functions-utils/node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5445,32 +5545,32 @@
       }
     },
     "node_modules/@netlify/functions-utils/node_modules/@netlify/serverless-functions-api": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@netlify/serverless-functions-api/-/serverless-functions-api-2.16.0.tgz",
-      "integrity": "sha512-yomP0pYRWPREiAuQbLghz9YbMb2+Mkmk1DMjyXVbIyrJ8QZhEtGcYQWAyl6cgki5CVqnOXvfIrRdLSf8bvxJCA==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@netlify/serverless-functions-api/-/serverless-functions-api-2.18.0.tgz",
+      "integrity": "sha512-Uo5XyMFZOinq6AonHu6dUOkLvVydn+SaldoVkB4yQSpDrtqYWi56CoA26IIOur1EMJqRdt6JIzjzIe4jpzYdhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@netlify/types": "^2.6.0"
+        "@netlify/types": "^2.8.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@netlify/functions-utils/node_modules/@netlify/zip-it-and-ship-it": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-15.3.0.tgz",
-      "integrity": "sha512-m8lUq1kbzwC3Npapp2dZVUM5PZuFJTimLPqeUdbEDnMF2VHlNJP+Of8BZC4gWFr0kI/X0Ip9/Ce5IBXeeC9AAg==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-15.3.4.tgz",
+      "integrity": "sha512-6j3BjHXWX+Wn10Mj9AGL9MkBsT7Aqidwy6y6b8x40WC594BYe6swfiM/HjBw0AtWbXTSTP1ap/wbMj4Gvx5FrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.22.5",
         "@babel/types": "^7.28.5",
         "@netlify/binary-info": "^1.0.0",
-        "@netlify/serverless-functions-api": "2.16.0",
+        "@netlify/serverless-functions-api": "2.18.0",
         "@opentelemetry/api": "~1.8.0",
         "@vercel/nft": "0.29.4",
-        "archiver": "^7.0.0",
+        "archiver": "^8.0.0",
         "common-path-prefix": "^3.0.0",
         "copy-file": "^11.0.0",
         "es-module-lexer": "^1.0.0",
@@ -5496,13 +5596,34 @@
         "unixify": "^1.0.0",
         "urlpattern-polyfill": "8.0.2",
         "yargs": "^17.0.0",
-        "zod": "^3.23.8"
+        "zod": "^4.0.5"
       },
       "bin": {
         "zip-it-and-ship-it": "bin.js"
       },
       "engines": {
         "node": ">=22.12.0"
+      }
+    },
+    "node_modules/@netlify/functions-utils/node_modules/archiver": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-8.0.0.tgz",
+      "integrity": "sha512-fV1orZfsnPn9BaSByR/qE67rJCLJEy2Ox5bq7nJh+jquWaNh6Sfec75kJ2T6PtdGUbPQlrVoSVCEOa5SdiTQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "is-stream": "^4.0.0",
+        "lazystream": "^1.0.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^3.0.0",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^7.0.2"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@netlify/functions-utils/node_modules/balanced-match": {
@@ -5526,6 +5647,37 @@
       },
       "engines": {
         "node": "20 || >=22"
+      }
+    },
+    "node_modules/@netlify/functions-utils/node_modules/compress-commons": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-7.0.1.tgz",
+      "integrity": "sha512-g0S8KAD8qf4+V//pr3BfB1aBnARLXNz2Gx+jmHU0LEriUuoQUOPOulVquHKTJ8+EAIIO7fhseNDr9wK5Q9FKBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^7.0.1",
+        "is-stream": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@netlify/functions-utils/node_modules/crc32-stream": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-7.0.1.tgz",
+      "integrity": "sha512-IBWsY8xznyQrcHn8h4bC8/4ErNke5elzgG8GcqF4RFPw6aHkWWRc7Tgw6upjaTX/CT/yQgqYENkxYsTYN+hW2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@netlify/functions-utils/node_modules/esbuild": {
@@ -5586,6 +5738,47 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/@netlify/functions-utils/node_modules/readdir-glob": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-3.0.0.tgz",
+      "integrity": "sha512-AhNB2KgKeVJr16nK9LLZbJNWnYoT23ZrumNKFDebHBdkC8KHSqWo871JAUhoWC/RtjEVdqNMFpM6qrwRbaUqpw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/yqnn"
+      }
+    },
+    "node_modules/@netlify/functions-utils/node_modules/zip-stream": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-7.0.5.tgz",
+      "integrity": "sha512-dSvYKdvLsAHCDqPOhIwk/q5CvuWtTB3Dgpoe0uVEFjTzIOAmsQpprX25InCvrvJsirEbu1OHyy67n/kAj1Sw/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "compress-commons": "^7.0.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@netlify/functions-utils/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
     "node_modules/@netlify/functions/node_modules/@netlify/blobs": {
       "version": "9.1.2",
       "resolved": "https://registry.npmjs.org/@netlify/blobs/-/blobs-9.1.2.tgz",
@@ -5640,34 +5833,17 @@
       }
     },
     "node_modules/@netlify/headers-parser": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/@netlify/headers-parser/-/headers-parser-10.1.0.tgz",
-      "integrity": "sha512-77hO29DpV8bIvLcf5zgJ9oXtnh1Oa1KgSMlotlH848nU84ZDjV2qA46SiYiSpZQEc3YGqWis0EF6IAnMfYCRtA==",
+      "version": "10.1.1",
+      "resolved": "https://registry.npmjs.org/@netlify/headers-parser/-/headers-parser-10.1.1.tgz",
+      "integrity": "sha512-ooiSc/eN/ktuugZmY4GVPh6nBYz2um0zpemokDvTLLQPF12QyXil8N6fr82wdLi03WNowwiL98eultZkTyHlyw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "escape-string-regexp": "^5.0.0",
-        "fast-safe-stringify": "^2.0.7",
-        "is-plain-obj": "^4.0.0",
-        "map-obj": "^5.0.0",
-        "path-exists": "^5.0.0",
         "smol-toml": "^1.5.2"
       },
       "engines": {
         "node": ">=22.12.0"
-      }
-    },
-    "node_modules/@netlify/headers-parser/node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@netlify/images": {
@@ -5707,13 +5883,13 @@
       }
     },
     "node_modules/@netlify/otel": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/@netlify/otel/-/otel-6.0.4.tgz",
-      "integrity": "sha512-ip7oBZ31rVasqpZT/acc20itbadrVvTLaZTWF8nAKIUn4mAzJ6ma5vSwQO77hTHeVMKqfBaIIHTywbb9+tfwhA==",
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@netlify/otel/-/otel-6.0.6.tgz",
+      "integrity": "sha512-KpiJ8c4V4GvgpQH5E1axg43kYdIN9saToLbzvgrDzPun4XMGwz/tLfoIkwJ4jwrVmbPj35+8+dj3gkggQAtjtg==",
       "license": "MIT",
       "dependencies": {
         "@opentelemetry/api": "1.9.1",
-        "@opentelemetry/core": "2.7.1",
+        "@opentelemetry/core": "2.8.0",
         "@opentelemetry/instrumentation": "^0.220.0",
         "@opentelemetry/resources": "2.9.0",
         "@opentelemetry/sdk-trace-node": "2.9.0"
@@ -6235,9 +6411,9 @@
       }
     },
     "node_modules/@opentelemetry/core": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.7.1.tgz",
-      "integrity": "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw==",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.8.0.tgz",
+      "integrity": "sha512-hd1Lfh8p545nNz+jq1Ejfz+Mn1hyLuxYn1YzTfFNrxr8urEWMNQLPf1Th8kjOH+HxwawCrtgBp8JpBUR4ZSgww==",
       "license": "Apache-2.0",
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -7095,9 +7271,9 @@
       }
     },
     "node_modules/@tsconfig/node10": {
-      "version": "1.0.12",
-      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.12.tgz",
-      "integrity": "sha512-UCYBaeFvM11aU2y3YPZ//O5Rhj+xKyzy7mvcIoAjASbigy8mHMryP5cK7dgjlz2hWxh1g5pLw084E0a/wlUSFQ==",
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.13.tgz",
+      "integrity": "sha512-gcLdvR9HO1ZJBypsOGqaP6TFEzb6vIta0KSTLt9NAQ6pXQO3cRgSVyCN6pzYqI9DlJgY71XKO0dpDhCf08b3pg==",
       "dev": true,
       "license": "MIT"
     },
@@ -8742,9 +8918,9 @@
       }
     },
     "node_modules/cjs-module-lexer": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.0.tgz",
-      "integrity": "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-2.2.1.tgz",
+      "integrity": "sha512-Ca8swihM+/4yKecYHY52kgJd300hi2lADU/a1RxNTRe+RJ9jvqQlESpbz9DnG9mowez8qwXHB8qYdIUw9e+F5Q==",
       "license": "MIT"
     },
     "node_modules/clean-stack": {
@@ -11666,9 +11842,9 @@
       }
     },
     "node_modules/http-proxy-middleware": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
-      "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz",
+      "integrity": "sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -11680,7 +11856,7 @@
         "micromatch": "^4.0.8"
       },
       "engines": {
-        "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+        "node": "^14.18.0 || ^16.10.0 || >=18.0.0"
       }
     },
     "node_modules/http-proxy/node_modules/eventemitter3": {
@@ -11792,6 +11968,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/image-size/-/image-size-2.0.2.tgz",
       "integrity": "sha512-IRqXKlaXwgSMAMtpNzZa1ZAe8m+Sa1770Dhk8VkSsP9LS+iHD62Zd8FQKs8fbPiagBE7BzoFX23cxFnwshpV6w==",
+      "dev": true,
       "license": "MIT",
       "bin": {
         "image-size": "bin/image-size.js"
@@ -11811,9 +11988,9 @@
       }
     },
     "node_modules/import-in-the-middle": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.2.tgz",
-      "integrity": "sha512-jTd2FfOgOWOdgjkHuk/1Ms8VKFXkPs15ymYBETw1sAOrO/dY3XeGVRWir9qBbw7pXr0T2eTFwfCZ+N02HmiNGA==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/import-in-the-middle/-/import-in-the-middle-3.3.3.tgz",
+      "integrity": "sha512-AiohS3H80sXO6owEltjGX+glb7qXaDhBoJb9XcQVH4UI207xu/bDLUcadVKp7Qe576reg9yr/PXZjV5qx8gfbA==",
       "license": "Apache-2.0",
       "dependencies": {
         "cjs-module-lexer": "^2.2.0",
@@ -11825,9 +12002,9 @@
       }
     },
     "node_modules/import-in-the-middle/node_modules/es-module-lexer": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
-      "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.2.tgz",
+      "integrity": "sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==",
       "license": "MIT"
     },
     "node_modules/imurmurhash": {
@@ -12837,12 +13014,14 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/jpeg-js/-/jpeg-js-0.4.4.tgz",
       "integrity": "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg==",
+      "dev": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/js-image-generator": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/js-image-generator/-/js-image-generator-1.0.4.tgz",
       "integrity": "sha512-ckb7kyVojGAnArouVR+5lBIuwU1fcrn7E/YYSd0FK7oIngAkMmRvHASLro9Zt5SQdWToaI66NybG+OGxPw/HlQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "jpeg-js": "^0.4.2"
@@ -13859,9 +14038,9 @@
       }
     },
     "node_modules/modern-tar": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.7.5.tgz",
-      "integrity": "sha512-YTefgdpKKFgoTDbEUqXqgUJct2OG6/4hs4XWLsxcHkDLj/x/V8WmKIRppPnXP5feQ7d1vuYWSp3qKkxfwaFaxA==",
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/modern-tar/-/modern-tar-0.8.4.tgz",
+      "integrity": "sha512-gN54ddmyzEg10orwZ2u4OOv+bjpMWdIl5jIkodK97bMq8QBSL5c0D7YX0lT1Ooz+99S7+PvFbnxzdjgHo1r41g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13912,6 +14091,48 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/multiparty": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-4.3.0.tgz",
+      "integrity": "sha512-LD3YDFI9KrDoOGHsPM+hNraPDQQDPLe8Un/kvJfsZCsHKriA4mphg6Ctc2Cuup/59DtHMdAPm6ICXlUmhwTiug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "http-errors": "2.0.0",
+        "safe-buffer": "5.2.1",
+        "uid-safe": "2.1.5"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/multiparty/node_modules/http-errors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "depd": "2.0.0",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/multiparty/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/mute-stream": {
       "version": "0.0.8",
@@ -13976,30 +14197,30 @@
       }
     },
     "node_modules/netlify-cli": {
-      "version": "27.0.1",
-      "resolved": "https://registry.npmjs.org/netlify-cli/-/netlify-cli-27.0.1.tgz",
-      "integrity": "sha512-hFoSs19f9CM1xnPP7OYW5+WHPT0/clBl4J8BZpfXwDAdhoor5JpQUW0OXMuEBVlNTvnNELupF/qHC7Y/mDCfXQ==",
+      "version": "27.1.1",
+      "resolved": "https://registry.npmjs.org/netlify-cli/-/netlify-cli-27.1.1.tgz",
+      "integrity": "sha512-GspNyyKIKG2y76JY6+vPRPo2IszEZraSZga25bevB6DwtKa1Hmm5ASsTZZnwCcNFeHeK7wr4eOpJ1gNOeDBW/A==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@fastify/static": "^10.0.0",
         "@netlify/ai": "^0.4.3",
-        "@netlify/api": "^15.1.0",
+        "@netlify/api": "^15.1.1",
         "@netlify/blobs": "^10.7.10",
-        "@netlify/build": "^36.2.3",
-        "@netlify/build-info": "^11.2.0",
-        "@netlify/config": "^25.1.1",
+        "@netlify/build": "^36.3.2",
+        "@netlify/build-info": "^11.3.0",
+        "@netlify/config": "^25.2.1",
         "@netlify/dev": "^4.18.10",
         "@netlify/dev-utils": "^4.4.7",
-        "@netlify/edge-bundler": "^16.0.0",
+        "@netlify/edge-bundler": "^16.0.1",
         "@netlify/edge-functions": "^3.0.8",
         "@netlify/edge-functions-bootstrap": "^2.17.1",
         "@netlify/headers-parser": "^10.1.0",
         "@netlify/images": "^1.3.11",
         "@netlify/local-functions-proxy": "^2.0.3",
         "@netlify/redirect-parser": "^16.1.0",
-        "@netlify/zip-it-and-ship-it": "^15.3.0",
+        "@netlify/zip-it-and-ship-it": "^15.3.2",
         "@octokit/rest": "^22.0.0",
         "@opentelemetry/api": "^1.8.0",
         "@pnpm/tabtab": "^0.5.4",
@@ -14051,7 +14272,7 @@
         "log-update": "^7.2.0",
         "maxstache": "^1.0.7",
         "maxstache-stream": "^1.0.4",
-        "modern-tar": "^0.7.5",
+        "modern-tar": "^0.8.0",
         "multiparty": "^4.2.3",
         "nanospinner": "^1.2.2",
         "netlify-redirector": "^0.5.0",
@@ -14089,9 +14310,9 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@babel/types": {
-      "version": "7.29.7",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
-      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "version": "7.29.8",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.8.tgz",
+      "integrity": "sha512-Vj1jF3cPfxg7OAfoI7QnVKLoILlm2JF9pnVHrX8qx7AHMiYWT+NDAA7jChlNgRS4WTLc/fD1lXLmPixluj+3Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -14799,32 +15020,32 @@
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/serverless-functions-api": {
-      "version": "2.16.0",
-      "resolved": "https://registry.npmjs.org/@netlify/serverless-functions-api/-/serverless-functions-api-2.16.0.tgz",
-      "integrity": "sha512-yomP0pYRWPREiAuQbLghz9YbMb2+Mkmk1DMjyXVbIyrJ8QZhEtGcYQWAyl6cgki5CVqnOXvfIrRdLSf8bvxJCA==",
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/@netlify/serverless-functions-api/-/serverless-functions-api-2.18.0.tgz",
+      "integrity": "sha512-Uo5XyMFZOinq6AonHu6dUOkLvVydn+SaldoVkB4yQSpDrtqYWi56CoA26IIOur1EMJqRdt6JIzjzIe4jpzYdhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@netlify/types": "^2.6.0"
+        "@netlify/types": "^2.8.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/netlify-cli/node_modules/@netlify/zip-it-and-ship-it": {
-      "version": "15.3.0",
-      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-15.3.0.tgz",
-      "integrity": "sha512-m8lUq1kbzwC3Npapp2dZVUM5PZuFJTimLPqeUdbEDnMF2VHlNJP+Of8BZC4gWFr0kI/X0Ip9/Ce5IBXeeC9AAg==",
+      "version": "15.3.4",
+      "resolved": "https://registry.npmjs.org/@netlify/zip-it-and-ship-it/-/zip-it-and-ship-it-15.3.4.tgz",
+      "integrity": "sha512-6j3BjHXWX+Wn10Mj9AGL9MkBsT7Aqidwy6y6b8x40WC594BYe6swfiM/HjBw0AtWbXTSTP1ap/wbMj4Gvx5FrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.22.5",
         "@babel/types": "^7.28.5",
         "@netlify/binary-info": "^1.0.0",
-        "@netlify/serverless-functions-api": "2.16.0",
+        "@netlify/serverless-functions-api": "2.18.0",
         "@opentelemetry/api": "~1.8.0",
         "@vercel/nft": "0.29.4",
-        "archiver": "^7.0.0",
+        "archiver": "^8.0.0",
         "common-path-prefix": "^3.0.0",
         "copy-file": "^11.0.0",
         "es-module-lexer": "^1.0.0",
@@ -14850,7 +15071,7 @@
         "unixify": "^1.0.0",
         "urlpattern-polyfill": "8.0.2",
         "yargs": "^17.0.0",
-        "zod": "^3.23.8"
+        "zod": "^4.0.5"
       },
       "bin": {
         "zip-it-and-ship-it": "bin.js"
@@ -15146,6 +15367,27 @@
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
+    "node_modules/netlify-cli/node_modules/archiver": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/archiver/-/archiver-8.0.0.tgz",
+      "integrity": "sha512-fV1orZfsnPn9BaSByR/qE67rJCLJEy2Ox5bq7nJh+jquWaNh6Sfec75kJ2T6PtdGUbPQlrVoSVCEOa5SdiTQ1g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "async": "^3.2.4",
+        "buffer-crc32": "^1.0.0",
+        "is-stream": "^4.0.0",
+        "lazystream": "^1.0.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0",
+        "readdir-glob": "^3.0.0",
+        "tar-stream": "^3.0.0",
+        "zip-stream": "^7.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/netlify-cli/node_modules/ascii-table": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/ascii-table/-/ascii-table-0.0.9.tgz",
@@ -15306,6 +15548,23 @@
         "node": ">=18"
       }
     },
+    "node_modules/netlify-cli/node_modules/compress-commons": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-7.0.1.tgz",
+      "integrity": "sha512-g0S8KAD8qf4+V//pr3BfB1aBnARLXNz2Gx+jmHU0LEriUuoQUOPOulVquHKTJ8+EAIIO7fhseNDr9wK5Q9FKBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "crc32-stream": "^7.0.1",
+        "is-stream": "^4.0.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/netlify-cli/node_modules/config-chain": {
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
@@ -15356,6 +15615,20 @@
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
+    "node_modules/netlify-cli/node_modules/crc32-stream": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-7.0.1.tgz",
+      "integrity": "sha512-IBWsY8xznyQrcHn8h4bC8/4ErNke5elzgG8GcqF4RFPw6aHkWWRc7Tgw6upjaTX/CT/yQgqYENkxYsTYN+hW2g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "crc-32": "^1.2.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/netlify-cli/node_modules/cyclist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cyclist/-/cyclist-1.0.1.tgz",
@@ -15369,15 +15642,6 @@
       "dev": true,
       "engines": {
         "node": ">=4.0.0"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/netlify-cli/node_modules/dot-prop": {
@@ -15750,31 +16014,6 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/netlify-cli/node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-      "dev": true,
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/http-errors/node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
     "node_modules/netlify-cli/node_modules/https-proxy-agent": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-8.0.0.tgz",
@@ -16106,40 +16345,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/netlify-cli/node_modules/multiparty": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/multiparty/-/multiparty-4.2.3.tgz",
-      "integrity": "sha512-Ak6EUJZuhGS8hJ3c2fY6UW5MbkGUPMBEGd13djUzoY/BHqV/gTuFWtC6IuVA7A2+v3yjBS6c4or50xhzTQZImQ==",
-      "dev": true,
-      "dependencies": {
-        "http-errors": "~1.8.1",
-        "safe-buffer": "5.2.1",
-        "uid-safe": "2.1.5"
-      },
-      "engines": {
-        "node": ">= 0.10"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/multiparty/node_modules/safe-buffer": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/netlify-cli/node_modules/nanospinner": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/nanospinner/-/nanospinner-1.2.2.tgz",
@@ -16363,15 +16568,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/netlify-cli/node_modules/random-bytes": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
-      "integrity": "sha1-T2ih3Arli9P7lYSMMDJNt11kNgs=",
-      "dev": true,
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/netlify-cli/node_modules/rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
@@ -16517,6 +16713,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/netlify-cli/node_modules/readdir-glob": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-3.0.0.tgz",
+      "integrity": "sha512-AhNB2KgKeVJr16nK9LLZbJNWnYoT23ZrumNKFDebHBdkC8KHSqWo871JAUhoWC/RtjEVdqNMFpM6qrwRbaUqpw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/yqnn"
+      }
+    },
     "node_modules/netlify-cli/node_modules/readdirp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
@@ -16656,18 +16868,6 @@
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
     },
-    "node_modules/netlify-cli/node_modules/uid-safe": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
-      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
-      "dev": true,
-      "dependencies": {
-        "random-bytes": "~1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.8"
-      }
-    },
     "node_modules/netlify-cli/node_modules/untildify": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
@@ -16789,6 +16989,31 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/zip-stream": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-7.0.5.tgz",
+      "integrity": "sha512-dSvYKdvLsAHCDqPOhIwk/q5CvuWtTB3Dgpoe0uVEFjTzIOAmsQpprX25InCvrvJsirEbu1OHyy67n/kAj1Sw/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "compress-commons": "^7.0.0",
+        "normalize-path": "^3.0.0",
+        "readable-stream": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/netlify-cli/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/netlify-redirector": {
@@ -17141,13 +17366,6 @@
         "node-fetch-native": "^1.6.7",
         "ufo": "^1.6.1"
       }
-    },
-    "node_modules/omit.js": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/omit.js/-/omit.js-2.0.2.tgz",
-      "integrity": "sha512-hJmu9D+bNB40YpL9jYebQl4lsTW6yEHRTroJzNLqQJYHm7c+NQnJGfZmIWh8S3q3KoaxV1aLhV6B3+0N0/kyJg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
@@ -18224,6 +18442,16 @@
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/random-bytes": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/random-bytes/-/random-bytes-1.0.0.tgz",
+      "integrity": "sha512-iv7LhNVO047HzYR3InF6pUcUsPQiHTM1Qal51DcGSuZFBil1aBBWG5eHPNek7bvILMaYJ/8RU1e8w1AMdHmLQQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/range-parser": {
       "version": "1.2.1",
@@ -19959,6 +20187,7 @@
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
       "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.14"
@@ -19968,6 +20197,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
       "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tmp": "^0.2.0"
@@ -20225,6 +20455,19 @@
       "integrity": "sha512-JFNbkD1Svwe0KvGi8GOeLcP4kAWQ609twvCdcHxq1oSL8svv39ZuSvajcD8B+5D0eL4+s1Is2D/O6KN3qcTeRA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/uid-safe": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/uid-safe/-/uid-safe-2.1.5.tgz",
+      "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "random-bytes": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/ulid": {
       "version": "3.0.2",
@@ -20623,9 +20866,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21093,9 +21336,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+      "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@google/genai": "^1.30.0",
-    "@netlify/blobs": "^10.7.4",
+    "@netlify/blobs": "^10.7.13",
     "@supabase/supabase-js": "^2.45.0",
     "lucide-react": "^0.554.0",
     "react": "^19.2.0",
@@ -23,8 +23,13 @@
     "@netlify/functions": "^3.0.0",
     "@types/node": "^22.14.0",
     "@vitejs/plugin-react": "^5.0.0",
-    "netlify-cli": "^27.0.1",
+    "netlify-cli": "^27.1.1",
     "typescript": "~5.8.2",
-    "vite": "^6.2.0"
+    "vite": "^6.4.3"
+  },
+  "overrides": {
+    "http-proxy-middleware": "3.0.7",
+    "multiparty": "4.3.0",
+    "ws": "8.21.3"
   }
 }


### PR DESCRIPTION
## Summary
- update netlify-cli from 27.0.1 to 27.1.1
- keep Vite on the supported 6.x line and update to 6.4.3
- update @netlify/blobs to 10.7.13
- pin patched transitive versions for ws, multiparty, and http-proxy-middleware

## Security impact
- npm audit decreases from 21 findings on main to 15
- removes current audit findings for Vite, ws, multiparty, and http-proxy-middleware
- avoids the Vite 8 major upgrade in #137
- supersedes the security intent of #128, #132, #134, and #137

## Validation
- npm ci
- npm run build
- Netlify dev loaded all 10 functions
- HTTP smoke: root 200, favicon 200, API GET 405, evidence GET 503 without temp-clone Supabase credentials
- npx tsc --noEmit still reports the same five pre-existing errors seen on main