### PR TITLE
security: remove legacy browser-readable BYOK key

### DIFF
--- a/supabase/migrations/021_contract_legacy_byok_key.sql
+++ b/supabase/migrations/021_contract_legacy_byok_key.sql
@@ -1,0 +1,41 @@
+-- ============================================================
+-- 021 - Remove the browser-readable legacy BYOK key column
+-- ============================================================
+-- Production application code must use organization_ai_secrets before this
+-- migration is applied. Migration 020 created and initially backfilled it.
+
+BEGIN;
+
+-- Recover only missing secret rows. Never overwrite a credential that was
+-- rotated through the server-only endpoint after migration 020 was applied.
+INSERT INTO organization_ai_secrets (organization_id, byok_api_key)
+SELECT organization_id, byok_api_key
+FROM organization_ai_settings
+WHERE NULLIF(trim(byok_api_key), '') IS NOT NULL
+ON CONFLICT (organization_id) DO NOTHING;
+
+-- Fail before dropping the legacy column if an enabled BYOK configuration
+-- would be left without a server-only credential.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM organization_ai_settings settings
+    LEFT JOIN organization_ai_secrets secrets
+      ON secrets.organization_id = settings.organization_id
+    WHERE settings.use_byok = true
+      AND secrets.organization_id IS NULL
+  ) THEN
+    RAISE EXCEPTION
+      'Cannot remove legacy BYOK credentials while an enabled organization has no server-only secret';
+  END IF;
+END;
+$$;
+
+ALTER TABLE organization_ai_settings
+  DROP COLUMN IF EXISTS byok_api_key;
+
+COMMENT ON COLUMN organization_ai_settings.use_byok
+  IS 'When true the server uses the organization credential stored in organization_ai_secrets';
+
+COMMIT;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1007,3 +1007,43 @@ WHERE NULLIF(trim(byok_api_key), '') IS NOT NULL
 ON CONFLICT (organization_id) DO UPDATE
 SET byok_api_key = EXCLUDED.byok_api_key,
     updated_at = now();
+
+-- ============================================================
+-- Migration 021 - Remove the browser-readable legacy BYOK key
+-- ============================================================
+
+BEGIN;
+
+-- Recover only missing secret rows. Never overwrite a credential that was
+-- rotated through the server-only endpoint after migration 020 was applied.
+INSERT INTO organization_ai_secrets (organization_id, byok_api_key)
+SELECT organization_id, byok_api_key
+FROM organization_ai_settings
+WHERE NULLIF(trim(byok_api_key), '') IS NOT NULL
+ON CONFLICT (organization_id) DO NOTHING;
+
+-- Fail before dropping the legacy column if an enabled BYOK configuration
+-- would be left without a server-only credential.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+    FROM organization_ai_settings settings
+    LEFT JOIN organization_ai_secrets secrets
+      ON secrets.organization_id = settings.organization_id
+    WHERE settings.use_byok = true
+      AND secrets.organization_id IS NULL
+  ) THEN
+    RAISE EXCEPTION
+      'Cannot remove legacy BYOK credentials while an enabled organization has no server-only secret';
+  END IF;
+END;
+$$;
+
+ALTER TABLE organization_ai_settings
+  DROP COLUMN IF EXISTS byok_api_key;
+
+COMMENT ON COLUMN organization_ai_settings.use_byok
+  IS 'When true the server uses the organization credential stored in organization_ai_secrets';
+
+COMMIT;

--- a/tests/security/byok-secret-isolation.test.mjs
+++ b/tests/security/byok-secret-isolation.test.mjs
@@ -440,6 +440,27 @@ test("migration denies browser roles access to organization AI secrets", async (
   assert.match(migration, /INSERT INTO organization_ai_secrets[\s\S]+FROM organization_ai_settings/i);
 });
 
+test("contract migration preserves rotated secrets before dropping the legacy column", async () => {
+  const migration = await readFile(
+    new URL("../../supabase/migrations/021_contract_legacy_byok_key.sql", import.meta.url),
+    "utf8",
+  );
+  const backfillIndex = migration.indexOf("INSERT INTO organization_ai_secrets");
+  const guardIndex = migration.indexOf("IF EXISTS");
+  const dropIndex = migration.indexOf("DROP COLUMN IF EXISTS byok_api_key");
+
+  assert.ok(backfillIndex >= 0);
+  assert.ok(guardIndex > backfillIndex);
+  assert.ok(dropIndex > guardIndex);
+  assert.match(migration, /ON CONFLICT \(organization_id\) DO NOTHING/i);
+  assert.doesNotMatch(migration, /ON CONFLICT[\s\S]+DO UPDATE/i);
+  assert.match(
+    migration,
+    /WHERE settings\.use_byok = true[\s\S]+secrets\.organization_id IS NULL/i,
+  );
+  assert.match(migration, /BEGIN;[\s\S]+COMMIT;/i);
+});
+
 test("browser data service uses the authenticated endpoint instead of raw table access", async () => {
   const source = await readFile(
     new URL("../../services/dbService.ts", import.meta.url),


### PR DESCRIPTION
## Summary
- backfill only missing organization_ai_secrets rows without overwriting credentials rotated after migration 020
- abort if any organization has BYOK enabled without a server-only credential
- remove organization_ai_settings.byok_api_key inside one transaction
- update the canonical schema and add contract-order regression coverage

## Rollout order
1. Production commit f6c92f7 from #161 must remain published before applying migration 021.
2. Apply supabase/migrations/021_contract_legacy_byok_key.sql in Supabase.
3. Verify Settings > AI metadata, one production AI smoke test, and anonymous denial for organization_ai_secrets.
4. Merge this PR only after the database and production checks pass.

## Safety
- existing server-only credentials win on conflict, preserving keys rotated after the expand migration
- the migration fails before DROP if enabled BYOK settings have no matching secret
- BEGIN/COMMIT keeps backfill, guard, DROP, and comment update atomic
- application runtime has no remaining read or write of the legacy column

## Verification
- npm run test:security (44/44)
- npx tsc --noEmit
- npm run build
- git diff --check

Closes #155