### PR TITLE
security: authenticate background AI functions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,12 @@ VITE_GOOGLE_API_KEY=your_google_picker_api_key
 GEMINI_API_KEY=your_gemini_api_key_here
 SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
 
+# Authenticates calls from api.ts to privileged background functions.
+# Generate a value with: openssl rand -hex 32
+INTERNAL_JOB_SECRET=replace_with_at_least_32_random_characters
+# Optional for non-Netlify/self-hosted deployments; HTTPS is required outside local development.
+# INTERNAL_FUNCTION_BASE_URL=https://app.example.com
+
 # Google Drive OAuth — server-only secrets (never use VITE_ prefix for these)
 GOOGLE_CLIENT_ID=your_google_oauth_client_id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your_google_oauth_client_secret

--- a/components/SwotAnalysisWizard.tsx
+++ b/components/SwotAnalysisWizard.tsx
@@ -86,22 +86,46 @@ const ArrayFieldEditor: React.FC<ArrayFieldEditorProps> = ({
 const SwotAnalysisWizard: React.FC<Props> = ({ data, onChange, profile, bmcData, saveStatus, isDirty, onSave, saveError }) => {
   const [step, setStep] = useState<number>(0);
   const [loadingMap, setLoadingMap] = useState<Record<string, boolean>>({});
+  const [aiErrorMap, setAiErrorMap] = useState<Record<string, string | null>>({});
+
+  const setAiError = (field: string, error: unknown) => {
+    const message = error instanceof Error
+      ? error.message
+      : 'AI suggestion failed. Please try again.';
+    setAiErrorMap(current => ({ ...current, [field]: message }));
+  };
 
   const handleGenerateInternalField = async (field: 'strengths' | 'weaknesses') => {
     setLoadingMap(m => ({ ...m, [field]: true }));
-    const result = await generateSwotInternal(profile, bmcData);
-    if (field === 'strengths' && result.strengths.length > 0)
-      onChange({ ...data, strengths: result.strengths });
-    else if (field === 'weaknesses' && result.weaknesses.length > 0)
-      onChange({ ...data, weaknesses: result.weaknesses });
-    setLoadingMap(m => ({ ...m, [field]: false }));
+    setAiErrorMap(current => ({ ...current, [field]: null }));
+    try {
+      const result = await generateSwotInternal(profile, bmcData);
+      const suggestions = result[field];
+      if (suggestions.length === 0) {
+        throw new Error('The AI did not return any suggestions. Please try again.');
+      }
+      onChange({ ...data, [field]: suggestions });
+    } catch (error) {
+      setAiError(field, error);
+    } finally {
+      setLoadingMap(m => ({ ...m, [field]: false }));
+    }
   };
 
   const handleGenerateExternal = async (field: 'opportunities' | 'threats') => {
     setLoadingMap(m => ({ ...m, [field]: true }));
-    const result = await generateSwotExternal(profile, field === 'opportunities' ? 'OPPORTUNITIES' : 'THREATS');
-    onChange({ ...data, [field]: result });
-    setLoadingMap(m => ({ ...m, [field]: false }));
+    setAiErrorMap(current => ({ ...current, [field]: null }));
+    try {
+      const result = await generateSwotExternal(profile, field === 'opportunities' ? 'OPPORTUNITIES' : 'THREATS');
+      if (result.length === 0) {
+        throw new Error('The AI did not return any suggestions. Please try again.');
+      }
+      onChange({ ...data, [field]: result });
+    } catch (error) {
+      setAiError(field, error);
+    } finally {
+      setLoadingMap(m => ({ ...m, [field]: false }));
+    }
   };
 
   const renderStepInternal = () => (
@@ -133,6 +157,7 @@ const SwotAnalysisWizard: React.FC<Props> = ({ data, onChange, profile, bmcData,
             placeholder="e.g. Strong proprietary technology"
             focusRingColor="focus:ring-emerald-500"
           />
+          {aiErrorMap.strengths && <p role="alert" className="text-xs text-red-600 dark:text-red-400">{aiErrorMap.strengths}</p>}
         </div>
 
         {/* Weaknesses */}
@@ -156,6 +181,7 @@ const SwotAnalysisWizard: React.FC<Props> = ({ data, onChange, profile, bmcData,
             placeholder="e.g. High dependency on single supplier"
             focusRingColor="focus:ring-amber-500"
           />
+          {aiErrorMap.weaknesses && <p role="alert" className="text-xs text-red-600 dark:text-red-400">{aiErrorMap.weaknesses}</p>}
         </div>
       </div>
     </div>
@@ -190,6 +216,7 @@ const SwotAnalysisWizard: React.FC<Props> = ({ data, onChange, profile, bmcData,
             placeholder="e.g. Growing demand for sustainable products"
             focusRingColor="focus:ring-blue-500"
           />
+          {aiErrorMap.opportunities && <p role="alert" className="text-xs text-red-600 dark:text-red-400">{aiErrorMap.opportunities}</p>}
           <p className="text-xs text-slate-400 dark:text-slate-500">AI searches for: Market trends, new regulations, competitor shifts.</p>
         </div>
 
@@ -214,6 +241,7 @@ const SwotAnalysisWizard: React.FC<Props> = ({ data, onChange, profile, bmcData,
             placeholder="e.g. Supply chain disruptions"
             focusRingColor="focus:ring-red-500"
           />
+          {aiErrorMap.threats && <p role="alert" className="text-xs text-red-600 dark:text-red-400">{aiErrorMap.threats}</p>}
           <p className="text-xs text-slate-400 dark:text-slate-500">AI searches for: Economic downturns, geopolitical risks, resource scarcity.</p>
         </div>
       </div>

--- a/netlify/functions/_shared/aiRequestFence.js
+++ b/netlify/functions/_shared/aiRequestFence.js
@@ -1,0 +1,32 @@
+// @ts-check
+
+export const NETLIFY_SYNC_LIMIT_MS = 60_000;
+export const AI_REQUEST_FENCE_MS = 50_000;
+
+/**
+ * Leave time for usage and error logging before Netlify's synchronous limit.
+ * @template T
+ * @param {Promise<T>} request
+ * @param {string} action
+ * @param {number} [timeoutMs]
+ * @returns {Promise<T>}
+ */
+export function withAIRequestFence(
+  request,
+  action,
+  timeoutMs = AI_REQUEST_FENCE_MS,
+) {
+  let fenceId;
+  const fence = new Promise((_, reject) => {
+    fenceId = setTimeout(() => {
+      const error = new Error(
+        `Action '${action}' exceeded the ${timeoutMs / 1000}s timeout`,
+      );
+      // @ts-ignore -- consumed by api.ts when mapping timeout responses.
+      error.isTimeout = true;
+      reject(error);
+    }, timeoutMs);
+  });
+
+  return Promise.race([request, fence]).finally(() => clearTimeout(fenceId));
+}

--- a/netlify/functions/_shared/internalJobAuth.js
+++ b/netlify/functions/_shared/internalJobAuth.js
@@ -1,0 +1,146 @@
+// @ts-check
+
+import { createHash, timingSafeEqual } from "node:crypto";
+
+export const INTERNAL_JOB_SECRET_HEADER = "x-internal-job-secret";
+const MIN_SECRET_LENGTH = 32;
+
+const jsonError = (statusCode, error) => ({
+  statusCode,
+  headers: { "Content-Type": "application/json" },
+  body: JSON.stringify({ error }),
+});
+
+/**
+ * @param {Record<string, string | undefined> | undefined} headers
+ * @param {string} name
+ */
+function getHeader(headers, name) {
+  const entry = Object.entries(headers ?? {}).find(
+    ([headerName]) => headerName.toLowerCase() === name,
+  );
+  return entry?.[1];
+}
+
+/** @param {string | undefined} secret */
+function isConfiguredSecret(secret) {
+  return typeof secret === "string" && secret.length >= MIN_SECRET_LENGTH;
+}
+
+function unavailableError() {
+  const error = new Error(
+    "Background processing is temporarily unavailable. Please contact the administrator.",
+  );
+  // api.ts maps numeric status values to the HTTP response code.
+  // @ts-ignore -- status is intentionally attached for the existing error mapper.
+  error.status = 503;
+  return error;
+}
+
+/**
+ * Compare fixed-length hashes so the comparison does not reveal secret length.
+ * @param {string} provided
+ * @param {string} expected
+ */
+function secretsMatch(provided, expected) {
+  const providedHash = createHash("sha256").update(provided).digest();
+  const expectedHash = createHash("sha256").update(expected).digest();
+  return timingSafeEqual(providedHash, expectedHash);
+}
+
+/**
+ * @param {{ headers?: Record<string, string | undefined> }} event
+ * @param {string | undefined} [configuredSecret]
+ */
+export function requireInternalJobAuth(
+  event,
+  configuredSecret = process.env.INTERNAL_JOB_SECRET,
+) {
+  if (!isConfiguredSecret(configuredSecret)) {
+    console.error(
+      `[security] INTERNAL_JOB_SECRET must contain at least ${MIN_SECRET_LENGTH} characters.`,
+    );
+    return jsonError(503, "Background processing is temporarily unavailable.");
+  }
+
+  const providedSecret = getHeader(event.headers, INTERNAL_JOB_SECRET_HEADER);
+  if (!providedSecret || !secretsMatch(providedSecret, configuredSecret)) {
+    return jsonError(401, "Unauthorized background job request.");
+  }
+
+  return null;
+}
+
+/** @param {string | undefined} [configuredSecret] */
+export function createInternalJobHeaders(
+  configuredSecret = process.env.INTERNAL_JOB_SECRET,
+) {
+  if (!isConfiguredSecret(configuredSecret)) {
+    console.error(
+      `[security] INTERNAL_JOB_SECRET must contain at least ${MIN_SECRET_LENGTH} characters.`,
+    );
+    throw unavailableError();
+  }
+
+  return {
+    "Content-Type": "application/json",
+    [INTERNAL_JOB_SECRET_HEADER]: configuredSecret,
+  };
+}
+
+/**
+ * Build a trusted function URL without trusting a caller-controlled Host header.
+ * The Host header is used only for loopback traffic during local development.
+ *
+ * @param {{ headers?: Record<string, string | undefined> }} event
+ * @param {string} functionName
+ * @param {string | undefined} [configuredBaseUrl]
+ */
+export function createInternalFunctionUrl(
+  event,
+  functionName,
+  configuredBaseUrl = process.env.INTERNAL_FUNCTION_BASE_URL || process.env.URL,
+) {
+  if (!/^[a-z0-9-]+$/.test(functionName)) {
+    console.error("[security] Invalid internal function name.");
+    throw unavailableError();
+  }
+
+  let baseUrl;
+  if (configuredBaseUrl) {
+    try {
+      baseUrl = new URL(configuredBaseUrl);
+    } catch {
+      console.error("[security] Netlify deployment URL is invalid.");
+      throw unavailableError();
+    }
+  } else {
+    const host = getHeader(event.headers, "host");
+    if (!host) {
+      console.error("[security] No trusted deployment URL is available.");
+      throw unavailableError();
+    }
+
+    try {
+      baseUrl = new URL(`http://${host}`);
+    } catch {
+      console.error("[security] Local function host is invalid.");
+      throw unavailableError();
+    }
+  }
+
+  const isLoopback = ["localhost", "127.0.0.1", "::1"].includes(
+    baseUrl.hostname,
+  );
+  if (baseUrl.protocol !== "https:" && !(baseUrl.protocol === "http:" && isLoopback)) {
+    console.error("[security] Internal function URL must use HTTPS outside local development.");
+    throw unavailableError();
+  }
+
+  if (!configuredBaseUrl && !isLoopback) {
+    console.error("[security] Refusing an untrusted Host header for an internal function call.");
+    throw unavailableError();
+  }
+
+  return new URL(`/.netlify/functions/${functionName}`, baseUrl).toString();
+}

--- a/netlify/functions/_shared/internalJobAuth.js
+++ b/netlify/functions/_shared/internalJobAuth.js
@@ -99,7 +99,11 @@ export function createInternalJobHeaders(
 export function createInternalFunctionUrl(
   event,
   functionName,
-  configuredBaseUrl = process.env.INTERNAL_FUNCTION_BASE_URL || process.env.URL,
+  configuredBaseUrl =
+    process.env.INTERNAL_FUNCTION_BASE_URL ||
+    process.env.DEPLOY_PRIME_URL ||
+    process.env.DEPLOY_URL ||
+    process.env.URL,
 ) {
   if (!/^[a-z0-9-]+$/.test(functionName)) {
     console.error("[security] Invalid internal function name.");

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -1,5 +1,9 @@
 import { GoogleGenAI, Type } from "@google/genai";
 import { createClient } from "@supabase/supabase-js";
+import {
+  createInternalFunctionUrl,
+  createInternalJobHeaders,
+} from "./_shared/internalJobAuth.js";
 
 const apiKey = process.env.GEMINI_API_KEY;
 const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
@@ -288,13 +292,13 @@ async function runAction(
     case "generateKPISuggestions":
       return generateKPISuggestions(ai, model, params);
     case "triggerReportGeneration":
-      return triggerReportGeneration(event, { organization_id, user_id: user.id, user_email: user.email ?? null, ...params });
+      return triggerReportGeneration(event, { ...params, organization_id, user_id: user.id, user_email: user.email ?? null });
     case "triggerDMAAnalysis":
-      return triggerDMAAnalysis(event, { organization_id, user_id: user.id, user_email: user.email ?? null, ...params });
+      return triggerDMAAnalysis(event, { ...params, organization_id, user_id: user.id, user_email: user.email ?? null });
     case "triggerAssessmentAutofill":
-      return triggerAssessmentAutofill(event, { organization_id, user_id: user.id, user_email: user.email ?? null, ...params });
+      return triggerAssessmentAutofill(event, { ...params, organization_id, user_id: user.id, user_email: user.email ?? null });
     case "triggerAssessmentScoring":
-      return triggerAssessmentScoring(event, { organization_id, user_id: user.id, user_email: user.email ?? null, ...params });
+      return triggerAssessmentScoring(event, { ...params, organization_id, user_id: user.id, user_email: user.email ?? null });
     case "analyzeTopicQuality":
       return analyzeTopicQuality(ai, model, params);
     case "analyzeDMASynthesis":
@@ -829,9 +833,8 @@ Return ONLY valid JSON, no markdown:
 }
 
 async function triggerReportGeneration(event: any, { organization_id, profile, materialAssessments, user_id, user_email }: any) {
-  const host = event.headers.host || event.headers.Host;
-  const protocol = host.startsWith('localhost') ? 'http' : 'https';
-  const url = `${protocol}://${host}/.netlify/functions/report-background`;
+  const url = createInternalFunctionUrl(event, "report-background");
+  const internalJobHeaders = createInternalJobHeaders();
   
   console.log(`[api] Triggering background report at ${url}`);
   
@@ -843,7 +846,7 @@ async function triggerReportGeneration(event: any, { organization_id, profile, m
   try {
     const resp = await fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: internalJobHeaders,
       body: JSON.stringify({ organization_id, profile, materialAssessments, user_id, user_email }),
     });
     console.log(`[api] Background function trigger status: ${resp.status}`);
@@ -859,9 +862,8 @@ async function triggerReportGeneration(event: any, { organization_id, profile, m
 }
 
 async function triggerDMAAnalysis(event: any, { organization_id, profile, assessments, bmcData, swotData, user_id, user_email }: any) {
-  const host = event.headers.host || event.headers.Host;
-  const protocol = host.startsWith('localhost') ? 'http' : 'https';
-  const url = `${protocol}://${host}/.netlify/functions/dma-background`;
+  const url = createInternalFunctionUrl(event, "dma-background");
+  const internalJobHeaders = createInternalJobHeaders();
   
   console.log(`[api] Triggering background DMA analysis at ${url}`);
 
@@ -873,7 +875,7 @@ async function triggerDMAAnalysis(event: any, { organization_id, profile, assess
   try {
     const resp = await fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: internalJobHeaders,
       body: JSON.stringify({ organization_id, profile, assessments, bmcData, swotData, user_id, user_email }),
     });
     console.log(`[api] Background function trigger status: ${resp.status}`);
@@ -889,9 +891,8 @@ async function triggerDMAAnalysis(event: any, { organization_id, profile, assess
 }
 
 async function triggerAssessmentAutofill(event: any, { organization_id, assessment_id, topic, profile, qualityCheckContext, user_id, user_email }: any) {
-  const host = event.headers.host || event.headers.Host;
-  const protocol = host.startsWith('localhost') ? 'http' : 'https';
-  const url = `${protocol}://${host}/.netlify/functions/assessment-background`;
+  const url = createInternalFunctionUrl(event, "assessment-background");
+  const internalJobHeaders = createInternalJobHeaders();
   
   console.log(`[api] Triggering background assessment autofill at ${url}`);
 
@@ -903,7 +904,7 @@ async function triggerAssessmentAutofill(event: any, { organization_id, assessme
   try {
     fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: internalJobHeaders,
       body: JSON.stringify({ organization_id, assessment_id, action: 'autofill', topic, profile, qualityCheckContext, user_id, user_email }),
     }).then(resp => console.log(`[api] Background function trigger status: ${resp.status}`))
       .catch(e => console.error("[api] Failed to trigger background function:", e));
@@ -919,9 +920,8 @@ async function triggerAssessmentAutofill(event: any, { organization_id, assessme
 }
 
 async function triggerAssessmentScoring(event: any, { organization_id, assessment_id, topic, profile, bmcData, swotData, impactDescription, financialDescription, user_id, user_email }: any) {
-  const host = event.headers.host || event.headers.Host;
-  const protocol = host.startsWith('localhost') ? 'http' : 'https';
-  const url = `${protocol}://${host}/.netlify/functions/assessment-background`;
+  const url = createInternalFunctionUrl(event, "assessment-background");
+  const internalJobHeaders = createInternalJobHeaders();
   
   console.log(`[api] Triggering background assessment scoring at ${url}`);
 
@@ -933,7 +933,7 @@ async function triggerAssessmentScoring(event: any, { organization_id, assessmen
   try {
     fetch(url, {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: internalJobHeaders,
       body: JSON.stringify({ organization_id, assessment_id, action: 'scoring', topic, profile, bmcData, swotData, impactDescription, financialDescription, user_id, user_email }),
     }).then(resp => console.log(`[api] Background function trigger status: ${resp.status}`))
       .catch(e => console.error("[api] Failed to trigger background function:", e));

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -4,6 +4,7 @@ import {
   createInternalFunctionUrl,
   createInternalJobHeaders,
 } from "./_shared/internalJobAuth.js";
+import { withAIRequestFence } from "./_shared/aiRequestFence.js";
 
 const apiKey = process.env.GEMINI_API_KEY;
 const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
@@ -157,30 +158,15 @@ const handler = async (event: any) => {
   let upstreamStatus: number | null = null;
   let userFacingMessage = "Something went wrong while contacting the AI service.";
 
-  // Internal fence at 9 s — Netlify kills the process at 10 s with no chance to log.
-  // Rejecting one second early lets the catch block write to ai_usage_log + error_log
-  // before the hard deadline hits.
-  const FENCE_MS = 9_000;
-  let fenceId: ReturnType<typeof setTimeout>;
-  const fencePromise = new Promise<never>((_, reject) => {
-    fenceId = setTimeout(() => {
-      const err = new Error(`Action '${action}' exceeded the ${FENCE_MS / 1000}s timeout`);
-      (err as any).isTimeout = true;
-      reject(err);
-    }, FENCE_MS);
-  });
-
   try {
-    const outcome = await Promise.race([
+    const outcome = await withAIRequestFence(
       runAction(ai, model, action, params, event, organization_id, user),
-      fencePromise,
-    ]);
-    clearTimeout(fenceId!);
+      action,
+    );
     result = outcome.result;
     inputTokens = outcome.inputTokens;
     outputTokens = outcome.outputTokens;
   } catch (error: any) {
-    clearTimeout(fenceId!);
     console.error("API Error:", error);
     success = false;
     rawAiResponse = error?.rawAiResponse ?? null;
@@ -198,7 +184,7 @@ const handler = async (event: any) => {
         ? "The AI service is temporarily overloaded. Please try again in a moment."
         : upstreamStatus === 429
         ? "AI rate limit reached. Please wait a minute and try again."
-        : errorMessage || userFacingMessage;
+        : userFacingMessage;
   }
 
   const durationMs = Date.now() - start;

--- a/netlify/functions/assessment-background.ts
+++ b/netlify/functions/assessment-background.ts
@@ -1,5 +1,6 @@
 import { GoogleGenAI, Type } from "@google/genai";
 import { createClient } from "@supabase/supabase-js";
+import { requireInternalJobAuth } from "./_shared/internalJobAuth.js";
 
 const apiKey = process.env.GEMINI_API_KEY;
 const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
@@ -61,6 +62,9 @@ const handler = async (event: any) => {
   if (event.httpMethod !== "POST") {
     return { statusCode: 405, body: "Method Not Allowed" };
   }
+
+  const authError = requireInternalJobAuth(event);
+  if (authError) return authError;
 
   const {
     organization_id,

--- a/netlify/functions/dma-background.ts
+++ b/netlify/functions/dma-background.ts
@@ -1,5 +1,6 @@
 import { GoogleGenAI, Type } from "@google/genai";
 import { createClient } from "@supabase/supabase-js";
+import { requireInternalJobAuth } from "./_shared/internalJobAuth.js";
 
 const apiKey = process.env.GEMINI_API_KEY;
 const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
@@ -18,6 +19,9 @@ const handler = async (event: any) => {
   if (event.httpMethod !== "POST") {
     return { statusCode: 405, body: "Method Not Allowed" };
   }
+
+  const authError = requireInternalJobAuth(event);
+  if (authError) return authError;
 
   const { organization_id, profile, assessments, bmcData, swotData, user_id, user_email } = JSON.parse(event.body);
 

--- a/netlify/functions/report-background.ts
+++ b/netlify/functions/report-background.ts
@@ -1,5 +1,6 @@
 import { GoogleGenAI, Type } from "@google/genai";
 import { createClient } from "@supabase/supabase-js";
+import { requireInternalJobAuth } from "./_shared/internalJobAuth.js";
 
 const apiKey = process.env.GEMINI_API_KEY;
 const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
@@ -18,6 +19,9 @@ const handler = async (event: any) => {
   if (event.httpMethod !== "POST") {
     return { statusCode: 405, body: "Method Not Allowed" };
   }
+
+  const authError = requireInternalJobAuth(event);
+  if (authError) return authError;
 
   const { organization_id, profile, materialAssessments, user_id, user_email } = JSON.parse(event.body);
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "dev:netlify": "netlify dev",
     "build": "vite build",
+    "test:security": "node --experimental-strip-types --test tests/security/*.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/services/geminiService.ts
+++ b/services/geminiService.ts
@@ -145,22 +145,14 @@ export const generateSwotInternal = async (
   profile: CompanyProfile,
   bmcData: SustainabilityBusinessModel
 ): Promise<{ strengths: string[]; weaknesses: string[] }> => {
-  try {
-    return await callApi("generateSwotInternal", { profile, bmcData });
-  } catch {
-    return { strengths: [], weaknesses: [] };
-  }
+  return await callApi("generateSwotInternal", { profile, bmcData });
 };
 
 export const generateSwotExternal = async (
   profile: CompanyProfile,
   type: "OPPORTUNITIES" | "THREATS"
 ): Promise<string[]> => {
-  try {
-    return await callApi("generateSwotExternal", { profile, type });
-  } catch {
-    return [];
-  }
+  return await callApi("generateSwotExternal", { profile, type });
 };
 
 export const generateKPISuggestions = async (

--- a/tests/security/ai-request-fence.test.mjs
+++ b/tests/security/ai-request-fence.test.mjs
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  AI_REQUEST_FENCE_MS,
+  NETLIFY_SYNC_LIMIT_MS,
+  withAIRequestFence,
+} from "../../netlify/functions/_shared/aiRequestFence.js";
+
+test("AI request fence leaves time for logging before the Netlify limit", () => {
+  assert.equal(AI_REQUEST_FENCE_MS, 50_000);
+  assert.ok(AI_REQUEST_FENCE_MS < NETLIFY_SYNC_LIMIT_MS);
+});
+
+test("AI request fence allows a response before the deadline", async () => {
+  const result = await withAIRequestFence(Promise.resolve("ok"), "test", 20);
+
+  assert.equal(result, "ok");
+});
+
+test("AI request fence marks deadline failures as timeouts", async () => {
+  await assert.rejects(
+    withAIRequestFence(
+      new Promise(resolve => setTimeout(resolve, 30)),
+      "generateSwotInternal",
+      5,
+    ),
+    error => {
+      assert.equal(error.isTimeout, true);
+      assert.match(error.message, /generateSwotInternal/);
+      return true;
+    },
+  );
+});

--- a/tests/security/background-job-auth.test.mjs
+++ b/tests/security/background-job-auth.test.mjs
@@ -69,6 +69,33 @@ test("internal function URLs use the trusted deployment URL instead of Host", ()
   );
 });
 
+test("internal function URLs prefer the current Netlify deploy over production", () => {
+  const previous = {
+    INTERNAL_FUNCTION_BASE_URL: process.env.INTERNAL_FUNCTION_BASE_URL,
+    DEPLOY_PRIME_URL: process.env.DEPLOY_PRIME_URL,
+    DEPLOY_URL: process.env.DEPLOY_URL,
+    URL: process.env.URL,
+  };
+
+  try {
+    delete process.env.INTERNAL_FUNCTION_BASE_URL;
+    process.env.DEPLOY_PRIME_URL =
+      "https://deploy-preview-158--example.netlify.app";
+    process.env.DEPLOY_URL = "https://deploy-id--example.netlify.app";
+    process.env.URL = "https://production.example.com";
+
+    assert.equal(
+      createInternalFunctionUrl({ headers: {} }, "report-background"),
+      "https://deploy-preview-158--example.netlify.app/.netlify/functions/report-background",
+    );
+  } finally {
+    for (const [name, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    }
+  }
+});
+
 test("internal function URLs allow only loopback Host fallback", () => {
   assert.equal(
     createInternalFunctionUrl(

--- a/tests/security/background-job-auth.test.mjs
+++ b/tests/security/background-job-auth.test.mjs
@@ -1,0 +1,133 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createInternalFunctionUrl,
+  createInternalJobHeaders,
+  INTERNAL_JOB_SECRET_HEADER,
+  requireInternalJobAuth,
+} from "../../netlify/functions/_shared/internalJobAuth.js";
+import { handler as assessmentHandler } from "../../netlify/functions/assessment-background.ts";
+import { handler as dmaHandler } from "../../netlify/functions/dma-background.ts";
+import { handler as reportHandler } from "../../netlify/functions/report-background.ts";
+
+const VALID_SECRET = "a".repeat(64);
+const INVALID_SECRET = "b".repeat(64);
+
+test("internal job auth fails closed when the secret is not configured", () => {
+  const response = requireInternalJobAuth({ headers: {} }, "");
+
+  assert.equal(response?.statusCode, 503);
+  assert.doesNotMatch(response?.body ?? "", /INTERNAL_JOB_SECRET|a{8}/);
+});
+
+test("internal job auth rejects missing and invalid credentials", () => {
+  assert.equal(
+    requireInternalJobAuth({ headers: {} }, VALID_SECRET)?.statusCode,
+    401,
+  );
+  assert.equal(
+    requireInternalJobAuth(
+      { headers: { [INTERNAL_JOB_SECRET_HEADER]: INVALID_SECRET } },
+      VALID_SECRET,
+    )?.statusCode,
+    401,
+  );
+});
+
+test("internal job auth accepts a valid credential case-insensitively", () => {
+  const response = requireInternalJobAuth(
+    { headers: { "X-Internal-Job-Secret": VALID_SECRET } },
+    VALID_SECRET,
+  );
+
+  assert.equal(response, null);
+});
+
+test("internal request headers fail closed and include the configured secret", () => {
+  assert.throws(
+    () => createInternalJobHeaders("too-short"),
+    /Background processing is temporarily unavailable/,
+  );
+
+  assert.deepEqual(createInternalJobHeaders(VALID_SECRET), {
+    "Content-Type": "application/json",
+    [INTERNAL_JOB_SECRET_HEADER]: VALID_SECRET,
+  });
+});
+
+test("internal function URLs use the trusted deployment URL instead of Host", () => {
+  const url = createInternalFunctionUrl(
+    { headers: { host: "attacker.example" } },
+    "report-background",
+    "https://deploy-preview-1--example.netlify.app",
+  );
+
+  assert.equal(
+    url,
+    "https://deploy-preview-1--example.netlify.app/.netlify/functions/report-background",
+  );
+});
+
+test("internal function URLs allow only loopback Host fallback", () => {
+  assert.equal(
+    createInternalFunctionUrl(
+      { headers: { host: "localhost:8888" } },
+      "dma-background",
+      "",
+    ),
+    "http://localhost:8888/.netlify/functions/dma-background",
+  );
+
+  assert.throws(
+    () =>
+      createInternalFunctionUrl(
+        { headers: { host: "attacker.example" } },
+        "dma-background",
+        "",
+      ),
+    /Background processing is temporarily unavailable/,
+  );
+});
+
+test("internal function URLs reject cleartext non-loopback deployment URLs", () => {
+  assert.throws(
+    () =>
+      createInternalFunctionUrl(
+        { headers: {} },
+        "assessment-background",
+        "http://app.example.com",
+      ),
+    /Background processing is temporarily unavailable/,
+  );
+});
+
+for (const [name, handler] of [
+  ["report-background", reportHandler],
+  ["dma-background", dmaHandler],
+  ["assessment-background", assessmentHandler],
+]) {
+  test(`${name} rejects unauthenticated requests before parsing the body`, async () => {
+    process.env.INTERNAL_JOB_SECRET = VALID_SECRET;
+
+    const response = await handler({
+      httpMethod: "POST",
+      headers: {},
+      body: "not-json",
+    });
+
+    assert.equal(response.statusCode, 401);
+  });
+
+  test(`${name} accepts the internal credential before validating fields`, async () => {
+    process.env.INTERNAL_JOB_SECRET = VALID_SECRET;
+
+    const response = await handler({
+      httpMethod: "POST",
+      headers: { [INTERNAL_JOB_SECRET_HEADER]: VALID_SECRET },
+      body: "{}",
+    });
+
+    assert.equal(response.statusCode, 400);
+  });
+}


### PR DESCRIPTION
## Summary

- require a server-only internal credential for report, DMA, and assessment background functions
- reject missing or invalid credentials before parsing request data or accessing Supabase/AI services
- build internal function URLs from trusted deployment configuration instead of an incoming Host header
- keep organization and user identity sourced from the authenticated API request
- add focused regression coverage using the Node test runner

Closes #153

## Deployment requirement

Set INTERNAL_JOB_SECRET to the same cryptographically random value of at least 32 characters for the Functions scope in every deploy context before deploying this change. Netlify applies updated function environment variables on the next deploy.

For self-hosted deployments, INTERNAL_FUNCTION_BASE_URL may be set to the trusted HTTPS application origin. Netlify deployments use the platform-provided URL variable.

## Testing

- npm run test:security (13 passing)
- npm run build (passing)
- npx netlify functions:build --src netlify/functions (passing)
- npx tsc --noEmit (no new errors; still reports the existing five baseline errors in DMAInsightHub.tsx, ally-support.ts, and dma-background.ts)

## Database migration

No database migration.