### PR TITLE
security: isolate organization BYOK credentials (expand phase)

### DIFF
--- a/netlify/functions/_shared/byokSecurity.js
+++ b/netlify/functions/_shared/byokSecurity.js
@@ -1,0 +1,71 @@
+// @ts-check
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export function isValidOrganizationId(value) {
+  return typeof value === "string" && UUID_PATTERN.test(value);
+}
+
+export function canManageByok(role) {
+  return role === "Owner" || role === "Admin";
+}
+
+export function toSafeByokMetadata(settings, hasSecret) {
+  return {
+    model: settings?.model ?? "gemini-2.5-flash",
+    use_byok: settings?.use_byok === true,
+    byok_provider: settings?.byok_provider ?? null,
+    has_byok_key: Boolean(hasSecret),
+    soft_quota_monthly: settings?.soft_quota_monthly ?? null,
+  };
+}
+
+/**
+ * @param {any} input
+ * @param {boolean} hasExistingSecret
+ */
+export function normalizeByokUpdate(input, hasExistingSecret) {
+  if (typeof input?.use_byok !== "boolean") {
+    throw Object.assign(new Error("use_byok must be a boolean."), { status: 400 });
+  }
+
+  const provider = input.use_byok ? input.byok_provider : null;
+  if (input.use_byok && provider !== "gemini") {
+    throw Object.assign(new Error("Only the Gemini BYOK provider is supported."), {
+      status: 400,
+    });
+  }
+
+  const hasKeyField = Object.prototype.hasOwnProperty.call(input, "byok_api_key");
+  if (!input.use_byok) {
+    if (hasKeyField && input.byok_api_key !== null) {
+      throw Object.assign(new Error("Disable BYOK before clearing its key."), {
+        status: 400,
+      });
+    }
+    return { useByok: false, provider: null, keyAction: "clear", key: null };
+  }
+
+  if (!hasKeyField) {
+    if (!hasExistingSecret) {
+      throw Object.assign(new Error("A BYOK API key is required."), { status: 400 });
+    }
+    return { useByok: true, provider, keyAction: "keep", key: null };
+  }
+
+  if (typeof input.byok_api_key !== "string") {
+    throw Object.assign(new Error("A valid BYOK API key is required."), {
+      status: 400,
+    });
+  }
+
+  const key = input.byok_api_key.trim();
+  if (key.length < 20 || key.length > 2048 || /\s|[\u0000-\u001f\u007f]/.test(key)) {
+    throw Object.assign(new Error("A valid BYOK API key is required."), {
+      status: 400,
+    });
+  }
+
+  return { useByok: true, provider, keyAction: "set", key };
+}

--- a/netlify/functions/_shared/organizationAiConfig.js
+++ b/netlify/functions/_shared/organizationAiConfig.js
@@ -1,0 +1,61 @@
+// @ts-check
+
+/**
+ * Load non-secret settings and, only when BYOK is enabled, resolve the raw key
+ * from the service-role-only secrets table.
+ *
+ * @param {any} admin Supabase service-role client
+ * @param {string} organizationId
+ * @param {string} platformApiKey
+ * @param {string} defaultModel
+ */
+export async function loadOrganizationAiConfig(
+  admin,
+  organizationId,
+  platformApiKey,
+  defaultModel,
+) {
+  const { data: settings, error: settingsError } = await admin
+    .from("organization_ai_settings")
+    .select("model, use_byok, byok_provider, soft_quota_monthly")
+    .eq("organization_id", organizationId)
+    .maybeSingle();
+
+  if (settingsError) {
+    throw new Error("Organization AI settings are unavailable.");
+  }
+
+  const byokRequested = settings?.use_byok === true;
+  if (byokRequested && settings?.byok_provider !== "gemini") {
+    throw new Error("Organization AI credentials are unavailable.");
+  }
+
+  let byokApiKey = null;
+  if (byokRequested) {
+    const { data: secret, error: secretError } = await admin
+      .from("organization_ai_secrets")
+      .select("byok_api_key")
+      .eq("organization_id", organizationId)
+      .maybeSingle();
+
+    if (secretError) {
+      throw new Error("Organization AI credentials are unavailable.");
+    }
+    byokApiKey = secret?.byok_api_key ?? null;
+    if (typeof byokApiKey !== "string" || byokApiKey.length === 0) {
+      throw new Error("Organization AI credentials are unavailable.");
+    }
+  }
+
+  if (!byokRequested && !platformApiKey) {
+    throw new Error("Platform AI credentials are unavailable.");
+  }
+
+  return {
+    model: settings?.model ?? defaultModel,
+    useBYOK: byokRequested,
+    resolvedApiKey: byokRequested ? byokApiKey : platformApiKey,
+    quotaType: byokRequested ? "byok" : "platform_free",
+    softQuotaMonthly: settings?.soft_quota_monthly ?? null,
+  };
+}

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -5,6 +5,7 @@ import {
   createInternalJobHeaders,
 } from "./_shared/internalJobAuth.js";
 import { withAIRequestFence } from "./_shared/aiRequestFence.js";
+import { loadOrganizationAiConfig } from "./_shared/organizationAiConfig.js";
 
 const apiKey = process.env.GEMINI_API_KEY;
 const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
