### PR TITLE
security: prevent admin magic-link disclosure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -36,8 +36,10 @@ PLATFORM_ADMIN_PASSWORD=change-me-to-something-strong
 
 # Resend — transactional email for admin magic-link emails.
 # Sign up free at https://resend.com (3,000 emails/month on free tier).
-# Without this key the server runs in dev mode: the magic link is returned
-# in the API response and shown directly in the UI instead of being emailed.
+# Production fails closed when this key is absent or delivery fails.
 RESEND_API_KEY=re_your_resend_api_key_here
 # Sender address — must be a verified domain/email in your Resend account.
 RESEND_FROM_EMAIL=noreply@your-domain.com
+
+# Local development only. Dev links also require Netlify Dev and a loopback request host.
+ALLOW_DEV_ADMIN_MAGIC_LINKS=false

--- a/components/admin/AdminLoginScreen.tsx
+++ b/components/admin/AdminLoginScreen.tsx
@@ -16,7 +16,6 @@ const AdminLoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
   const [stage, setStage]         = useState<Stage>('input');
   const [errorMsg, setError]      = useState('');
   const [devLink, setDevLink]     = useState<string | null>(null);
-  const [emailErr, setEmailErr]   = useState<string | null>(null);
 
   // ── Password login (bootstrap: table must be empty) ──────────────────────
   const handlePasswordLogin = async (e: React.FormEvent) => {
@@ -62,18 +61,17 @@ const AdminLoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
     setStage('submitting');
 
     try {
-      const res = await fetch('/.netlify/functions/admin', {
+      const res = await fetch('/.netlify/functions/admin-magic-link', {
         method:  'POST',
         headers: { 'Content-Type': 'application/json' },
-        body:    JSON.stringify({ action: 'request_admin_magic_link', email: email.trim() }),
+        body:    JSON.stringify({ email: email.trim() }),
       });
 
       const json = await res.json();
       if (!res.ok) throw new Error(json.error ?? 'Failed to send link');
 
-      // dev_link is returned when Resend is not set OR when email sending fails
+      // dev_link is available only in explicitly enabled local development.
       if (json.dev_link) setDevLink(json.dev_link);
-      if (json.email_error) setEmailErr(json.email_error);
 
       setStage('sent');
     } catch (err: any) {
@@ -82,7 +80,7 @@ const AdminLoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
     }
   };
 
-  const handleReset = () => { setStage('input'); setError(''); setDevLink(null); setEmailErr(null); };
+  const handleReset = () => { setStage('input'); setError(''); setDevLink(null); };
 
   const switchMode = (m: Mode) => { setMode(m); handleReset(); };
 
@@ -110,12 +108,10 @@ const AdminLoginScreen: React.FC<Props> = ({ onLoginSuccess }) => {
             {devLink && (
               <div className="bg-amber-950/40 border border-amber-700/50 rounded-lg p-3 space-y-2">
                 <p className="text-xs font-semibold text-amber-400 uppercase tracking-wide">
-                  ⚠️ {emailErr ? 'Email delivery failed' : 'Dev mode — no RESEND_API_KEY set'}
+                  Local development link
                 </p>
                 <p className="text-xs text-amber-300/70">
-                  {emailErr
-                    ? `Email could not be sent (${emailErr}). Use the link below to sign in:`
-                    : 'No email was sent. Use the link below to sign in:'}
+                  No email was sent. Use the link below to sign in:
                 </p>
                 <a
                   href={devLink}

--- a/netlify/functions/_shared/adminMagicLinkSecurity.js
+++ b/netlify/functions/_shared/adminMagicLinkSecurity.js
@@ -1,0 +1,80 @@
+// @ts-check
+
+const GENERIC_DELIVERY_ERROR =
+  "Admin sign-in email is temporarily unavailable. Please try again later.";
+
+function deliveryUnavailableError() {
+  return Object.assign(new Error(GENERIC_DELIVERY_ERROR), { status: 503 });
+}
+
+/**
+ * Dev links require three independent signals so a single production
+ * misconfiguration cannot expose a platform-admin sign-in URL.
+ *
+ * @param {string} requestHost
+ * @param {NodeJS.ProcessEnv} [env]
+ */
+export function isExplicitLocalAdminMagicLinkMode(requestHost, env = process.env) {
+  if (
+    env.ALLOW_DEV_ADMIN_MAGIC_LINKS !== "true" ||
+    env.NETLIFY_DEV !== "true"
+  ) {
+    return false;
+  }
+
+  if (!requestHost || /[@/?#]/.test(requestHost)) return false;
+
+  try {
+    const hostname = new URL(`http://${requestHost}`).hostname;
+    return ["localhost", "127.0.0.1", "::1"].includes(hostname);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Check delivery configuration before looking up an email address. This keeps
+ * missing-provider behavior uniform for admin and non-admin addresses.
+ *
+ * @param {boolean} emailDeliveryConfigured
+ * @param {boolean} allowDevLink
+ */
+export function requireAdminMagicLinkDelivery(
+  emailDeliveryConfigured,
+  allowDevLink,
+) {
+  if (!emailDeliveryConfigured && !allowDevLink) {
+    throw deliveryUnavailableError();
+  }
+}
+
+/**
+ * @param {{
+ *   magicLink: string,
+ *   emailDeliveryConfigured: boolean,
+ *   allowDevLink: boolean,
+ *   sendEmail: () => Promise<void>
+ * }} options
+ */
+export async function deliverAdminMagicLink(options) {
+  const {
+    magicLink,
+    emailDeliveryConfigured,
+    allowDevLink,
+    sendEmail,
+  } = options;
+
+  requireAdminMagicLinkDelivery(emailDeliveryConfigured, allowDevLink);
+
+  if (!emailDeliveryConfigured) {
+    return { sent: true, dev_link: magicLink };
+  }
+
+  try {
+    await sendEmail();
+    return { sent: true };
+  } catch {
+    if (allowDevLink) return { sent: true, dev_link: magicLink };
+    throw deliveryUnavailableError();
+  }
+}

--- a/netlify/functions/admin-magic-link.ts
+++ b/netlify/functions/admin-magic-link.ts
@@ -1,0 +1,163 @@
+import { createClient } from '@supabase/supabase-js';
+import {
+  deliverAdminMagicLink,
+  isExplicitLocalAdminMagicLinkMode,
+  requireAdminMagicLinkDelivery,
+} from './_shared/adminMagicLinkSecurity.js';
+
+const json = (status: number, body: object) => new Response(JSON.stringify(body), {
+  status,
+  headers: {
+    'Content-Type': 'application/json',
+    'Cache-Control': 'no-store',
+  },
+});
+
+function getAdminClient() {
+  const supabaseUrl = process.env.SUPABASE_URL ?? process.env.VITE_SUPABASE_URL ?? '';
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
+  if (!supabaseUrl || !serviceRoleKey) throw new Error('Admin auth service is not configured');
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+function getAppUrl() {
+  return (process.env.APP_URL ?? process.env.VITE_APP_URL ?? 'http://localhost:8888').replace(/\/$/, '');
+}
+
+async function sendAdminMagicLinkEmail(toEmail: string, magicLink: string): Promise<void> {
+  const resendApiKey = process.env.RESEND_API_KEY ?? '';
+  const fromEmail = process.env.RESEND_FROM_EMAIL ?? 'no-reply@aeternumally.com';
+  const html = `<!DOCTYPE html>
+<html lang="en"><head><meta charset="UTF-8"/><title>Aeternum Ally Admin Access</title></head>
+<body style="margin:0;padding:0;background:#020617;font-family:Inter,'Helvetica Neue',Arial,sans-serif;">
+<table width="100%" cellpadding="0" cellspacing="0" style="background:#020617;padding:48px 16px;">
+<tr><td align="center">
+<table width="100%" style="max-width:480px;background:#0f172a;border:1px solid #1e293b;border-radius:16px;overflow:hidden;">
+  <tr><td style="background:#14532d;padding:24px 32px;text-align:center;">
+    <span style="color:#fff;font-size:18px;font-weight:700;">Aeternum Ally</span><br/>
+    <span style="color:#86efac;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;">Platform Admin Portal</span>
+  </td></tr>
+  <tr><td style="padding:32px;">
+    <p style="margin:0 0 8px;color:#94a3b8;font-size:12px;font-weight:600;letter-spacing:1px;text-transform:uppercase;">Secure Sign-In Link</p>
+    <h1 style="margin:0 0 16px;color:#f1f5f9;font-size:20px;font-weight:700;">Your admin access link</h1>
+    <p style="margin:0 0 24px;color:#94a3b8;font-size:15px;line-height:1.6;">
+      Click below to sign in to the <strong style="color:#e2e8f0;">Platform Admin Portal</strong>.
+      Valid for <strong style="color:#e2e8f0;">60 minutes</strong>, single use.
+    </p>
+    <table cellpadding="0" cellspacing="0" style="margin:0 0 24px;">
+      <tr><td style="background:#16a34a;border-radius:10px;">
+        <a href="${magicLink}" style="display:inline-block;padding:14px 28px;color:#fff;font-size:15px;font-weight:600;text-decoration:none;">Sign in to Admin Portal</a>
+      </td></tr>
+    </table>
+    <table cellpadding="0" cellspacing="0" style="background:#1e293b;border:1px solid #334155;border-radius:10px;width:100%;">
+      <tr><td style="padding:16px 20px;">
+        <p style="margin:0 0 4px;color:#fbbf24;font-size:12px;font-weight:600;text-transform:uppercase;">Security Notice</p>
+        <p style="margin:0;color:#94a3b8;font-size:13px;line-height:1.5;">
+          This link grants <strong style="color:#e2e8f0;">platform-level access</strong> to all companies and data.
+          If you did not request this, ignore this email. It expires automatically.
+        </p>
+      </td></tr>
+    </table>
+  </td></tr>
+  <tr><td style="padding:0 32px 24px;"><p style="margin:0;color:#475569;font-size:11px;word-break:break-all;font-family:monospace;">${magicLink}</p></td></tr>
+  <tr><td style="padding:16px 32px;border-top:1px solid #1e293b;text-align:center;">
+    <p style="margin:0;color:#334155;font-size:12px;">Aeternum Ally - Platform Administration - Do not reply</p>
+  </td></tr>
+</table>
+</td></tr></table>
+</body></html>`;
+
+  const response = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${resendApiKey}` },
+    body: JSON.stringify({
+      from: `Aeternum Ally Admin <${fromEmail}>`,
+      to: [toEmail],
+      subject: 'Your Aeternum Ally Admin Access Link',
+      html,
+    }),
+  });
+
+  if (!response.ok) throw new Error('Email provider rejected the request');
+}
+
+export default async (request: Request) => {
+  if (request.method === 'OPTIONS') {
+    return new Response(null, { status: 204, headers: { Allow: 'POST, OPTIONS' } });
+  }
+  if (request.method !== 'POST') return json(405, { error: 'Method not allowed' });
+
+  const requestUrl = new URL(request.url);
+  const origin = request.headers.get('origin');
+  if (origin && origin !== requestUrl.origin) {
+    return json(403, { error: 'Cross-origin requests are not allowed' });
+  }
+  if (!request.headers.get('content-type')?.toLowerCase().startsWith('application/json')) {
+    return json(415, { error: 'Content-Type must be application/json' });
+  }
+
+  let body: any;
+  try {
+    body = await request.json();
+  } catch {
+    return json(400, { error: 'Invalid JSON' });
+  }
+
+  try {
+    const email = typeof body?.email === 'string' ? body.email.trim().toLowerCase() : '';
+    if (!email || email.length > 320 || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+      return json(400, { error: 'A valid email is required' });
+    }
+
+    const allowDevLink = isExplicitLocalAdminMagicLinkMode(requestUrl.host);
+    const emailDeliveryConfigured = Boolean(process.env.RESEND_API_KEY);
+    requireAdminMagicLinkDelivery(emailDeliveryConfigured, allowDevLink);
+
+    const admin = getAdminClient();
+    const { data: adminRow } = await admin
+      .from('platform_admins')
+      .select('id, is_active')
+      .eq('email', email)
+      .maybeSingle();
+
+    if (!adminRow?.is_active) {
+      console.info('[admin-magic-link] request completed');
+      return json(200, { sent: true });
+    }
+
+    const { data: linkData, error: linkError } = await admin.auth.admin.generateLink({
+      type: 'magiclink',
+      email,
+      options: { redirectTo: `${getAppUrl()}/admin` },
+    });
+    const magicLink = linkData?.properties?.action_link;
+    if (linkError || !magicLink) throw new Error('Magic-link generation failed');
+
+    const result = await deliverAdminMagicLink({
+      magicLink,
+      emailDeliveryConfigured,
+      allowDevLink,
+      sendEmail: () => sendAdminMagicLinkEmail(email, magicLink),
+    });
+    console.info('[admin-magic-link] request completed');
+    return json(200, result);
+  } catch (error: any) {
+    const status = error?.status === 503 ? 503 : 500;
+    const message = status === 503
+      ? error.message
+      : 'Admin sign-in is temporarily unavailable. Please try again later.';
+    console.error(`[admin-magic-link] request failed status=${status}`);
+    return json(status, { error: message });
+  }
+};
+
+export const config = {
+  path: '/.netlify/functions/admin-magic-link',
+  rateLimit: {
+    windowLimit: 5,
+    windowSize: 60,
+    aggregateBy: ['ip', 'domain'],
+  },
+} as const;

--- a/netlify/functions/admin.ts
+++ b/netlify/functions/admin.ts
@@ -9,9 +9,8 @@
  *   On success: seeds first admin row + returns a signed admin JWT (8 h).
  *
  * Normal     (platform_admins table has rows):
- *   POST { action: 'request_admin_magic_link', email }
- *   Server generates a Supabase magic link (server-side, bypasses redirect allowlist)
- *   and sends a custom admin-branded email via Resend.
+ *   POST /.netlify/functions/admin-magic-link { email }
+ *   The dedicated rate-limited function generates and emails the sign-in link.
  *   POST { action: 'verify_admin' } with Bearer <supabase-token>
  *   After the magic link is clicked, AdminApp exchanges the Supabase session
  *   for a signed admin JWT by calling this action.
@@ -22,7 +21,7 @@
  * SUPABASE_SERVICE_ROLE_KEY if the secret is not set — no extra env var needed).
  */
 
-import { Handler } from '@netlify/functions';
+import type { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
 import crypto from 'crypto';
 
@@ -148,55 +147,6 @@ async function handleAdminLogin(body: any): Promise<object> {
   console.info('[admin] Bootstrap: first platform admin seeded:', email);
 
   return { token: signAdminToken(email), email };
-}
-
-// ---------------------------------------------------------------------------
-// Pre-auth: request_admin_magic_link  (normal mode — table has rows)
-// ---------------------------------------------------------------------------
-async function handleRequestAdminMagicLink(body: any): Promise<object> {
-  const email = (body.email ?? '').trim().toLowerCase();
-  if (!email) throw Object.assign(new Error('email is required'), { status: 400 });
-
-  const sb = getAdminClient();
-
-  // Check email is an active platform admin (silent success if not — don't leak)
-  const { data: adminRow } = await sb
-    .from('platform_admins').select('id, is_active').eq('email', email).maybeSingle();
-
-  if (!adminRow?.is_active) {
-    console.info('[admin] magic-link requested for non-admin email:', email);
-    return { sent: true };   // silent — don't reveal whether this is an admin
-  }
-
-  // Generate magic link server-side — bypasses Supabase redirect-URL allowlist
-  const { data: linkData, error: linkError } = await sb.auth.admin.generateLink({
-    type: 'magiclink',
-    email,
-    options: { redirectTo: `${appUrl}/admin` },
-  });
-
-  if (linkError || !linkData?.properties?.action_link) {
-    console.error('[admin] generateLink failed:', linkError?.message);
-    throw Object.assign(new Error('Failed to generate sign-in link'), { status: 500 });
-  }
-
-  const magicLink = linkData.properties.action_link;
-
-  if (!resendApiKey) {
-    // Dev mode — return link directly (shown in UI)
-    console.info(`\n[admin] ✉️  MAGIC LINK (dev — no RESEND_API_KEY):\n${magicLink}\n`);
-    return { sent: true, dev_link: magicLink };
-  }
-
-  try {
-    await sendAdminMagicLinkEmail(email, magicLink);
-    return { sent: true };
-  } catch (emailErr: any) {
-    // Email sending failed (e.g. domain not verified in Resend).
-    // Fall back to returning the link directly so the admin is never locked out.
-    console.error('[admin] Resend failed, returning dev_link fallback:', emailErr?.message);
-    return { sent: true, dev_link: magicLink, email_error: emailErr?.message };
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -706,7 +656,7 @@ async function handleCreateCompany(body: any): Promise<object> {
           devLink = magicLink;
         }
       } else {
-        console.info(`\n[admin] ✉️  OWNER INVITE LINK (dev):\n${magicLink}\n`);
+        console.info('[admin] Owner invite generated without email delivery');
         devLink = magicLink;
       }
     }
@@ -907,7 +857,7 @@ async function handleAddAdmin(body: any, actorEmail: string): Promise<object> {
       adminDevLink = magicLink;
     }
   } else if (magicLink) {
-    console.info(`\n[admin] ✉️  ADMIN INVITE LINK (dev — no RESEND_API_KEY):\n${magicLink}\n`);
+    console.info('[admin] Admin invite generated without email delivery');
     adminDevLink = magicLink;
   }
 
@@ -1048,64 +998,6 @@ async function sendAdminInviteEmail(toEmail: string, magicLink: string, invitedB
 }
 
 // ---------------------------------------------------------------------------
-// Email helper — custom admin-branded HTML via Resend
-// ---------------------------------------------------------------------------
-async function sendAdminMagicLinkEmail(toEmail: string, magicLink: string): Promise<void> {
-  const html = `<!DOCTYPE html>
-<html lang="en"><head><meta charset="UTF-8"/><title>Aeternum Ally Admin Access</title></head>
-<body style="margin:0;padding:0;background:#020617;font-family:Inter,'Helvetica Neue',Arial,sans-serif;">
-<table width="100%" cellpadding="0" cellspacing="0" style="background:#020617;padding:48px 16px;">
-<tr><td align="center">
-<table width="100%" style="max-width:480px;background:#0f172a;border:1px solid #1e293b;border-radius:16px;overflow:hidden;">
-  <tr><td style="background:#14532d;padding:24px 32px;text-align:center;">
-    <span style="color:#fff;font-size:18px;font-weight:700;">🛡️ Aeternum Ally</span><br/>
-    <span style="color:#86efac;font-size:11px;font-weight:600;letter-spacing:1px;text-transform:uppercase;">Platform Admin Portal</span>
-  </td></tr>
-  <tr><td style="padding:32px;">
-    <p style="margin:0 0 8px;color:#94a3b8;font-size:12px;font-weight:600;letter-spacing:1px;text-transform:uppercase;">Secure Sign-In Link</p>
-    <h1 style="margin:0 0 16px;color:#f1f5f9;font-size:20px;font-weight:700;">Your admin access link</h1>
-    <p style="margin:0 0 24px;color:#94a3b8;font-size:15px;line-height:1.6;">
-      Click below to sign in to the <strong style="color:#e2e8f0;">Platform Admin Portal</strong>.
-      Valid for <strong style="color:#e2e8f0;">60 minutes</strong>, single use.
-    </p>
-    <table cellpadding="0" cellspacing="0" style="margin:0 0 24px;">
-      <tr><td style="background:#16a34a;border-radius:10px;">
-        <a href="${magicLink}" style="display:inline-block;padding:14px 28px;color:#fff;font-size:15px;font-weight:600;text-decoration:none;">Sign in to Admin Portal →</a>
-      </td></tr>
-    </table>
-    <table cellpadding="0" cellspacing="0" style="background:#1e293b;border:1px solid #334155;border-radius:10px;width:100%;">
-      <tr><td style="padding:16px 20px;">
-        <p style="margin:0 0 4px;color:#fbbf24;font-size:12px;font-weight:600;text-transform:uppercase;">⚠️ Security Notice</p>
-        <p style="margin:0;color:#94a3b8;font-size:13px;line-height:1.5;">
-          This link grants <strong style="color:#e2e8f0;">platform-level access</strong> to all companies and data.
-          If you did not request this, ignore this email — it expires automatically.
-        </p>
-      </td></tr>
-    </table>
-  </td></tr>
-  <tr><td style="padding:0 32px 24px;"><p style="margin:0;color:#475569;font-size:11px;word-break:break-all;font-family:monospace;">${magicLink}</p></td></tr>
-  <tr><td style="padding:16px 32px;border-top:1px solid #1e293b;text-align:center;">
-    <p style="margin:0;color:#334155;font-size:12px;">Aeternum Ally · Platform Administration · Do not reply</p>
-  </td></tr>
-</table>
-</td></tr></table>
-</body></html>`;
-
-  const res = await fetch('https://api.resend.com/emails', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json', 'Authorization': `Bearer ${resendApiKey}` },
-    body: JSON.stringify({
-      from:    `Aeternum Ally Admin <${fromEmail}>`,
-      to:      [toEmail],
-      subject: '🛡️ Your Aeternum Ally Admin Access Link',
-      html,
-    }),
-  });
-
-  if (!res.ok) throw new Error(`Resend error ${res.status}: ${await res.text()}`);
-}
-
-// ---------------------------------------------------------------------------
 // Post-auth: list_emission_factors
 // ---------------------------------------------------------------------------
 async function handleListEmissionFactors(): Promise<object> {
@@ -1208,9 +1100,6 @@ export const handler: Handler = async (event) => {
     // ── Pre-auth actions (no token required) ───────────────────────────────
     if (action === 'admin_login') {
       result = await handleAdminLogin(body);
-
-    } else if (action === 'request_admin_magic_link') {
-      result = await handleRequestAdminMagicLink(body);
 
     } else if (action === 'verify_admin') {
       result = await handleVerifyAdmin(authHeader);

--- a/tests/security/admin-magic-link-security.test.mjs
+++ b/tests/security/admin-magic-link-security.test.mjs
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import adminMagicLinkHandler, {
+  config as adminMagicLinkConfig,
+} from "../../netlify/functions/admin-magic-link.ts";
+import { handler as legacyAdminHandler } from "../../netlify/functions/admin.ts";
+import {
+  deliverAdminMagicLink,
+  isExplicitLocalAdminMagicLinkMode,
+  requireAdminMagicLinkDelivery,
+} from "../../netlify/functions/_shared/adminMagicLinkSecurity.js";
+
+const MAGIC_LINK =
+  "https://example.supabase.co/auth/v1/verify?token=top-secret-admin-token";
+
+test("production mode never enables admin dev links", () => {
+  const productionEnv = {
+    ALLOW_DEV_ADMIN_MAGIC_LINKS: "true",
+    NETLIFY_DEV: "false",
+  };
+
+  assert.equal(
+    isExplicitLocalAdminMagicLinkMode(
+      "app.example.com",
+      productionEnv,
+    ),
+    false,
+  );
+});
+
+test("dev links require an explicit flag, Netlify Dev, and loopback host", () => {
+  const localEnv = {
+    ALLOW_DEV_ADMIN_MAGIC_LINKS: "true",
+    NETLIFY_DEV: "true",
+  };
+
+  assert.equal(
+    isExplicitLocalAdminMagicLinkMode(
+      "localhost:8888",
+      localEnv,
+    ),
+    true,
+  );
+  assert.equal(
+    isExplicitLocalAdminMagicLinkMode(
+      "app.example.com",
+      localEnv,
+    ),
+    false,
+  );
+  assert.equal(
+    isExplicitLocalAdminMagicLinkMode(
+      "localhost:8888",
+      { ...localEnv, ALLOW_DEV_ADMIN_MAGIC_LINKS: "false" },
+    ),
+    false,
+  );
+});
+
+test("missing production email configuration fails closed", () => {
+  assert.throws(
+    () => requireAdminMagicLinkDelivery(false, false),
+    (error) => {
+      assert.equal(error.status, 503);
+      assert.doesNotMatch(error.message, /supabase|token|RESEND_API_KEY/i);
+      return true;
+    },
+  );
+});
+
+test("production email failure never returns or throws the magic link", async () => {
+  await assert.rejects(
+    () =>
+      deliverAdminMagicLink({
+        magicLink: MAGIC_LINK,
+        emailDeliveryConfigured: true,
+        allowDevLink: false,
+        sendEmail: async () => {
+          throw new Error(`Provider rejected ${MAGIC_LINK}`);
+        },
+      }),
+    (error) => {
+      assert.equal(error.status, 503);
+      assert.doesNotMatch(error.message, /top-secret-admin-token|supabase/i);
+      return true;
+    },
+  );
+});
+
+test("explicit local mode may return a dev link", async () => {
+  const result = await deliverAdminMagicLink({
+    magicLink: MAGIC_LINK,
+    emailDeliveryConfigured: false,
+    allowDevLink: true,
+    sendEmail: async () => assert.fail("email should not be sent"),
+  });
+
+  assert.deepEqual(result, { sent: true, dev_link: MAGIC_LINK });
+});
+
+test("successful production delivery returns no dev link", async () => {
+  let sent = false;
+  const result = await deliverAdminMagicLink({
+    magicLink: MAGIC_LINK,
+    emailDeliveryConfigured: true,
+    allowDevLink: false,
+    sendEmail: async () => {
+      sent = true;
+    },
+  });
+
+  assert.equal(sent, true);
+  assert.deepEqual(result, { sent: true });
+  assert.equal("dev_link" in result, false);
+});
+
+test("production handler with missing email configuration returns no link", async (t) => {
+  const originalResendKey = process.env.RESEND_API_KEY;
+  delete process.env.RESEND_API_KEY;
+  t.after(() => {
+    if (originalResendKey === undefined) delete process.env.RESEND_API_KEY;
+    else process.env.RESEND_API_KEY = originalResendKey;
+  });
+
+  const response = await adminMagicLinkHandler(new Request(
+    "https://app.example.com/.netlify/functions/admin-magic-link",
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email: "admin@example.com" }),
+    },
+  ));
+  const body = await response.json();
+
+  assert.equal(response.status, 503);
+  assert.equal("dev_link" in body, false);
+  assert.doesNotMatch(JSON.stringify(body), /supabase|token|RESEND_API_KEY/i);
+});
+
+test("legacy admin endpoint no longer accepts unauthenticated magic-link requests", async () => {
+  const response = await legacyAdminHandler({
+    httpMethod: "POST",
+    headers: {},
+    body: JSON.stringify({
+      action: "request_admin_magic_link",
+      email: "admin@example.com",
+    }),
+  });
+  const body = JSON.parse(response.body);
+
+  assert.equal(response.statusCode, 401);
+  assert.equal("dev_link" in body, false);
+});
+
+test("magic-link endpoint rejects cross-origin requests", async () => {
+  const response = await adminMagicLinkHandler(new Request(
+    "https://app.example.com/.netlify/functions/admin-magic-link",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Origin: "https://attacker.example",
+      },
+      body: JSON.stringify({ email: "admin@example.com" }),
+    },
+  ));
+
+  assert.equal(response.status, 403);
+});
+
+test("dedicated magic-link endpoint has a strict per-IP rate limit", () => {
+  assert.equal(adminMagicLinkConfig.path, "/.netlify/functions/admin-magic-link");
+  assert.deepEqual(adminMagicLinkConfig.rateLimit.aggregateBy, ["ip", "domain"]);
+  assert.equal(adminMagicLinkConfig.rateLimit.windowLimit, 5);
+  assert.equal(adminMagicLinkConfig.rateLimit.windowSize, 60);
+});


### PR DESCRIPTION
## Summary

- move unauthenticated admin magic-link requests to a dedicated Fetch-style Netlify Function
- remove the legacy pre-auth action so the original admin endpoint cannot bypass the new controls
- return dev links only when explicitly enabled under Netlify Dev on a loopback host
- fail closed with generic responses when production email delivery is unavailable
- remove magic-link URLs from server logs and provider error responses
- enforce same-origin JSON requests, no-store responses, and a 5 requests/minute per domain+IP rate limit

Closes #154

## Review order

This PR is stacked on #158 and should be reviewed/merged after it. Once #158 is merged, this PR can be retargeted to main.

## Deployment notes

- Production must have RESEND_API_KEY available to Functions or admin magic-link requests return 503 by design.
- Do not set ALLOW_DEV_ADMIN_MAGIC_LINKS=true in any hosted deploy context.
- The Netlify deploy log should confirm the code-based rate-limit rule during post-processing.

## Testing

- npm run test:security (23 passing across #153 and #154)
- npm run build (passing)
- npx netlify functions:build --src netlify/functions (passing; admin-magic-link uses runtime API v2)
- npx tsc --noEmit (no new errors; existing five baseline errors remain)

## Database migration

No database migration.