@@ -105,23 +106,33 @@ const handler = async (event: any) => {
   // ------------------------------------------------------------------
   // 4. Look up the org's chosen model + BYOK settings
   // ------------------------------------------------------------------
-  const { data: settings } = await admin
-    .from("organization_ai_settings")
-    .select("model, use_byok, byok_provider, byok_api_key, soft_quota_monthly")
-    .eq("organization_id", organization_id)
-    .maybeSingle();
-  const model = settings?.model ?? DEFAULT_MODEL;
-
-  // Determine which API key to use and record the quota type
-  const useBYOK = settings?.use_byok === true && !!settings?.byok_api_key;
-  const resolvedApiKey = useBYOK ? settings!.byok_api_key! : apiKey!;
-  const quotaType: string = useBYOK ? "byok" : "platform_free";
+  let aiConfig;
+  try {
+    aiConfig = await loadOrganizationAiConfig(
+      admin,
+      organization_id,
+      apiKey,
+      DEFAULT_MODEL,
+    );
+  } catch {
+    console.error(`[api] AI configuration unavailable org=${organization_id}`);
+    return json(503, {
+      error: "AI settings are temporarily unavailable. Please try again later.",
+    });
+  }
+  const {
+    model,
+    useBYOK,
+    resolvedApiKey,
+    quotaType,
+    softQuotaMonthly,
+  } = aiConfig;
 
   // ------------------------------------------------------------------
   // 4a. Soft quota check (platform calls only, BYOK bypasses)
   // ------------------------------------------------------------------
   if (!useBYOK) {
-    const PLATFORM_SOFT_LIMIT = settings?.soft_quota_monthly ?? 100;
+    const PLATFORM_SOFT_LIMIT = softQuotaMonthly ?? 100;
     const monthStart = new Date();
     monthStart.setDate(1);
     monthStart.setHours(0, 0, 0, 0);

--- a/netlify/functions/assessment-background.ts
+++ b/netlify/functions/assessment-background.ts
@@ -1,6 +1,7 @@
 import { GoogleGenAI, Type } from "@google/genai";
 import { createClient } from "@supabase/supabase-js";
 import { requireInternalJobAuth } from "./_shared/internalJobAuth.js";
+import { loadOrganizationAiConfig } from "./_shared/organizationAiConfig.js";
 
 const apiKey = process.env.GEMINI_API_KEY;
 const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
@@ -90,17 +91,23 @@ const handler = async (event: any) => {
 
   const admin = createClient(supabaseUrl!, serviceKey!);
 
-  // Look up the org's chosen model + BYOK settings
-  const { data: settings } = await admin
-    .from("organization_ai_settings")
-    .select("model, use_byok, byok_provider, byok_api_key")
-    .eq("organization_id", organization_id)
-    .maybeSingle();
-
-  const activeModel = settings?.model ?? DEFAULT_MODEL;
-  const useBYOK = settings?.use_byok === true && !!settings?.byok_api_key;
-  const resolvedApiKey = useBYOK ? settings!.byok_api_key! : apiKey!;
-  const quotaType = useBYOK ? "byok" : "platform_free";
+  let aiConfig;
+  try {
+    aiConfig = await loadOrganizationAiConfig(
+      admin,
+      organization_id,
+      apiKey!,
+      DEFAULT_MODEL,
+    );
+  } catch {
+    console.error(`[assessment-background] AI configuration unavailable org=${organization_id}`);
+    return { statusCode: 503, body: "AI settings are temporarily unavailable" };
+  }
+  const {
+    model: activeModel,
+    resolvedApiKey,
+    quotaType,
+  } = aiConfig;
 
   console.log(`[assessment-background] Using model=${activeModel}, quotaType=${quotaType}`);
 

--- a/netlify/functions/byok-settings.ts
+++ b/netlify/functions/byok-settings.ts
@@ -1,0 +1,181 @@
+import { createClient } from "@supabase/supabase-js";
+import {
+  canManageByok,
+  isValidOrganizationId,
+  normalizeByokUpdate,
+  toSafeByokMetadata,
+} from "./_shared/byokSecurity.js";
+
+const json = (status: number, body: object) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+    },
+  });
+
+function getAdminClient() {
+  const supabaseUrl = process.env.SUPABASE_URL ?? process.env.VITE_SUPABASE_URL ?? "";
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw Object.assign(new Error("BYOK settings are temporarily unavailable."), {
+      status: 503,
+    });
+  }
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+async function loadSafeMetadata(admin: any, organizationId: string) {
+  const [{ data: settings, error: settingsError }, { data: secret, error: secretError }] =
+    await Promise.all([
+      admin
+        .from("organization_ai_settings")
+        .select("model, use_byok, byok_provider, soft_quota_monthly")
+        .eq("organization_id", organizationId)
+        .maybeSingle(),
+      admin
+        .from("organization_ai_secrets")
+        .select("organization_id")
+        .eq("organization_id", organizationId)
+        .maybeSingle(),
+    ]);
+
+  if (settingsError || secretError) {
+    throw new Error("Could not load BYOK metadata.");
+  }
+  return toSafeByokMetadata(settings, Boolean(secret));
+}
+
+async function handleByokSettings(
+  request: Request,
+  createAdminClient: () => any,
+) {
+  if (request.method === "OPTIONS") {
+    return new Response(null, { status: 204, headers: { Allow: "GET, PUT, OPTIONS" } });
+  }
+  if (!["GET", "PUT"].includes(request.method)) {
+    return json(405, { error: "Method not allowed." });
+  }
+
+  const requestUrl = new URL(request.url);
+  const origin = request.headers.get("origin");
+  if (origin && origin !== requestUrl.origin) {
+    return json(403, { error: "Cross-origin requests are not allowed." });
+  }
+
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return json(401, { error: "You must be signed in to manage BYOK settings." });
+  }
+
+  let body: any = null;
+  if (request.method === "PUT") {
+    if (!request.headers.get("content-type")?.toLowerCase().startsWith("application/json")) {
+      return json(415, { error: "Content-Type must be application/json." });
+    }
+    try {
+      body = await request.json();
+    } catch {
+      return json(400, { error: "Invalid JSON." });
+    }
+  }
+
+  const organizationId =
+    request.method === "GET"
+      ? requestUrl.searchParams.get("organization_id")
+      : body?.organization_id;
+  if (!isValidOrganizationId(organizationId)) {
+    return json(400, { error: "A valid organization_id is required." });
+  }
+
+  try {
+    const admin = createAdminClient();
+    const accessToken = authHeader.slice("Bearer ".length);
+    const { data: userResponse, error: userError } = await admin.auth.getUser(accessToken);
+    if (userError || !userResponse?.user) {
+      return json(401, { error: "Your session has expired. Please sign in again." });
+    }
+
+    const { data: membership, error: membershipError } = await admin
+      .from("organization_members")
+      .select("role")
+      .eq("organization_id", organizationId)
+      .eq("user_id", userResponse.user.id)
+      .maybeSingle();
+    if (membershipError || !membership) {
+      return json(403, { error: "You don't have access to this organization." });
+    }
+
+    if (request.method === "GET") {
+      return json(200, await loadSafeMetadata(admin, organizationId));
+    }
+
+    if (!canManageByok(membership.role)) {
+      return json(403, { error: "Only Owners and Admins can manage BYOK settings." });
+    }
+
+    const { data: existingSecret, error: secretLookupError } = await admin
+      .from("organization_ai_secrets")
+      .select("organization_id")
+      .eq("organization_id", organizationId)
+      .maybeSingle();
+    if (secretLookupError) throw new Error("Could not load BYOK metadata.");
+
+    const update = normalizeByokUpdate(body, Boolean(existingSecret));
+
+    if (update.keyAction === "set") {
+      const { error } = await admin.from("organization_ai_secrets").upsert(
+        { organization_id: organizationId, byok_api_key: update.key },
+        { onConflict: "organization_id" },
+      );
+      if (error) throw new Error("Could not store the BYOK credential.");
+    }
+
+    const { error: settingsError } = await admin.from("organization_ai_settings").upsert(
+      {
+        organization_id: organizationId,
+        use_byok: update.useByok,
+        byok_provider: update.provider,
+      },
+      { onConflict: "organization_id" },
+    );
+    if (settingsError) throw new Error("Could not update BYOK settings.");
+
+    if (update.keyAction === "clear") {
+      const { error } = await admin
+        .from("organization_ai_secrets")
+        .delete()
+        .eq("organization_id", organizationId);
+      if (error) throw new Error("Could not clear the BYOK credential.");
+    }
+
+    return json(200, await loadSafeMetadata(admin, organizationId));
+  } catch (error: any) {
+    const status = typeof error?.status === "number" ? error.status : 500;
+    const message = status === 400 || status === 503
+      ? error.message
+      : "BYOK settings are temporarily unavailable. Please try again later.";
+    console.error(`[byok-settings] request failed status=${status}`);
+    return json(status, { error: message });
+  }
+}
+
+export function createByokSettingsHandler(
+  createAdminClient: () => any = getAdminClient,
+) {
+  return (request: Request) => handleByokSettings(request, createAdminClient);
+}
+
+export default createByokSettingsHandler();
+
+export const config = {
+  path: "/.netlify/functions/byok-settings",
+  rateLimit: {
+    windowLimit: 20,
+    windowSize: 60,
+    aggregateBy: ["ip", "domain"],
+  },
+} as const;

--- a/netlify/functions/dma-background.ts
+++ b/netlify/functions/dma-background.ts
@@ -1,6 +1,7 @@
 import { GoogleGenAI, Type } from "@google/genai";
 import { createClient } from "@supabase/supabase-js";
 import { requireInternalJobAuth } from "./_shared/internalJobAuth.js";
+import { loadOrganizationAiConfig } from "./_shared/organizationAiConfig.js";
 
 const apiKey = process.env.GEMINI_API_KEY;
 const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
@@ -34,17 +35,23 @@ const handler = async (event: any) => {
 
   const admin = createClient(supabaseUrl!, serviceKey!);
 
-  // Look up the org's chosen model + BYOK settings
-  const { data: settings } = await admin
-    .from("organization_ai_settings")
-    .select("model, use_byok, byok_provider, byok_api_key")
-    .eq("organization_id", organization_id)
-    .maybeSingle();
-
-  const activeModel = settings?.model ?? DEFAULT_MODEL;
-  const useBYOK = settings?.use_byok === true && !!settings?.byok_api_key;
-  const resolvedApiKey = useBYOK ? settings!.byok_api_key! : apiKey!;
-  const quotaType = useBYOK ? "byok" : "platform_free";
+  let aiConfig;
+  try {
+    aiConfig = await loadOrganizationAiConfig(
+      admin,
+      organization_id,
+      apiKey!,
+      DEFAULT_MODEL,
+    );
+  } catch {
+    console.error(`[dma-background] AI configuration unavailable org=${organization_id}`);
+    return { statusCode: 503, body: "AI settings are temporarily unavailable" };
+  }
+  const {
+    model: activeModel,
+    resolvedApiKey,
+    quotaType,
+  } = aiConfig;
 
   console.log(`[dma-background] Using model=${activeModel}, quotaType=${quotaType}`);
 

--- a/netlify/functions/report-background.ts
+++ b/netlify/functions/report-background.ts
@@ -1,6 +1,7 @@
 import { GoogleGenAI, Type } from "@google/genai";
 import { createClient } from "@supabase/supabase-js";
 import { requireInternalJobAuth } from "./_shared/internalJobAuth.js";
+import { loadOrganizationAiConfig } from "./_shared/organizationAiConfig.js";
 
 const apiKey = process.env.GEMINI_API_KEY;
 const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
@@ -34,17 +35,23 @@ const handler = async (event: any) => {
 
   const admin = createClient(supabaseUrl!, serviceKey!);
 
-  // Look up the org's chosen model + BYOK settings
-  const { data: settings } = await admin
-    .from("organization_ai_settings")
-    .select("model, use_byok, byok_provider, byok_api_key")
-    .eq("organization_id", organization_id)
-    .maybeSingle();
-
-  const activeModel = settings?.model ?? DEFAULT_MODEL;
-  const useBYOK = settings?.use_byok === true && !!settings?.byok_api_key;
-  const resolvedApiKey = useBYOK ? settings!.byok_api_key! : apiKey!;
-  const quotaType = useBYOK ? "byok" : "platform_free";
+  let aiConfig;
+  try {
+    aiConfig = await loadOrganizationAiConfig(
+      admin,
+      organization_id,
+      apiKey!,
+      DEFAULT_MODEL,
+    );
+  } catch {
+    console.error(`[report-background] AI configuration unavailable org=${organization_id}`);
+    return { statusCode: 503, body: "AI settings are temporarily unavailable" };
+  }
+  const {
+    model: activeModel,
+    resolvedApiKey,
+    quotaType,
+  } = aiConfig;
 
   console.log(`[report-background] Using model=${activeModel}, quotaType=${quotaType}`);
 

--- a/services/dbService.ts
+++ b/services/dbService.ts
@@ -161,24 +161,48 @@ export interface AiSettings {
   soft_quota_monthly: number | null;
 }
 
+const BYOK_SETTINGS_ENDPOINT = "/.netlify/functions/byok-settings";
+
+async function requestByokSettings(
+  orgId: string,
+  method: "GET" | "PUT",
+  settings?: {
+    use_byok: boolean;
+    byok_provider: string | null;
+    byok_api_key?: string | null;
+  }
+): Promise<AiSettings> {
+  const { data: sessionData, error: sessionError } = await supabase.auth.getSession();
+  const accessToken = sessionData.session?.access_token;
+  if (sessionError || !accessToken) {
+    throw new Error("You must be signed in to manage BYOK settings.");
+  }
+
+  const url = method === "GET"
+    ? `${BYOK_SETTINGS_ENDPOINT}?organization_id=${encodeURIComponent(orgId)}`
+    : BYOK_SETTINGS_ENDPOINT;
+  const response = await fetch(url, {
+    method,
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      ...(method === "PUT" ? { "Content-Type": "application/json" } : {}),
+    },
+    body: method === "PUT"
+      ? JSON.stringify({ organization_id: orgId, ...settings })
+      : undefined,
+  });
+
+  const payload = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new Error(payload?.error ?? "BYOK settings are temporarily unavailable.");
+  }
+  return payload as AiSettings;
+}
+
 export async function fetchAiSettings(
   orgId: string
 ): Promise<AiSettings | null> {
-  const { data, error } = await supabase
-    .from("organization_ai_settings")
-    .select("model, use_byok, byok_provider, byok_api_key, soft_quota_monthly")
-    .eq("organization_id", orgId)
-    .maybeSingle();
-  if (error) throw error;
-  if (!data) return null;
-  return {
-    model: data.model ?? "gemini-2.5-flash",
-    use_byok: data.use_byok ?? false,
-    byok_provider: data.byok_provider ?? null,
-    // Never expose the raw key to the browser — just whether one is stored
-    has_byok_key: !!data.byok_api_key,
-    soft_quota_monthly: data.soft_quota_monthly ?? null,
-  };
+  return requestByokSettings(orgId, "GET");
 }
 
 /** Upserts the AI model choice (always safe to call). */
@@ -198,19 +222,7 @@ export async function upsertByokSettings(
     byok_api_key?: string | null; // omit to leave unchanged
   }
 ): Promise<void> {
-  const payload: Record<string, unknown> = {
-    organization_id: orgId,
-    use_byok: settings.use_byok,
-    byok_provider: settings.byok_provider,
-  };
-  // Only include the key field when explicitly provided
-  if ("byok_api_key" in settings) {
-    payload.byok_api_key = settings.byok_api_key ?? null;
-  }
-  const { error } = await supabase
-    .from("organization_ai_settings")
-    .upsert(payload, { onConflict: "organization_id" });
-  if (error) throw error;
+  await requestByokSettings(orgId, "PUT", settings);
 }
 
 /** Returns the number of successful AI calls made by this org this calendar month. */

--- a/supabase/migrations/020_expand_organization_ai_secrets.sql
+++ b/supabase/migrations/020_expand_organization_ai_secrets.sql
@@ -1,0 +1,39 @@
+-- ============================================================
+-- 020 - Expand BYOK storage into a server-only table
+-- ============================================================
+-- This is the expand phase of an expand/migrate/contract rollout.
+-- The legacy organization_ai_settings.byok_api_key column remains until
+-- application code has switched to this table and production is verified.
+
+CREATE TABLE IF NOT EXISTS organization_ai_secrets (
+  organization_id uuid PRIMARY KEY REFERENCES organizations(id) ON DELETE CASCADE,
+  byok_api_key     text NOT NULL CHECK (char_length(byok_api_key) <= 2048),
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TRIGGER trg_ai_secrets_updated_at
+  BEFORE UPDATE ON organization_ai_secrets
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+ALTER TABLE organization_ai_secrets ENABLE ROW LEVEL SECURITY;
+
+-- Defense in depth: browser roles have neither table grants nor RLS policies.
+-- Only trusted service-role clients may access raw credentials.
+REVOKE ALL ON TABLE organization_ai_secrets FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE organization_ai_secrets TO service_role;
+
+COMMENT ON TABLE organization_ai_secrets
+  IS 'Server-only organization credentials. Never expose rows or raw values to browser clients.';
+COMMENT ON COLUMN organization_ai_secrets.byok_api_key
+  IS 'Organization-owned AI provider credential. Service-role access only.';
+
+-- Preserve existing customer keys. The legacy column is intentionally retained
+-- for the expand phase and will be removed by a separate contract migration.
+INSERT INTO organization_ai_secrets (organization_id, byok_api_key)
+SELECT organization_id, byok_api_key
+FROM organization_ai_settings
+WHERE NULLIF(trim(byok_api_key), '') IS NOT NULL
+ON CONFLICT (organization_id) DO UPDATE
+SET byok_api_key = EXCLUDED.byok_api_key,
+    updated_at = now();

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -967,3 +967,43 @@ CREATE POLICY "members_read_dma_jobs" ON dma_analysis_jobs
 
 CREATE POLICY "members_write_dma_jobs" ON dma_analysis_jobs
   FOR ALL USING (is_org_member(organization_id));
+
+-- ============================================================
+-- Migration 020 - Expand BYOK storage into a server-only table
+-- ============================================================
+-- This is the expand phase of an expand/migrate/contract rollout.
+-- The legacy organization_ai_settings.byok_api_key column remains until
+-- application code has switched to this table and production is verified.
+
+CREATE TABLE IF NOT EXISTS organization_ai_secrets (
+  organization_id uuid PRIMARY KEY REFERENCES organizations(id) ON DELETE CASCADE,
+  byok_api_key     text NOT NULL CHECK (char_length(byok_api_key) <= 2048),
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE TRIGGER trg_ai_secrets_updated_at
+  BEFORE UPDATE ON organization_ai_secrets
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at();
+
+ALTER TABLE organization_ai_secrets ENABLE ROW LEVEL SECURITY;
+
+-- Browser roles have neither table grants nor RLS policies.
+-- Only trusted service-role clients may access raw credentials.
+REVOKE ALL ON TABLE organization_ai_secrets FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE organization_ai_secrets TO service_role;
+
+COMMENT ON TABLE organization_ai_secrets
+  IS 'Server-only organization credentials. Never expose rows or raw values to browser clients.';
+COMMENT ON COLUMN organization_ai_secrets.byok_api_key
+  IS 'Organization-owned AI provider credential. Service-role access only.';
+
+-- Preserve existing customer keys. The legacy column is intentionally retained
+-- for the expand phase and will be removed by a separate contract migration.
+INSERT INTO organization_ai_secrets (organization_id, byok_api_key)
+SELECT organization_id, byok_api_key
+FROM organization_ai_settings
+WHERE NULLIF(trim(byok_api_key), '') IS NOT NULL
+ON CONFLICT (organization_id) DO UPDATE
+SET byok_api_key = EXCLUDED.byok_api_key,
+    updated_at = now();

--- a/tests/security/byok-secret-isolation.test.mjs
+++ b/tests/security/byok-secret-isolation.test.mjs
@@ -1,0 +1,458 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import byokSettingsHandler, {
+  createByokSettingsHandler,
+  config as byokSettingsConfig,
+} from "../../netlify/functions/byok-settings.ts";
+import {
+  canManageByok,
+  isValidOrganizationId,
+  normalizeByokUpdate,
+  toSafeByokMetadata,
+} from "../../netlify/functions/_shared/byokSecurity.js";
+import { loadOrganizationAiConfig } from "../../netlify/functions/_shared/organizationAiConfig.js";
+
+const ORG_ID = "11111111-1111-4111-8111-111111111111";
+const TEST_KEY = `test-${"a".repeat(32)}`;
+
+function createAdminMock(rows) {
+  const calls = [];
+  return {
+    calls,
+    from(table) {
+      return {
+        select(columns) {
+          calls.push({ table, columns });
+          return {
+            eq(column, value) {
+              assert.equal(column, "organization_id");
+              assert.equal(value, ORG_ID);
+              return {
+                maybeSingle: async () => rows[table],
+              };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+function createEndpointAdminMock({ role = "Owner", hasSecret = true } = {}) {
+  const calls = [];
+  let storedSecret = hasSecret;
+  let useByok = hasSecret;
+  let provider = hasSecret ? "gemini" : null;
+  const admin = {
+    calls,
+    auth: {
+      getUser: async (token) => {
+        calls.push({ operation: "getUser", token });
+        return {
+          data: { user: { id: "22222222-2222-4222-8222-222222222222" } },
+          error: null,
+        };
+      },
+    },
+    from(table) {
+      const filters = [];
+      let operation = null;
+      let columns = null;
+      const query = {
+        select(value) {
+          operation = "select";
+          columns = value;
+          return query;
+        },
+        delete() {
+          operation = "delete";
+          return query;
+        },
+        async upsert(payload, options) {
+          calls.push({ table, operation: "upsert", payload, options });
+          if (table === "organization_ai_secrets") storedSecret = true;
+          if (table === "organization_ai_settings") {
+            useByok = payload.use_byok;
+            provider = payload.byok_provider;
+          }
+          return { error: null };
+        },
+        eq(column, value) {
+          filters.push([column, value]);
+          return query;
+        },
+        async maybeSingle() {
+          calls.push({ table, operation, columns, filters });
+          if (table === "organization_members") {
+            return { data: role ? { role } : null, error: null };
+          }
+          if (table === "organization_ai_settings") {
+            return {
+              data: {
+                model: "gemini-2.5-flash",
+                use_byok: useByok,
+                byok_provider: provider,
+                byok_api_key: TEST_KEY,
+                soft_quota_monthly: 100,
+              },
+              error: null,
+            };
+          }
+          if (table === "organization_ai_secrets") {
+            return {
+              data: storedSecret ? { organization_id: ORG_ID } : null,
+              error: null,
+            };
+          }
+          throw new Error(`Unexpected table ${table}`);
+        },
+        then(resolve, reject) {
+          calls.push({ table, operation, columns, filters });
+          if (table === "organization_ai_secrets" && operation === "delete") {
+            storedSecret = false;
+          }
+          return Promise.resolve({ error: null }).then(resolve, reject);
+        },
+      };
+      return query;
+    },
+  };
+  return admin;
+}
+
+test("only Owner and Admin roles can manage organization BYOK credentials", () => {
+  assert.equal(canManageByok("Owner"), true);
+  assert.equal(canManageByok("Admin"), true);
+  assert.equal(canManageByok("Manager"), false);
+  assert.equal(canManageByok("Consultant"), false);
+  assert.equal(canManageByok(undefined), false);
+});
+
+test("organization identifiers must be valid UUIDs", () => {
+  assert.equal(isValidOrganizationId(ORG_ID), true);
+  assert.equal(isValidOrganizationId("../../another-tenant"), false);
+  assert.equal(isValidOrganizationId("not-a-uuid"), false);
+});
+
+test("safe BYOK metadata never serializes a raw key", () => {
+  const metadata = toSafeByokMetadata(
+    {
+      model: "gemini-2.5-flash",
+      use_byok: true,
+      byok_provider: "gemini",
+      byok_api_key: TEST_KEY,
+      soft_quota_monthly: 250,
+    },
+    true,
+  );
+
+  assert.equal(metadata.has_byok_key, true);
+  assert.equal("byok_api_key" in metadata, false);
+  assert.doesNotMatch(JSON.stringify(metadata), new RegExp(TEST_KEY));
+});
+
+test("BYOK updates validate provider, key presence, and key shape", () => {
+  assert.deepEqual(
+    normalizeByokUpdate(
+      { use_byok: true, byok_provider: "gemini", byok_api_key: TEST_KEY },
+      false,
+    ),
+    { useByok: true, provider: "gemini", keyAction: "set", key: TEST_KEY },
+  );
+  assert.deepEqual(
+    normalizeByokUpdate({ use_byok: true, byok_provider: "gemini" }, true),
+    { useByok: true, provider: "gemini", keyAction: "keep", key: null },
+  );
+  assert.deepEqual(
+    normalizeByokUpdate(
+      { use_byok: false, byok_provider: null, byok_api_key: null },
+      true,
+    ),
+    { useByok: false, provider: null, keyAction: "clear", key: null },
+  );
+  assert.throws(
+    () => normalizeByokUpdate({ use_byok: true, byok_provider: "openai" }, true),
+    /Only the Gemini BYOK provider is supported/,
+  );
+  assert.throws(
+    () => normalizeByokUpdate({ use_byok: true, byok_provider: "gemini" }, false),
+    /API key is required/,
+  );
+  assert.throws(
+    () => normalizeByokUpdate(
+      { use_byok: true, byok_provider: "gemini", byok_api_key: "short" },
+      false,
+    ),
+    /valid BYOK API key/,
+  );
+});
+
+test("server resolver reads secret storage without selecting a key from settings", async () => {
+  const admin = createAdminMock({
+    organization_ai_settings: {
+      data: {
+        model: "gemini-2.5-pro",
+        use_byok: true,
+        byok_provider: "gemini",
+        soft_quota_monthly: 300,
+      },
+      error: null,
+    },
+    organization_ai_secrets: {
+      data: { byok_api_key: TEST_KEY },
+      error: null,
+    },
+  });
+
+  const config = await loadOrganizationAiConfig(
+    admin,
+    ORG_ID,
+    "platform-test-key",
+    "gemini-2.5-flash",
+  );
+
+  assert.equal(config.resolvedApiKey, TEST_KEY);
+  assert.equal(config.quotaType, "byok");
+  assert.equal(config.model, "gemini-2.5-pro");
+  assert.equal(config.softQuotaMonthly, 300);
+  assert.deepEqual(admin.calls, [
+    {
+      table: "organization_ai_settings",
+      columns: "model, use_byok, byok_provider, soft_quota_monthly",
+    },
+    { table: "organization_ai_secrets", columns: "byok_api_key" },
+  ]);
+});
+
+test("server resolver uses the platform key when BYOK is disabled", async () => {
+  const admin = createAdminMock({
+    organization_ai_settings: {
+      data: {
+        model: null,
+        use_byok: false,
+        byok_provider: null,
+        soft_quota_monthly: null,
+      },
+      error: null,
+    },
+  });
+
+  const config = await loadOrganizationAiConfig(
+    admin,
+    ORG_ID,
+    "platform-test-key",
+    "gemini-2.5-flash",
+  );
+
+  assert.equal(config.resolvedApiKey, "platform-test-key");
+  assert.equal(config.quotaType, "platform_free");
+  assert.equal(config.model, "gemini-2.5-flash");
+  assert.equal(admin.calls.length, 1);
+});
+
+test("server resolver fails closed when BYOK is enabled without a credential", async () => {
+  const admin = createAdminMock({
+    organization_ai_settings: {
+      data: {
+        model: "gemini-2.5-flash",
+        use_byok: true,
+        byok_provider: "gemini",
+        soft_quota_monthly: null,
+      },
+      error: null,
+    },
+    organization_ai_secrets: { data: null, error: null },
+  });
+
+  await assert.rejects(
+    () => loadOrganizationAiConfig(
+      admin,
+      ORG_ID,
+      "platform-test-key",
+      "gemini-2.5-flash",
+    ),
+    /Organization AI credentials are unavailable/,
+  );
+});
+
+test("BYOK endpoint rejects cross-origin and unauthenticated requests early", async () => {
+  const crossOrigin = await byokSettingsHandler(new Request(
+    `https://app.example.com/.netlify/functions/byok-settings?organization_id=${ORG_ID}`,
+    { headers: { Origin: "https://attacker.example" } },
+  ));
+  assert.equal(crossOrigin.status, 403);
+
+  const unauthenticated = await byokSettingsHandler(new Request(
+    `https://app.example.com/.netlify/functions/byok-settings?organization_id=${ORG_ID}`,
+  ));
+  assert.equal(unauthenticated.status, 401);
+});
+
+test("authenticated members receive safe metadata for their organization", async () => {
+  const admin = createEndpointAdminMock();
+  const handler = createByokSettingsHandler(() => admin);
+  const response = await handler(new Request(
+    `https://app.example.com/.netlify/functions/byok-settings?organization_id=${ORG_ID}`,
+    { headers: { Authorization: "Bearer member-token" } },
+  ));
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.has_byok_key, true);
+  assert.equal("byok_api_key" in body, false);
+  assert.doesNotMatch(JSON.stringify(body), new RegExp(TEST_KEY));
+  assert.equal(
+    admin.calls.some((call) => call.table === "organization_ai_secrets"),
+    true,
+  );
+});
+
+test("non-members are rejected before the endpoint reads secret metadata", async () => {
+  const admin = createEndpointAdminMock({ role: null });
+  const handler = createByokSettingsHandler(() => admin);
+  const response = await handler(new Request(
+    `https://app.example.com/.netlify/functions/byok-settings?organization_id=${ORG_ID}`,
+    { headers: { Authorization: "Bearer outsider-token" } },
+  ));
+
+  assert.equal(response.status, 403);
+  assert.equal(
+    admin.calls.some((call) => call.table === "organization_ai_secrets"),
+    false,
+  );
+});
+
+test("Manager cannot write BYOK settings or touch secret storage", async () => {
+  const admin = createEndpointAdminMock({ role: "Manager" });
+  const handler = createByokSettingsHandler(() => admin);
+  const response = await handler(new Request(
+    "https://app.example.com/.netlify/functions/byok-settings",
+    {
+      method: "PUT",
+      headers: {
+        Authorization: "Bearer manager-token",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        organization_id: ORG_ID,
+        use_byok: true,
+        byok_provider: "gemini",
+        byok_api_key: TEST_KEY,
+      }),
+    },
+  ));
+
+  assert.equal(response.status, 403);
+  assert.equal(
+    admin.calls.some((call) => call.table === "organization_ai_secrets"),
+    false,
+  );
+});
+
+test("Owner can set a credential without receiving it in the response", async () => {
+  const admin = createEndpointAdminMock({ role: "Owner", hasSecret: false });
+  const handler = createByokSettingsHandler(() => admin);
+  const response = await handler(new Request(
+    "https://app.example.com/.netlify/functions/byok-settings",
+    {
+      method: "PUT",
+      headers: {
+        Authorization: "Bearer owner-token",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        organization_id: ORG_ID,
+        use_byok: true,
+        byok_provider: "gemini",
+        byok_api_key: TEST_KEY,
+      }),
+    },
+  ));
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.use_byok, true);
+  assert.equal(body.has_byok_key, true);
+  assert.equal("byok_api_key" in body, false);
+  assert.doesNotMatch(JSON.stringify(body), new RegExp(TEST_KEY));
+  assert.equal(
+    admin.calls.some((call) =>
+      call.table === "organization_ai_secrets" && call.operation === "upsert"
+    ),
+    true,
+  );
+});
+
+test("Owner can disable BYOK and clear the server-only credential", async () => {
+  const admin = createEndpointAdminMock({ role: "Owner", hasSecret: true });
+  const handler = createByokSettingsHandler(() => admin);
+  const response = await handler(new Request(
+    "https://app.example.com/.netlify/functions/byok-settings",
+    {
+      method: "PUT",
+      headers: {
+        Authorization: "Bearer owner-token",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        organization_id: ORG_ID,
+        use_byok: false,
+        byok_provider: null,
+        byok_api_key: null,
+      }),
+    },
+  ));
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(body.use_byok, false);
+  assert.equal(body.has_byok_key, false);
+  assert.equal(
+    admin.calls.some((call) =>
+      call.table === "organization_ai_secrets" && call.operation === "delete"
+    ),
+    true,
+  );
+});
+
+test("BYOK endpoint has a strict per-IP rate limit", () => {
+  assert.equal(byokSettingsConfig.path, "/.netlify/functions/byok-settings");
+  assert.deepEqual(byokSettingsConfig.rateLimit.aggregateBy, ["ip", "domain"]);
+  assert.equal(byokSettingsConfig.rateLimit.windowLimit, 20);
+  assert.equal(byokSettingsConfig.rateLimit.windowSize, 60);
+});
+
+test("migration denies browser roles access to organization AI secrets", async () => {
+  const migration = await readFile(
+    new URL("../../supabase/migrations/020_expand_organization_ai_secrets.sql", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(migration, /ALTER TABLE organization_ai_secrets ENABLE ROW LEVEL SECURITY/i);
+  assert.match(
+    migration,
+    /REVOKE ALL ON TABLE organization_ai_secrets FROM PUBLIC, anon, authenticated/i,
+  );
+  assert.match(migration, /GRANT ALL ON TABLE organization_ai_secrets TO service_role/i);
+  assert.doesNotMatch(migration, /CREATE POLICY[\s\S]+ON organization_ai_secrets/i);
+  assert.match(migration, /INSERT INTO organization_ai_secrets[\s\S]+FROM organization_ai_settings/i);
+});
+
+test("browser data service uses the authenticated endpoint instead of raw table access", async () => {
+  const source = await readFile(
+    new URL("../../services/dbService.ts", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(source, /\.netlify\/functions\/byok-settings/);
+  assert.doesNotMatch(
+    source,
+    /\.from\(["']organization_ai_settings["']\)[\s\S]{0,200}\.select\([^)]*byok_api_key/,
+  );
+  assert.doesNotMatch(
+    source,
+    /\.from\(["']organization_ai_settings["']\)[\s\S]{0,300}\.upsert\([^)]*byok_api_key/,
+  );
+});


### PR DESCRIPTION
## Summary
- add a service-role-only organization_ai_secrets table and backfill existing BYOK credentials
- add an authenticated, tenant-aware BYOK settings endpoint that returns only safe metadata
- restrict BYOK writes to Owner/Admin roles and validate provider/key input
- route foreground and background AI calls through one server-only credential resolver
- stop browser code from reading or writing byok_api_key through Supabase

## Rollout order
1. Apply supabase/migrations/020_expand_organization_ai_secrets.sql before preview E2E testing. It is additive and keeps the legacy column for rollback compatibility.
2. Verify safe metadata, Owner/Admin set/rotate/clear, denied Manager/Consultant writes, tenant isolation, and AI flows in preview.
3. After production verification, open a separate contract PR to revoke/remove organization_ai_settings.byok_api_key.

## Security properties
- authenticated/anon browser roles have no grants and no RLS policy on organization_ai_secrets
- the endpoint checks the caller session and exact organization membership
- raw credentials are never returned in endpoint responses or application logs
- AI execution fails closed when BYOK is enabled but its credential is missing

## Verification
- npm run test:security (43/43)
- npx tsc --noEmit
- npm run build
- npx netlify functions:build --src netlify/functions --functions /private/tmp/aeternum-155-functions-final
- git diff --check

Part 1 of #155. This PR intentionally does not close the issue until the contract migration removes the browser-readable legacy column.