### PR TITLE
[Security] Proxy Google Drive credentials server-side

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,12 +3,6 @@ VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your_anon_key_here
 VITE_APP_URL=http://localhost:8888
 
-# Google Drive integration (optional — enables Drive file picker in Evidence Vault)
-# Get these from Google Cloud Console → APIs & Services → Credentials
-# Authorized redirect URI to register: <app_url>/.netlify/functions/google-callback
-VITE_GOOGLE_CLIENT_ID=your_google_oauth_client_id.apps.googleusercontent.com
-VITE_GOOGLE_API_KEY=your_google_picker_api_key
-
 # Server-only (Netlify Functions / Netlify dashboard env vars)
 GEMINI_API_KEY=your_gemini_api_key_here
 SUPABASE_SERVICE_ROLE_KEY=your_service_role_key_here
@@ -19,7 +13,8 @@ INTERNAL_JOB_SECRET=replace_with_at_least_32_random_characters
 # Optional for non-Netlify/self-hosted deployments; HTTPS is required outside local development.
 # INTERNAL_FUNCTION_BASE_URL=https://app.example.com
 
-# Google Drive OAuth — server-only secrets (never use VITE_ prefix for these)
+# Google Drive OAuth - server-only secrets (never use VITE_ prefix for these)
+# Authorized redirect URI: <app_url>/.netlify/functions/google-callback
 GOOGLE_CLIENT_ID=your_google_oauth_client_id.apps.googleusercontent.com
 GOOGLE_CLIENT_SECRET=your_google_oauth_client_secret
 

--- a/components/EvidenceBadge.tsx
+++ b/components/EvidenceBadge.tsx
@@ -19,7 +19,7 @@
 
 import React, { useState, useEffect, useRef, useCallback, DragEvent } from 'react';
 import { createPortal } from 'react-dom';
-import { Paperclip, ExternalLink, Trash2, Plus, X, Link, Loader2, FileText, Image, File, AlertCircle, ChevronLeft, UploadCloud, Zap } from 'lucide-react';
+import { Paperclip, ExternalLink, Trash2, Plus, X, Link, Loader2, FileText, Image, File, AlertCircle, ChevronLeft, UploadCloud, Zap, Search, FolderOpen } from 'lucide-react';
 import {
   fetchEvidence,
   countEvidence,
@@ -29,12 +29,11 @@ import {
   getStorageQuota,
 } from '../services/evidenceService';
 import {
-  isGoogleDriveConfigured,
   getGoogleDriveStatus,
-  getGoogleDriveAccessToken,
   connectGoogleDrive,
-  openGooglePicker,
+  listGoogleDriveFiles,
   mimeToExtension,
+  type DriveFile,
 } from '../services/googleDriveService';
 import { supabase } from '../lib/supabaseClient';
 import { EvidenceAttachment, EvidenceLinkedToType, StorageType } from '../types';
@@ -53,7 +52,7 @@ interface Props {
 }
 
 type AddMethod = 'url' | 'google_drive' | 'onedrive';
-type ModalView = 'list' | 'add_method' | 'add_url' | 'add_drive' | 'add_upload';
+type ModalView = 'list' | 'add_method' | 'add_url' | 'browse_drive' | 'add_drive' | 'add_upload';
 
 const STORAGE_ICONS: Record<StorageType, React.ReactNode> = {
   google_drive:     <span className="text-blue-500">▲</span>,
@@ -147,8 +146,9 @@ const EvidenceModal: React.FC<ModalProps> = ({
   const [error, setError]             = useState<string | null>(null);
 
   // Google Drive state
-  const [driveConfigured]             = useState(isGoogleDriveConfigured);
+  const [driveConfigured, setDriveConfigured] = useState(false);
   const [driveConnected, setDriveConnected] = useState(false);
+  const [driveCanManage, setDriveCanManage] = useState(false);
   const [driveCheckDone, setDriveCheckDone] = useState(false);
 
   // Storage quota (fetched lazily when upload view is first opened)
@@ -173,16 +173,19 @@ const EvidenceModal: React.FC<ModalProps> = ({
 
   // ── Check Google Drive connection status ─────────────────────────────────
   useEffect(() => {
-    if (!driveConfigured) { setDriveCheckDone(true); return; }
     supabase.auth.getSession().then(({ data }) => {
       const token = data.session?.access_token;
       if (!token) { setDriveCheckDone(true); return; }
       getGoogleDriveStatus(orgId, token)
-        .then(setDriveConnected)
+        .then(status => {
+          setDriveConfigured(status.configured);
+          setDriveConnected(status.connected);
+          setDriveCanManage(status.canManage);
+        })
         .catch(() => {})
         .finally(() => setDriveCheckDone(true));
     });
-  }, [orgId, driveConfigured]);
+  }, [orgId]);
 
   // ── Delete an item ────────────────────────────────────────────────────────
   const handleDelete = async (item: EvidenceAttachment) => {
@@ -200,29 +203,22 @@ const EvidenceModal: React.FC<ModalProps> = ({
     }
   };
 
-  // ── Google Drive picker ───────────────────────────────────────────────────
-  const handlePickFromDrive = async () => {
+  const handleConnectDrive = async () => {
     setBusy(true);
     setError(null);
     try {
       const { data } = await supabase.auth.getSession();
-      const supaToken = data.session?.access_token ?? '';
-      const driveToken = await getGoogleDriveAccessToken(orgId, supaToken);
-      const file = await openGooglePicker(driveToken);
-      if (!file) { setBusy(false); return; }
-      // Pre-fill and show the link form so user can add notes
-      setDriveFile(file);
-      setView('add_drive');
+      const token = data.session?.access_token;
+      if (!token) throw new Error('Please sign in again.');
+      await connectGoogleDrive(orgId, token);
     } catch (e: any) {
-      setError(e?.message ?? 'Could not open Google Drive picker.');
+      setError(e?.message ?? 'Could not connect Google Drive.');
     } finally {
       setBusy(false);
     }
   };
 
-  const [driveFile, setDriveFile] = useState<{
-    id: string; name: string; url: string; mimeType: string; sizeBytes: number | null;
-  } | null>(null);
+  const [driveFile, setDriveFile] = useState<DriveFile | null>(null);
 
   // ── Load storage quota (lazy, on upload view open) ────────────────────────
   const loadQuota = useCallback(async () => {
@@ -329,27 +325,31 @@ const EvidenceModal: React.FC<ModalProps> = ({
                 icon="📁"
                 title="Link from Google Drive"
                 subtitle={
-                  !driveConfigured
-                    ? 'Google Drive not configured on this server'
-                    : !driveCheckDone
+                  !driveCheckDone
                     ? 'Checking connection…'
+                    : !driveConfigured
+                    ? 'Google Drive not configured on this server'
                     : driveConnected
-                    ? 'Your Drive is connected'
-                    : 'Connect Drive first'
+                    ? 'Browse files through the secure Drive connection'
+                    : driveCanManage
+                    ? 'Connect Drive to select a file'
+                    : 'Ask an Owner or Admin to connect Drive'
                 }
                 disabled={!driveConfigured || !driveConnected}
-                badge={!driveConfigured || !driveConnected ? (
-                  driveConfigured && !driveConnected ? (
-                    <button
-                      className="text-xs text-blue-500 hover:underline"
-                      onClick={() => connectGoogleDrive(orgId, currentUserId)}
-                    >
-                      Connect
-                    </button>
-                  ) : undefined
-                ) : undefined}
-                onClick={handlePickFromDrive}
+                onClick={() => setView('browse_drive')}
               />
+
+              {driveCheckDone && driveConfigured && !driveConnected && driveCanManage && (
+                <button
+                  type="button"
+                  onClick={handleConnectDrive}
+                  disabled={busy}
+                  className="w-full flex items-center justify-center gap-2 py-2 rounded-lg border border-blue-300 dark:border-blue-700 text-sm font-medium text-blue-600 dark:text-blue-300 hover:bg-blue-50 dark:hover:bg-blue-900/20 disabled:opacity-50"
+                >
+                  {busy && <Loader2 className="w-4 h-4 animate-spin" />}
+                  Connect Google Drive
+                </button>
+              )}
 
               <MethodCard
                 icon="🔗"
@@ -376,6 +376,18 @@ const EvidenceModal: React.FC<ModalProps> = ({
               orgId={orgId}
               userId={currentUserId}
               onSaved={() => { back(); loadItems(); }}
+              onError={setError}
+            />
+          )}
+
+          {/* GOOGLE DRIVE FILE BROWSER */}
+          {view === 'browse_drive' && (
+            <DriveFilePicker
+              orgId={orgId}
+              onSelect={file => {
+                setDriveFile(file);
+                setView('add_drive');
+              }}
               onError={setError}
             />
           )}
@@ -630,11 +642,128 @@ const URLForm: React.FC<{
 };
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Google Drive Confirm Form (pre-fills from picker selection)
+// Google Drive file browser
+// ─────────────────────────────────────────────────────────────────────────────
+
+const DriveFilePicker: React.FC<{
+  orgId: string;
+  onSelect: (file: DriveFile) => void;
+  onError: (msg: string) => void;
+}> = ({ orgId, onSelect, onError }) => {
+  const [files, setFiles] = useState<DriveFile[]>([]);
+  const [search, setSearch] = useState('');
+  const [activeSearch, setActiveSearch] = useState('');
+  const [nextPageToken, setNextPageToken] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  const loadPage = useCallback(async (
+    pageToken: string | null,
+    replace: boolean,
+    query: string,
+  ) => {
+    setLoading(true);
+    try {
+      const { data } = await supabase.auth.getSession();
+      const token = data.session?.access_token;
+      if (!token) throw new Error('Please sign in again.');
+      const page = await listGoogleDriveFiles(orgId, token, {
+        search: query || undefined,
+        pageToken,
+      });
+      setFiles(current => replace ? page.files : [...current, ...page.files]);
+      setNextPageToken(page.nextPageToken);
+    } catch (e: any) {
+      onError(e?.message ?? 'Could not load Google Drive files.');
+    } finally {
+      setLoading(false);
+    }
+  }, [orgId, onError]);
+
+  useEffect(() => {
+    void loadPage(null, true, '');
+  }, [loadPage]);
+
+  const submitSearch = (event: React.FormEvent) => {
+    event.preventDefault();
+    const query = search.trim();
+    setActiveSearch(query);
+    void loadPage(null, true, query);
+  };
+
+  return (
+    <div className="space-y-3">
+      <form onSubmit={submitSearch} className="flex gap-2">
+        <div className="relative flex-1">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400" />
+          <input
+            type="search"
+            value={search}
+            onChange={event => setSearch(event.target.value)}
+            maxLength={100}
+            placeholder="Search Drive files"
+            className="w-full pl-9 pr-3 py-2 rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-800 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+        <button
+          type="submit"
+          disabled={loading}
+          title="Search Google Drive"
+          className="w-10 h-10 flex items-center justify-center rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          {loading ? <Loader2 className="w-4 h-4 animate-spin" /> : <Search className="w-4 h-4" />}
+        </button>
+      </form>
+
+      {!loading && files.length === 0 ? (
+        <div className="py-8 text-center text-sm text-slate-500 dark:text-slate-400">
+          <FolderOpen className="w-9 h-9 mx-auto mb-2 text-slate-300 dark:text-slate-600" />
+          {activeSearch ? 'No matching Drive files found.' : 'No Drive files are available.'}
+        </div>
+      ) : (
+        <div className="divide-y divide-slate-200 dark:divide-slate-700 border border-slate-200 dark:border-slate-700 rounded-lg overflow-hidden">
+          {files.map(file => (
+            <button
+              type="button"
+              key={file.id}
+              onClick={() => onSelect(file)}
+              className="w-full min-h-14 flex items-center gap-3 px-3 py-2 text-left bg-white dark:bg-slate-800 hover:bg-blue-50 dark:hover:bg-blue-900/20"
+            >
+              {fileIcon(mimeToExtension(file.mimeType))}
+              <span className="flex-1 min-w-0">
+                <span className="block text-sm font-medium text-slate-800 dark:text-white truncate">
+                  {file.name}
+                </span>
+                <span className="block text-xs text-slate-400 truncate">
+                  {mimeToExtension(file.mimeType).toUpperCase() || 'FILE'}
+                  {file.modifiedTime ? ` · ${fmtDate(file.modifiedTime)}` : ''}
+                </span>
+              </span>
+              <ChevronLeft className="w-4 h-4 rotate-180 text-slate-400" />
+            </button>
+          ))}
+        </div>
+      )}
+
+      {nextPageToken && (
+        <button
+          type="button"
+          onClick={() => void loadPage(nextPageToken, false, activeSearch)}
+          disabled={loading}
+          className="w-full py-2 rounded-lg border border-slate-300 dark:border-slate-600 text-sm font-medium text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700 disabled:opacity-50"
+        >
+          {loading ? 'Loading…' : 'Load more'}
+        </button>
+      )}
+    </div>
+  );
+};
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Google Drive Confirm Form (pre-fills from server-proxied selection)
 // ─────────────────────────────────────────────────────────────────────────────
 
 const DriveConfirmForm: React.FC<{
-  driveFile:    { id: string; name: string; url: string; mimeType: string; sizeBytes: number | null };
+  driveFile:    DriveFile;
   linkedToType: EvidenceLinkedToType;
   linkedToId:   string;
   orgId:        string;

--- a/components/EvidenceBadge.tsx
+++ b/components/EvidenceBadge.tsx
@@ -19,7 +19,7 @@
 
 import React, { useState, useEffect, useRef, useCallback, DragEvent } from 'react';
 import { createPortal } from 'react-dom';
-import { Paperclip, ExternalLink, Trash2, Plus, X, Link, Loader2, FileText, Image, File, AlertCircle, ChevronLeft, UploadCloud, Zap, Search, FolderOpen } from 'lucide-react';
+import { Paperclip, ExternalLink, Trash2, Plus, X, Link, Loader2, FileText, Image, File, AlertCircle, ChevronLeft, UploadCloud, Zap, Search, FolderOpen, RefreshCw } from 'lucide-react';
 import {
   fetchEvidence,
   countEvidence,
@@ -146,10 +146,11 @@ const EvidenceModal: React.FC<ModalProps> = ({
   const [error, setError]             = useState<string | null>(null);
 
   // Google Drive state
-  const [driveConfigured, setDriveConfigured] = useState(false);
-  const [driveConnected, setDriveConnected] = useState(false);
+  const [driveConfigured, setDriveConfigured] = useState<boolean | null>(null);
+  const [driveConnected, setDriveConnected] = useState<boolean | null>(null);
   const [driveCanManage, setDriveCanManage] = useState(false);
   const [driveCheckDone, setDriveCheckDone] = useState(false);
+  const [driveStatusError, setDriveStatusError] = useState<string | null>(null);
 
   // Storage quota (fetched lazily when upload view is first opened)
   const [quota, setQuota]             = useState<{ used_mb: number; total_mb: number; available_mb: number } | null>(null);
@@ -172,20 +173,30 @@ const EvidenceModal: React.FC<ModalProps> = ({
   useEffect(() => { loadItems(); }, [loadItems]);
 
   // ── Check Google Drive connection status ─────────────────────────────────
-  useEffect(() => {
-    supabase.auth.getSession().then(({ data }) => {
+  const loadDriveStatus = useCallback(async () => {
+    setDriveCheckDone(false);
+    setDriveStatusError(null);
+    try {
+      const { data } = await supabase.auth.getSession();
       const token = data.session?.access_token;
-      if (!token) { setDriveCheckDone(true); return; }
-      getGoogleDriveStatus(orgId, token)
-        .then(status => {
-          setDriveConfigured(status.configured);
-          setDriveConnected(status.connected);
-          setDriveCanManage(status.canManage);
-        })
-        .catch(() => {})
-        .finally(() => setDriveCheckDone(true));
-    });
+      if (!token) throw new Error('Please sign in again.');
+      const status = await getGoogleDriveStatus(orgId, token);
+      setDriveConfigured(status.configured);
+      setDriveConnected(status.connected);
+      setDriveCanManage(status.canManage);
+    } catch (e: any) {
+      setDriveConfigured(null);
+      setDriveConnected(null);
+      setDriveCanManage(false);
+      setDriveStatusError(e?.message ?? 'Could not check Google Drive connection.');
+    } finally {
+      setDriveCheckDone(true);
+    }
   }, [orgId]);
+
+  useEffect(() => {
+    void loadDriveStatus();
+  }, [loadDriveStatus]);
 
   // ── Delete an item ────────────────────────────────────────────────────────
   const handleDelete = async (item: EvidenceAttachment) => {
@@ -327,6 +338,8 @@ const EvidenceModal: React.FC<ModalProps> = ({
                 subtitle={
                   !driveCheckDone
                     ? 'Checking connection…'
+                    : driveStatusError
+                    ? 'Could not check the Google Drive connection'
                     : !driveConfigured
                     ? 'Google Drive not configured on this server'
                     : driveConnected
@@ -335,9 +348,24 @@ const EvidenceModal: React.FC<ModalProps> = ({
                     ? 'Connect Drive to select a file'
                     : 'Ask an Owner or Admin to connect Drive'
                 }
-                disabled={!driveConfigured || !driveConnected}
+                disabled={Boolean(driveStatusError) || driveConfigured !== true || driveConnected !== true}
                 onClick={() => setView('browse_drive')}
               />
+
+              {driveCheckDone && driveStatusError && (
+                <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800 dark:border-amber-800 dark:bg-amber-900/20 dark:text-amber-200">
+                  <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+                  <span className="flex-1">{driveStatusError}</span>
+                  <button
+                    type="button"
+                    onClick={() => void loadDriveStatus()}
+                    title="Retry Google Drive status"
+                    className="flex h-7 w-7 flex-shrink-0 items-center justify-center rounded text-amber-700 hover:bg-amber-100 dark:text-amber-200 dark:hover:bg-amber-900/40"
+                  >
+                    <RefreshCw className="h-4 w-4" />
+                  </button>
+                </div>
+              )}
 
               {driveCheckDone && driveConfigured && !driveConnected && driveCanManage && (
                 <button

--- a/components/SettingsDashboard.tsx
+++ b/components/SettingsDashboard.tsx
@@ -3,6 +3,7 @@ import {
   Users, Sparkles, TrendingUp, Clock, Loader2, AlertCircle,
   UserPlus, CheckCircle2, Copy, ShieldOff, RefreshCw, XCircle,
   Save, Zap, Brain, Key, ShieldCheck, Eye, EyeOff, Hash, DollarSign, KeyRound,
+  Plug, HardDrive, Link2, Unplug,
 } from 'lucide-react';
 import { useAuth } from '../hooks/useAuth';
 import {
@@ -17,6 +18,12 @@ import {
 } from '../services/dbService';
 import { supabase } from '../lib/supabaseClient';
 import { logError } from '../services/errorLogService';
+import {
+  connectGoogleDrive,
+  disconnectGoogleDrive,
+  getGoogleDriveStatus,
+  type GoogleDriveStatus,
+} from '../services/googleDriveService';
 import type { OrgMember, OrgRole, OrgInvite } from '../types';
 
 // ─────────────────────────────────────────────────────────────────
@@ -32,7 +39,7 @@ interface Props {
   initialTab?: SettingsTab;
 }
 
-type SettingsTab = 'team' | 'ai' | 'usage' | 'activity';
+type SettingsTab = 'team' | 'ai' | 'integrations' | 'usage' | 'activity';
 
 // ─────────────────────────────────────────────────────────────────
 // Constants
@@ -139,6 +146,7 @@ const SettingsDashboard: React.FC<Props> = ({
   const TAB_DEFS: { id: SettingsTab; label: string; icon: React.ReactNode }[] = [
     { id: 'team',     label: 'Team',          icon: <Users className="w-4 h-4 flex-shrink-0" /> },
     { id: 'ai',       label: 'AI',            icon: <Sparkles className="w-4 h-4 flex-shrink-0" /> },
+    { id: 'integrations', label: 'Integrations', icon: <Plug className="w-4 h-4 flex-shrink-0" /> },
     { id: 'usage',    label: 'Usage',         icon: <TrendingUp className="w-4 h-4 flex-shrink-0" /> },
     { id: 'activity', label: 'Activity',      icon: <Clock className="w-4 h-4 flex-shrink-0" /> },
   ];
@@ -148,7 +156,7 @@ const SettingsDashboard: React.FC<Props> = ({
       <div className="mb-8">
         <h2 className="text-2xl font-bold text-slate-800 dark:text-white">Settings</h2>
         <p className="text-slate-500 dark:text-slate-400 mt-1">
-          Manage your workspace — team members, AI configuration, and usage.
+          Manage your workspace — team members, AI, integrations, and usage.
         </p>
       </div>
 
@@ -187,6 +195,12 @@ const SettingsDashboard: React.FC<Props> = ({
               settings={aiSettings}
               isLoading={aiLoading}
               onSettingsChanged={(s) => setAiSettings(s)}
+            />
+          )}
+          {activeTab === 'integrations' && (
+            <IntegrationsSection
+              organizationId={organizationId}
+              currentUserRole={currentUserRole}
             />
           )}
           {activeTab === 'usage' && (
@@ -610,6 +624,167 @@ const TeamSection: React.FC<TeamSectionProps> = ({
         )}
       </div>
     </div>
+  );
+};
+
+// ─────────────────────────────────────────────────────────────────
+// Integrations section
+// ─────────────────────────────────────────────────────────────────
+
+interface IntegrationsSectionProps {
+  organizationId: string;
+  currentUserRole: OrgRole | null;
+}
+
+const IntegrationsSection: React.FC<IntegrationsSectionProps> = ({
+  organizationId,
+  currentUserRole,
+}) => {
+  const roleCanManage = currentUserRole === 'Owner' || currentUserRole === 'Admin';
+  const [driveStatus, setDriveStatus] = useState<GoogleDriveStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadDriveStatus = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      const token = session?.access_token;
+      if (!token) throw new Error('Please sign in again.');
+      setDriveStatus(await getGoogleDriveStatus(organizationId, token));
+    } catch (e: any) {
+      setDriveStatus(null);
+      setError(e?.message ?? 'Failed to load Google Drive status.');
+    } finally {
+      setLoading(false);
+    }
+  }, [organizationId]);
+
+  useEffect(() => {
+    void loadDriveStatus();
+  }, [loadDriveStatus]);
+
+  const handleConnect = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      const token = session?.access_token;
+      if (!token) throw new Error('Please sign in again.');
+      await connectGoogleDrive(organizationId, token);
+    } catch (e: any) {
+      setError(e?.message ?? 'Failed to connect Google Drive.');
+      setBusy(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    if (!window.confirm('Disconnect Google Drive from this workspace?')) return;
+    setBusy(true);
+    setError(null);
+    try {
+      const { data: { session } } = await supabase.auth.getSession();
+      const token = session?.access_token;
+      if (!token) throw new Error('Please sign in again.');
+      await disconnectGoogleDrive(organizationId, token);
+      await loadDriveStatus();
+    } catch (e: any) {
+      setError(e?.message ?? 'Failed to disconnect Google Drive.');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const canManage = roleCanManage && driveStatus?.canManage === true;
+  const isConnected = driveStatus?.connected === true;
+  const isConfigured = driveStatus?.configured === true;
+
+  return (
+    <section>
+      <header className="mb-5 flex items-start justify-between gap-3">
+        <div>
+          <h3 className="font-bold text-slate-800 dark:text-white flex items-center gap-2">
+            <Plug className="w-4 h-4 text-esg-600" /> Workspace integrations
+          </h3>
+          <p className="text-sm text-slate-500 dark:text-slate-400">
+            Manage external services connected to this workspace.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void loadDriveStatus()}
+          disabled={loading || busy}
+          title="Refresh integration status"
+          className="w-9 h-9 flex items-center justify-center rounded-lg border border-slate-200 dark:border-slate-700 text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 disabled:opacity-50"
+        >
+          <RefreshCw className={`w-4 h-4 ${loading ? 'animate-spin' : ''}`} />
+        </button>
+      </header>
+
+      {error && <ErrorBanner message={error} />}
+
+      <div className="border-y border-slate-200 dark:border-slate-700 py-5 flex flex-col sm:flex-row sm:items-center gap-4">
+        <div className="w-10 h-10 flex items-center justify-center rounded-lg bg-blue-50 dark:bg-blue-900/30 text-blue-600 dark:text-blue-300 flex-shrink-0">
+          <HardDrive className="w-5 h-5" />
+        </div>
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <h4 className="font-semibold text-slate-800 dark:text-white">Google Drive</h4>
+            {!loading && driveStatus && (
+              <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium ${isConnected
+                ? 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-300'
+                : 'bg-slate-100 text-slate-600 dark:bg-slate-700 dark:text-slate-300'}`}>
+                {isConnected
+                  ? <><CheckCircle2 className="w-3 h-3" /> Connected</>
+                  : <><XCircle className="w-3 h-3" /> Not connected</>}
+              </span>
+            )}
+          </div>
+          <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+            Select Drive files as supporting evidence without exposing OAuth credentials to the browser.
+          </p>
+          {!loading && driveStatus && !isConfigured && (
+            <p className="text-xs text-amber-600 dark:text-amber-400 mt-2 flex items-center gap-1">
+              <AlertCircle className="w-3.5 h-3.5" /> Google Drive is not configured on this deployment.
+            </p>
+          )}
+          {!loading && driveStatus && !roleCanManage && (
+            <p className="text-xs text-slate-400 mt-2">Only Owners and Admins can manage this connection.</p>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2 sm:flex-shrink-0">
+          {loading ? (
+            <span className="inline-flex items-center gap-2 text-sm text-slate-500 dark:text-slate-400">
+              <Loader2 className="w-4 h-4 animate-spin" /> Checking
+            </span>
+          ) : canManage && isConnected ? (
+            <button
+              type="button"
+              onClick={handleDisconnect}
+              disabled={busy}
+              className="inline-flex items-center justify-center gap-2 px-3 py-2 rounded-lg border border-red-200 dark:border-red-800 text-sm font-medium text-red-600 dark:text-red-300 hover:bg-red-50 dark:hover:bg-red-900/20 disabled:opacity-50"
+            >
+              {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Unplug className="w-4 h-4" />}
+              Disconnect
+            </button>
+          ) : canManage && isConfigured ? (
+            <button
+              type="button"
+              onClick={handleConnect}
+              disabled={busy}
+              className="inline-flex items-center justify-center gap-2 px-3 py-2 rounded-lg bg-esg-600 text-white text-sm font-medium hover:bg-esg-700 disabled:opacity-50"
+            >
+              {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : <Link2 className="w-4 h-4" />}
+              Connect
+            </button>
+          ) : null}
+        </div>
+      </div>
+    </section>
   );
 };
 

--- a/netlify/functions/_shared/googleDriveSecurity.js
+++ b/netlify/functions/_shared/googleDriveSecurity.js
@@ -1,0 +1,113 @@
+// @ts-check
+
+import { createHash, randomBytes } from "node:crypto";
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const OAUTH_STATE_PATTERN = /^[A-Za-z0-9_-]{43}$/;
+const DRIVE_FILE_ID_PATTERN = /^[A-Za-z0-9_-]{1,256}$/;
+const GOOGLE_FOLDER_MIME_TYPE = "application/vnd.google-apps.folder";
+
+export function isValidGoogleDriveOrganizationId(value) {
+  return typeof value === "string" && UUID_PATTERN.test(value);
+}
+
+export function canManageGoogleDrive(role) {
+  return role === "Owner" || role === "Admin";
+}
+
+export function createGoogleOAuthState() {
+  return randomBytes(32).toString("base64url");
+}
+
+export function isValidGoogleOAuthState(value) {
+  return typeof value === "string" && OAUTH_STATE_PATTERN.test(value);
+}
+
+export function hashGoogleOAuthState(value) {
+  if (!isValidGoogleOAuthState(value)) {
+    throw Object.assign(new Error("Invalid OAuth state."), { status: 400 });
+  }
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function normalizeOptionalText(value, maxLength, fieldName) {
+  if (value == null || value === "") return null;
+  if (typeof value !== "string") {
+    throw Object.assign(new Error(`${fieldName} must be a string.`), { status: 400 });
+  }
+  const normalized = value.trim();
+  if (normalized.length > maxLength || /[\u0000-\u001f\u007f]/.test(normalized)) {
+    throw Object.assign(new Error(`${fieldName} is invalid.`), { status: 400 });
+  }
+  return normalized || null;
+}
+
+export function normalizeGoogleDriveListParams(search, pageToken) {
+  return {
+    search: normalizeOptionalText(search, 100, "search"),
+    pageToken: normalizeOptionalText(pageToken, 2048, "page_token"),
+  };
+}
+
+function escapeDriveQueryValue(value) {
+  return value.replace(/\\/g, "\\\\").replace(/'/g, "\\'");
+}
+
+export function buildGoogleDriveFilesUrl({ search, pageToken }) {
+  const url = new URL("https://www.googleapis.com/drive/v3/files");
+  const query = [
+    "trashed = false",
+    `mimeType != '${GOOGLE_FOLDER_MIME_TYPE}'`,
+  ];
+  if (search) query.push(`name contains '${escapeDriveQueryValue(search)}'`);
+
+  url.searchParams.set("q", query.join(" and "));
+  url.searchParams.set("pageSize", "30");
+  url.searchParams.set("orderBy", "modifiedTime desc");
+  url.searchParams.set("spaces", "drive");
+  url.searchParams.set("fields", "nextPageToken,files(id,name,mimeType,size,modifiedTime)");
+  url.searchParams.set("supportsAllDrives", "true");
+  url.searchParams.set("includeItemsFromAllDrives", "true");
+  if (pageToken) url.searchParams.set("pageToken", pageToken);
+  return url;
+}
+
+function safeSize(value) {
+  if (typeof value !== "string" || !/^\d+$/.test(value)) return null;
+  const size = Number(value);
+  return Number.isSafeInteger(size) ? size : null;
+}
+
+export function toSafeGoogleDriveFile(file) {
+  if (!DRIVE_FILE_ID_PATTERN.test(file?.id ?? "")) return null;
+  const name = typeof file?.name === "string" ? file.name.slice(0, 512) : "Untitled file";
+  const mimeType = typeof file?.mimeType === "string"
+    ? file.mimeType.slice(0, 255)
+    : "application/octet-stream";
+  const modifiedTime = typeof file?.modifiedTime === "string"
+    && !Number.isNaN(Date.parse(file.modifiedTime))
+    ? file.modifiedTime
+    : null;
+
+  return {
+    id: file.id,
+    name,
+    url: `https://drive.google.com/open?id=${encodeURIComponent(file.id)}`,
+    mimeType,
+    sizeBytes: safeSize(file.size),
+    modifiedTime,
+  };
+}
+
+export function toSafeGoogleDriveList(payload) {
+  const files = Array.isArray(payload?.files)
+    ? payload.files.map(toSafeGoogleDriveFile).filter(Boolean)
+    : [];
+  const nextPageToken = normalizeOptionalText(
+    payload?.nextPageToken,
+    2048,
+    "next_page_token",
+  );
+  return { files, next_page_token: nextPageToken };
+}

--- a/netlify/functions/admin.ts
+++ b/netlify/functions/admin.ts
@@ -529,7 +529,6 @@ const ORG_SCOPED_TABLES = [
   'organization_members',
   'organization_invites',
   'organization_ai_settings',
-  'organization_integrations',
   'ai_usage_log',
 ] as const;
 

--- a/netlify/functions/google-callback.ts
+++ b/netlify/functions/google-callback.ts
@@ -6,19 +6,18 @@
  * ┌──────────────────────────────────────────────────────────────────────┐
  * │  Google Cloud Console setup required:                                │
  * │  1. Create a project at https://console.cloud.google.com             │
- * │  2. Enable "Google Drive API" and "Google Picker API"                │
+ * │  2. Enable "Google Drive API"                                         │
  * │  3. Create OAuth 2.0 Client ID (Web Application)                     │
  * │  4. Add Authorized Redirect URI:                                      │
  * │       https://<your-netlify-site>/.netlify/functions/google-callback  │
  * │       http://localhost:8888/.netlify/functions/google-callback (dev)  │
- * │  5. Create an API Key (restrict to Picker API + your domain)         │
  * └──────────────────────────────────────────────────────────────────────┘
  *
  * Routes (all at /.netlify/functions/google-callback):
  *
  *   GET ?code=…&state=…        OAuth callback from Google (unauthenticated)
  *   GET ?action=status&…       Is Drive connected for this org?  (authed)
- *   GET ?action=token&…        Return current valid access token (authed)
+ *   GET ?action=token&…        Retired route; always returns 404
  *   DELETE body{organization_id} Disconnect (remove tokens)       (authed)
  *
  * Environment variables required:
@@ -30,6 +29,11 @@
  */
 
 import { createClient } from '@supabase/supabase-js';
+import {
+  canManageGoogleDrive,
+  hashGoogleOAuthState,
+  isValidGoogleOAuthState,
+} from './_shared/googleDriveSecurity.js';
 
 const SUPABASE_URL  = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL || '';
 const SERVICE_KEY   = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
@@ -39,7 +43,6 @@ const APP_URL       = process.env.VITE_APP_URL || 'http://localhost:8888';
 
 const REDIRECT_URI  = `${APP_URL}/.netlify/functions/google-callback`;
 const TOKEN_URL     = 'https://oauth2.googleapis.com/token';
-const SCOPE         = 'https://www.googleapis.com/auth/drive.readonly';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Response helpers
@@ -47,7 +50,11 @@ const SCOPE         = 'https://www.googleapis.com/auth/drive.readonly';
 
 const json = (code: number, body: unknown) => ({
   statusCode: code,
-  headers: { 'Content-Type': 'application/json' },
+  headers: {
+    'Content-Type': 'application/json',
+    'Cache-Control': 'no-store',
+    'X-Content-Type-Options': 'nosniff',
+  },
   body: JSON.stringify(body),
 });
 
@@ -79,7 +86,15 @@ export const handler = async (event: any) => {
 
   // ── Error redirect from Google (GET ?error=…) ────────────────────────────
   if (event.httpMethod === 'GET' && qs.error) {
-    const msg = encodeURIComponent(qs.error_description ?? qs.error ?? 'Google OAuth error');
+    const state = qs.state ?? '';
+    if (isValidGoogleOAuthState(state)) {
+      await admin
+        .from('organization_oauth_states')
+        .delete()
+        .eq('state_hash', hashGoogleOAuthState(state))
+        .eq('integration_type', 'google_drive');
+    }
+    const msg = encodeURIComponent('Google Drive authorization was not completed.');
     return redirect(`${APP_URL}?google_drive=error&message=${msg}`);
   }
 
@@ -105,23 +120,12 @@ export const handler = async (event: any) => {
     return json(200, { connected: !!integration });
   }
 
-  // GET ?action=token — returns a valid (auto-refreshed) access token
+  // GET ?action=token — retired; browser clients must never receive OAuth tokens
   if (event.httpMethod === 'GET' && qs.action === 'token') {
     const orgId = qs.organization_id;
     if (!orgId) return json(400, { error: 'Missing organization_id.' });
     if (!await isMember(admin, orgId, user.id)) return json(403, { error: 'Access denied.' });
-
-    if (!CLIENT_ID || !CLIENT_SECRET) {
-      return json(503, { error: 'Google Drive integration is not configured on this server.' });
-    }
-
-    const integration = await getIntegration(admin, orgId, 'google_drive');
-    if (!integration) {
-      return json(404, { error: 'Google Drive is not connected for this organization.' });
-    }
-
-    const token = await getValidToken(admin, integration);
-    return json(200, { access_token: token });
+    return json(404, { error: 'This Google Drive operation is no longer available.' });
   }
 
   // DELETE — disconnect Google Drive
@@ -157,38 +161,64 @@ async function handleOAuthCallback(admin: any, qs: Record<string, string | undef
   const code = qs.code!;
   const state = qs.state ?? '';
 
-  // State encodes "orgId:userId" as base64
-  let orgId: string;
-  let userId: string;
-  try {
-    const decoded = Buffer.from(state, 'base64').toString('utf-8');
-    [orgId, userId] = decoded.split(':');
-    if (!orgId || !userId) throw new Error('bad format');
-  } catch {
-    return redirect(`${APP_URL}?google_drive=error&message=${encodeURIComponent('Invalid OAuth state parameter.')}`);
+  if (!code || code.length > 4096 || /[\u0000-\u001f\u007f]/.test(code)) {
+    return redirect(`${APP_URL}?google_drive=error&message=${encodeURIComponent('Invalid Google Drive callback.')}`);
   }
 
   if (!CLIENT_ID || !CLIENT_SECRET) {
     return redirect(`${APP_URL}?google_drive=error&message=${encodeURIComponent('Google OAuth is not configured on this server.')}`);
   }
 
-  // Verify the user is actually a member of that org
-  if (!await isMember(admin, orgId, userId)) {
+  if (!isValidGoogleOAuthState(state)) {
+    return redirect(`${APP_URL}?google_drive=error&message=${encodeURIComponent('Google Drive authorization expired.')}`);
+  }
+
+  // Consume the hashed state atomically. Replays, expired states and legacy
+  // base64("orgId:userId") values all fail without exposing tenant identifiers.
+  const { data: oauthState, error: stateError } = await admin
+    .from('organization_oauth_states')
+    .delete()
+    .eq('state_hash', hashGoogleOAuthState(state))
+    .eq('integration_type', 'google_drive')
+    .gt('expires_at', new Date().toISOString())
+    .select('organization_id, user_id')
+    .maybeSingle();
+  if (stateError || !oauthState) {
+    console.error('[google-drive] OAuth state verification failed');
+    return redirect(`${APP_URL}?google_drive=error&message=${encodeURIComponent('Google Drive authorization expired.')}`);
+  }
+
+  const orgId = oauthState.organization_id as string;
+  const userId = oauthState.user_id as string;
+  const { data: membership, error: membershipError } = await admin
+    .from('organization_members')
+    .select('role')
+    .eq('organization_id', orgId)
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (membershipError || !membership || !canManageGoogleDrive(membership.role)) {
     return redirect(`${APP_URL}?google_drive=error&message=${encodeURIComponent('Access denied.')}`);
   }
 
-  // Exchange code for tokens
   let tokens: GoogleTokenResponse;
   try {
     tokens = await exchangeCode(code);
   } catch (e: any) {
-    console.error('Google token exchange failed:', e);
+    const providerStatus = typeof e?.providerStatus === 'number'
+      ? ` provider_status=${e.providerStatus}`
+      : '';
+    console.error(`[google-drive] token exchange failed${providerStatus}`);
     return redirect(`${APP_URL}?google_drive=error&message=${encodeURIComponent('Failed to obtain Google tokens.')}`);
   }
 
+  const existing = await getIntegration(admin, orgId, 'google_drive');
+  const refreshToken = tokens.refresh_token ?? existing?.refresh_token ?? null;
+  if (!refreshToken) {
+    console.error('[google-drive] OAuth response did not include a refresh token');
+    return redirect(`${APP_URL}?google_drive=error&message=${encodeURIComponent('Google Drive connection failed.')}`);
+  }
   const expiresAt = new Date(Date.now() + (tokens.expires_in ?? 3600) * 1000).toISOString();
 
-  // Upsert tokens into organization_integrations
   const { error } = await admin
     .from('organization_integrations')
     .upsert(
@@ -196,7 +226,7 @@ async function handleOAuthCallback(admin: any, qs: Record<string, string | undef
         organization_id:  orgId,
         integration_type: 'google_drive',
         access_token:     tokens.access_token,
-        refresh_token:    tokens.refresh_token ?? null,
+        refresh_token:    refreshToken,
         expires_at:       expiresAt,
         connected_by:     userId,
         connected_at:     new Date().toISOString(),
@@ -205,7 +235,7 @@ async function handleOAuthCallback(admin: any, qs: Record<string, string | undef
     );
 
   if (error) {
-    console.error('Failed to save Google tokens:', error);
+    console.error('[google-drive] failed to save OAuth credentials');
     return redirect(`${APP_URL}?google_drive=error&message=${encodeURIComponent('Failed to save integration. Please try again.')}`);
   }
 
@@ -236,57 +266,11 @@ async function exchangeCode(code: string): Promise<GoogleTokenResponse> {
     }).toString(),
   });
   if (!resp.ok) {
-    const body = await resp.text();
-    throw new Error(`Google responded ${resp.status}: ${body}`);
+    throw Object.assign(new Error('Google rejected the OAuth request.'), {
+      providerStatus: resp.status,
+    });
   }
   return resp.json() as Promise<GoogleTokenResponse>;
-}
-
-async function refreshAccessToken(refreshToken: string): Promise<GoogleTokenResponse> {
-  const resp = await fetch(TOKEN_URL, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    body: new URLSearchParams({
-      refresh_token: refreshToken,
-      client_id:     CLIENT_ID,
-      client_secret: CLIENT_SECRET,
-      grant_type:    'refresh_token',
-    }).toString(),
-  });
-  if (!resp.ok) {
-    const body = await resp.text();
-    throw new Error(`Token refresh failed (${resp.status}): ${body}`);
-  }
-  return resp.json() as Promise<GoogleTokenResponse>;
-}
-
-/** Returns a valid access token, refreshing it if expired. */
-async function getValidToken(admin: any, integration: any): Promise<string> {
-  const now = Date.now();
-  const expiresAt = integration.expires_at ? new Date(integration.expires_at).getTime() : 0;
-
-  // Refresh 60 seconds before actual expiry to avoid race conditions
-  if (expiresAt - now > 60_000) {
-    return integration.access_token as string;
-  }
-
-  if (!integration.refresh_token) {
-    throw new Error('No refresh token available. User must reconnect Google Drive.');
-  }
-
-  const tokens = await refreshAccessToken(integration.refresh_token);
-  const newExpiresAt = new Date(now + (tokens.expires_in ?? 3600) * 1000).toISOString();
-
-  // Update stored tokens
-  await admin
-    .from('organization_integrations')
-    .update({
-      access_token: tokens.access_token,
-      expires_at:   newExpiresAt,
-    })
-    .eq('id', integration.id);
-
-  return tokens.access_token;
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -296,7 +280,7 @@ async function getValidToken(admin: any, integration: any): Promise<string> {
 async function getIntegration(admin: any, orgId: string, type: string) {
   const { data } = await admin
     .from('organization_integrations')
-    .select('*')
+    .select('id, access_token, refresh_token, expires_at')
     .eq('organization_id', orgId)
     .eq('integration_type', type)
     .maybeSingle();

--- a/netlify/functions/google-drive.ts
+++ b/netlify/functions/google-drive.ts
@@ -1,0 +1,335 @@
+import { createClient } from "@supabase/supabase-js";
+import {
+  buildGoogleDriveFilesUrl,
+  canManageGoogleDrive,
+  createGoogleOAuthState,
+  hashGoogleOAuthState,
+  isValidGoogleDriveOrganizationId,
+  normalizeGoogleDriveListParams,
+  toSafeGoogleDriveList,
+} from "./_shared/googleDriveSecurity.js";
+
+const TOKEN_URL = "https://oauth2.googleapis.com/token";
+const AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+const SCOPE = "https://www.googleapis.com/auth/drive.readonly";
+const OAUTH_STATE_TTL_MS = 10 * 60 * 1000;
+
+type HandlerDependencies = {
+  createAdminClient: () => any;
+  fetchImpl: typeof fetch;
+  clientId: string;
+  clientSecret: string;
+  appUrl: string;
+  createState: () => string;
+  now: () => Date;
+};
+
+type GoogleTokenResponse = {
+  access_token?: string;
+  expires_in?: number;
+};
+
+const json = (status: number, body: object) =>
+  new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      "Content-Type": "application/json",
+      "Cache-Control": "no-store",
+      "X-Content-Type-Options": "nosniff",
+    },
+  });
+
+function getAdminClient() {
+  const supabaseUrl = process.env.SUPABASE_URL ?? process.env.VITE_SUPABASE_URL ?? "";
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
+  if (!supabaseUrl || !serviceRoleKey) {
+    throw Object.assign(new Error("Google Drive is temporarily unavailable."), {
+      status: 503,
+    });
+  }
+  return createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+function defaultDependencies(): HandlerDependencies {
+  return {
+    createAdminClient: getAdminClient,
+    fetchImpl: fetch,
+    clientId: process.env.GOOGLE_CLIENT_ID ?? "",
+    clientSecret: process.env.GOOGLE_CLIENT_SECRET ?? "",
+    appUrl: process.env.VITE_APP_URL ?? "http://localhost:8888",
+    createState: createGoogleOAuthState,
+    now: () => new Date(),
+  };
+}
+
+function hasGoogleConfiguration(deps: HandlerDependencies) {
+  return Boolean(deps.clientId && deps.clientSecret);
+}
+
+function redirectUri(appUrl: string) {
+  return new URL("/.netlify/functions/google-callback", appUrl).toString();
+}
+
+function buildAuthorizationUrl(state: string, deps: HandlerDependencies) {
+  const url = new URL(AUTHORIZATION_URL);
+  url.searchParams.set("client_id", deps.clientId);
+  url.searchParams.set("redirect_uri", redirectUri(deps.appUrl));
+  url.searchParams.set("response_type", "code");
+  url.searchParams.set("scope", SCOPE);
+  url.searchParams.set("state", state);
+  url.searchParams.set("access_type", "offline");
+  url.searchParams.set("prompt", "consent");
+  return url.toString();
+}
+
+async function getMembership(admin: any, organizationId: string, userId: string) {
+  const { data, error } = await admin
+    .from("organization_members")
+    .select("role")
+    .eq("organization_id", organizationId)
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (error) throw new Error("Could not verify organization access.");
+  return data ?? null;
+}
+
+async function getIntegration(admin: any, organizationId: string) {
+  const { data, error } = await admin
+    .from("organization_integrations")
+    .select("id, access_token, refresh_token, expires_at")
+    .eq("organization_id", organizationId)
+    .eq("integration_type", "google_drive")
+    .maybeSingle();
+  if (error) throw new Error("Could not load Google Drive integration.");
+  return data ?? null;
+}
+
+async function refreshAccessToken(
+  refreshToken: string,
+  deps: HandlerDependencies,
+) {
+  const response = await deps.fetchImpl(TOKEN_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    body: new URLSearchParams({
+      refresh_token: refreshToken,
+      client_id: deps.clientId,
+      client_secret: deps.clientSecret,
+      grant_type: "refresh_token",
+    }).toString(),
+  });
+  if (!response.ok) {
+    throw Object.assign(new Error("Google rejected the token refresh."), {
+      status: 502,
+      providerStatus: response.status,
+    });
+  }
+  const tokens = await response.json() as GoogleTokenResponse;
+  if (typeof tokens.access_token !== "string" || tokens.access_token.length === 0) {
+    throw Object.assign(new Error("Google returned an invalid OAuth response."), { status: 502 });
+  }
+  return tokens;
+}
+
+async function getValidAccessToken(
+  admin: any,
+  integration: any,
+  deps: HandlerDependencies,
+) {
+  const expiresAt = integration.expires_at
+    ? new Date(integration.expires_at).getTime()
+    : 0;
+  if (expiresAt - deps.now().getTime() > 60_000) {
+    return integration.access_token as string;
+  }
+  if (typeof integration.refresh_token !== "string" || !integration.refresh_token) {
+    throw Object.assign(new Error("Google Drive must be reconnected."), { status: 409 });
+  }
+
+  const tokens = await refreshAccessToken(integration.refresh_token, deps);
+  const expiresAtIso = new Date(
+    deps.now().getTime() + (tokens.expires_in ?? 3600) * 1000,
+  ).toISOString();
+  const { error } = await admin
+    .from("organization_integrations")
+    .update({ access_token: tokens.access_token, expires_at: expiresAtIso })
+    .eq("id", integration.id);
+  if (error) throw new Error("Could not refresh Google Drive integration.");
+  return tokens.access_token;
+}
+
+async function parseJsonBody(request: Request) {
+  if (!request.headers.get("content-type")?.toLowerCase().startsWith("application/json")) {
+    throw Object.assign(new Error("Content-Type must be application/json."), { status: 415 });
+  }
+  try {
+    return await request.json();
+  } catch {
+    throw Object.assign(new Error("Invalid JSON."), { status: 400 });
+  }
+}
+
+async function handleGoogleDrive(
+  request: Request,
+  deps: HandlerDependencies,
+) {
+  if (request.method === "OPTIONS") {
+    return new Response(null, {
+      status: 204,
+      headers: { Allow: "GET, POST, DELETE, OPTIONS" },
+    });
+  }
+  if (!["GET", "POST", "DELETE"].includes(request.method)) {
+    return json(405, { error: "Method not allowed." });
+  }
+
+  const requestUrl = new URL(request.url);
+  const origin = request.headers.get("origin");
+  if (origin && origin !== requestUrl.origin) {
+    return json(403, { error: "Cross-origin requests are not allowed." });
+  }
+
+  const authHeader = request.headers.get("authorization");
+  if (!authHeader?.startsWith("Bearer ")) {
+    return json(401, { error: "You must be signed in to use Google Drive." });
+  }
+
+  let body: any = null;
+  if (["POST", "DELETE"].includes(request.method)) {
+    try {
+      body = await parseJsonBody(request);
+    } catch (error: any) {
+      return json(error.status ?? 400, { error: error.message });
+    }
+  }
+
+  const action = request.method === "GET"
+    ? requestUrl.searchParams.get("action")
+    : body?.action ?? (request.method === "DELETE" ? "disconnect" : null);
+  const organizationId = request.method === "GET"
+    ? requestUrl.searchParams.get("organization_id")
+    : body?.organization_id;
+  if (!isValidGoogleDriveOrganizationId(organizationId)) {
+    return json(400, { error: "A valid organization_id is required." });
+  }
+
+  try {
+    const admin = deps.createAdminClient();
+    const accessToken = authHeader.slice("Bearer ".length);
+    const { data: userResponse, error: userError } = await admin.auth.getUser(accessToken);
+    if (userError || !userResponse?.user) {
+      return json(401, { error: "Your session has expired. Please sign in again." });
+    }
+
+    const membership = await getMembership(admin, organizationId, userResponse.user.id);
+    if (!membership) {
+      return json(403, { error: "You don't have access to this organization." });
+    }
+
+    if (request.method === "GET" && action === "token") {
+      return json(404, { error: "This Google Drive operation is not available." });
+    }
+
+    if (request.method === "GET" && action === "status") {
+      const integration = await getIntegration(admin, organizationId);
+      return json(200, {
+        configured: hasGoogleConfiguration(deps),
+        connected: Boolean(integration),
+        can_manage: canManageGoogleDrive(membership.role),
+      });
+    }
+
+    if (request.method === "POST" && action === "connect") {
+      if (!canManageGoogleDrive(membership.role)) {
+        return json(403, { error: "Only Owners and Admins can connect Google Drive." });
+      }
+      if (!hasGoogleConfiguration(deps)) {
+        return json(503, { error: "Google Drive is not configured on this server." });
+      }
+
+      const state = deps.createState();
+      const expiresAt = new Date(deps.now().getTime() + OAUTH_STATE_TTL_MS).toISOString();
+      const { error } = await admin.from("organization_oauth_states").insert({
+        state_hash: hashGoogleOAuthState(state),
+        organization_id: organizationId,
+        user_id: userResponse.user.id,
+        integration_type: "google_drive",
+        expires_at: expiresAt,
+      });
+      if (error) throw new Error("Could not start Google Drive authorization.");
+      return json(200, { authorization_url: buildAuthorizationUrl(state, deps) });
+    }
+
+    if (request.method === "GET" && action === "files") {
+      if (!hasGoogleConfiguration(deps)) {
+        return json(503, { error: "Google Drive is not configured on this server." });
+      }
+      const integration = await getIntegration(admin, organizationId);
+      if (!integration) {
+        return json(409, { error: "Google Drive is not connected for this organization." });
+      }
+      const params = normalizeGoogleDriveListParams(
+        requestUrl.searchParams.get("search"),
+        requestUrl.searchParams.get("page_token"),
+      );
+      const googleAccessToken = await getValidAccessToken(admin, integration, deps);
+      const response = await deps.fetchImpl(buildGoogleDriveFilesUrl(params), {
+        headers: { Authorization: `Bearer ${googleAccessToken}` },
+      });
+      if (!response.ok) {
+        throw Object.assign(new Error("Google Drive request failed."), {
+          status: 502,
+          providerStatus: response.status,
+        });
+      }
+      return json(200, toSafeGoogleDriveList(await response.json()));
+    }
+
+    if (request.method === "DELETE" && action === "disconnect") {
+      if (!canManageGoogleDrive(membership.role)) {
+        return json(403, { error: "Only Owners and Admins can disconnect Google Drive." });
+      }
+      const { error } = await admin
+        .from("organization_integrations")
+        .delete()
+        .eq("organization_id", organizationId)
+        .eq("integration_type", "google_drive");
+      if (error) throw new Error("Could not disconnect Google Drive.");
+      return json(200, { success: true });
+    }
+
+    return json(405, { error: "Method not allowed." });
+  } catch (error: any) {
+    const status = typeof error?.status === "number" ? error.status : 500;
+    const providerStatus = typeof error?.providerStatus === "number"
+      ? ` provider_status=${error.providerStatus}`
+      : "";
+    console.error(`[google-drive] request failed status=${status}${providerStatus}`);
+    const message = [400, 409, 415].includes(status)
+      ? error.message
+      : "Google Drive is temporarily unavailable. Please try again later.";
+    return json(status, { error: message });
+  }
+}
+
+export function createGoogleDriveHandler(
+  overrides: Partial<HandlerDependencies> = {},
+) {
+  return (request: Request) => handleGoogleDrive(request, {
+    ...defaultDependencies(),
+    ...overrides,
+  });
+}
+
+export default createGoogleDriveHandler();
+
+export const config = {
+  path: "/.netlify/functions/google-drive",
+  rateLimit: {
+    windowLimit: 60,
+    windowSize: 60,
+    aggregateBy: ["ip", "domain"],
+  },
+} as const;

--- a/services/googleDriveService.ts
+++ b/services/googleDriveService.ts
@@ -1,98 +1,115 @@
 /**
  * googleDriveService.ts
  *
- * Client-side helpers for Google Drive OAuth integration.
- *
- * Required environment variables:
- *   VITE_GOOGLE_CLIENT_ID  — OAuth client ID (safe to expose; used for Picker)
- *   VITE_GOOGLE_API_KEY    — Google API key restricted to Picker API + your domain
+ * Client-side helpers for the server-proxied Google Drive integration.
  *
  * Server-side env vars (in .env / Netlify dashboard — never VITE_):
  *   GOOGLE_CLIENT_ID       — same client ID (server uses it for token exchange)
  *   GOOGLE_CLIENT_SECRET   — OAuth client secret
  *
  * How to set up in Google Cloud Console:
- *   1. APIs & Services → Library → enable "Google Drive API" + "Google Picker API"
+ *   1. APIs & Services → Library → enable "Google Drive API"
  *   2. Credentials → Create Credentials → OAuth 2.0 Client ID (Web application)
  *      Authorized redirect URIs:
  *        https://<netlify-site>/.netlify/functions/google-callback
  *        http://localhost:8888/.netlify/functions/google-callback
- *   3. Credentials → Create Credentials → API Key
- *      Restrict to: Picker API + your domain(s)
  */
 
-const CLIENT_ID = (import.meta as any).env?.VITE_GOOGLE_CLIENT_ID as string | undefined;
-const API_KEY   = (import.meta as any).env?.VITE_GOOGLE_API_KEY   as string | undefined;
-
-const CALLBACK_URL  = '/.netlify/functions/google-callback';
-const OAUTH_SCOPE   = 'https://www.googleapis.com/auth/drive.readonly';
-const OAUTH_BASE    = 'https://accounts.google.com/o/oauth2/v2/auth';
+const GOOGLE_DRIVE_URL = '/.netlify/functions/google-drive';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // OAuth initiation
 // ─────────────────────────────────────────────────────────────────────────────
 
 /**
- * Build the Google OAuth consent-screen URL and navigate the browser to it.
- * After consent the user lands at google-callback which stores the tokens,
- * then redirects back to APP_URL with ?google_drive=connected.
+ * Ask the server to create a short-lived, single-use OAuth state, then navigate
+ * to the returned Google authorization URL.
  */
-export function connectGoogleDrive(orgId: string, userId: string): void {
-  if (!CLIENT_ID) {
-    throw new Error(
-      'VITE_GOOGLE_CLIENT_ID is not set. Configure the Google Cloud credentials first.',
-    );
+export async function connectGoogleDrive(
+  orgId: string,
+  accessToken: string,
+): Promise<void> {
+  const resp = await fetch(GOOGLE_DRIVE_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${accessToken}`,
+    },
+    body: JSON.stringify({ action: 'connect', organization_id: orgId }),
+  });
+  const body = await resp.json().catch(() => ({}));
+  if (!resp.ok) throw new Error((body as any).error ?? 'Failed to connect Google Drive.');
+
+  const authorizationUrl = new URL((body as any).authorization_url);
+  if (authorizationUrl.origin !== 'https://accounts.google.com') {
+    throw new Error('The Google authorization URL is invalid.');
   }
-
-  // State = base64("orgId:userId") — decoded server-side in google-callback.ts
-  const state = btoa(`${orgId}:${userId}`);
-
-  const url = new URL(OAUTH_BASE);
-  url.searchParams.set('client_id',     CLIENT_ID);
-  url.searchParams.set('redirect_uri',  `${window.location.origin}${CALLBACK_URL}`);
-  url.searchParams.set('response_type', 'code');
-  url.searchParams.set('scope',         OAUTH_SCOPE);
-  url.searchParams.set('state',         state);
-  url.searchParams.set('access_type',   'offline');   // request refresh token
-  url.searchParams.set('prompt',        'consent');   // always show consent to get refresh token
-
-  window.location.href = url.toString();
+  window.location.assign(authorizationUrl.toString());
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Token & status queries (via Netlify function)
+// Status and file queries (via Netlify function)
 // ─────────────────────────────────────────────────────────────────────────────
 
-/** Returns true if Google Drive is connected for the org. */
+export interface GoogleDriveStatus {
+  configured: boolean;
+  connected: boolean;
+  canManage: boolean;
+}
+
+/** Returns safe connection metadata for the organization. */
 export async function getGoogleDriveStatus(
   orgId: string,
   accessToken: string,
-): Promise<boolean> {
+): Promise<GoogleDriveStatus> {
   const resp = await fetch(
-    `${CALLBACK_URL}?action=status&organization_id=${encodeURIComponent(orgId)}`,
-    { headers: { Authorization: `Bearer ${accessToken}` } },
-  );
-  if (!resp.ok) return false;
-  const data = await resp.json();
-  return !!(data as any).connected;
-}
-
-/**
- * Returns a valid Google OAuth access token for this org.
- * The server auto-refreshes it if expired.
- * Use this token to open the Google Picker (see openGooglePicker below).
- */
-export async function getGoogleDriveAccessToken(
-  orgId: string,
-  accessToken: string,
-): Promise<string> {
-  const resp = await fetch(
-    `${CALLBACK_URL}?action=token&organization_id=${encodeURIComponent(orgId)}`,
+    `${GOOGLE_DRIVE_URL}?action=status&organization_id=${encodeURIComponent(orgId)}`,
     { headers: { Authorization: `Bearer ${accessToken}` } },
   );
   const body = await resp.json().catch(() => ({}));
-  if (!resp.ok) throw new Error((body as any).error ?? 'Failed to get Google Drive token.');
-  return (body as any).access_token as string;
+  if (!resp.ok) throw new Error((body as any).error ?? 'Failed to check Google Drive status.');
+  return {
+    configured: (body as any).configured === true,
+    connected: (body as any).connected === true,
+    canManage: (body as any).can_manage === true,
+  };
+}
+
+export interface DriveFile {
+  id: string;
+  name: string;
+  url: string;
+  mimeType: string;
+  sizeBytes: number | null;
+  modifiedTime: string | null;
+}
+
+export interface GoogleDriveFilePage {
+  files: DriveFile[];
+  nextPageToken: string | null;
+}
+
+/** List constrained file metadata without exposing the Google bearer token. */
+export async function listGoogleDriveFiles(
+  orgId: string,
+  accessToken: string,
+  options: { search?: string; pageToken?: string | null } = {},
+): Promise<GoogleDriveFilePage> {
+  const url = new URL(GOOGLE_DRIVE_URL, window.location.origin);
+  url.searchParams.set('action', 'files');
+  url.searchParams.set('organization_id', orgId);
+  if (options.search) url.searchParams.set('search', options.search);
+  if (options.pageToken) url.searchParams.set('page_token', options.pageToken);
+
+  const resp = await fetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });
+  const body = await resp.json().catch(() => ({}));
+  if (!resp.ok) throw new Error((body as any).error ?? 'Failed to load Google Drive files.');
+  return {
+    files: Array.isArray((body as any).files) ? (body as any).files : [],
+    nextPageToken: typeof (body as any).next_page_token === 'string'
+      ? (body as any).next_page_token
+      : null,
+  };
 }
 
 /** Disconnect Google Drive (removes stored tokens). */
@@ -100,7 +117,7 @@ export async function disconnectGoogleDrive(
   orgId: string,
   accessToken: string,
 ): Promise<void> {
-  const resp = await fetch(CALLBACK_URL, {
+  const resp = await fetch(GOOGLE_DRIVE_URL, {
     method: 'DELETE',
     headers: {
       'Content-Type': 'application/json',
@@ -113,97 +130,8 @@ export async function disconnectGoogleDrive(
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Google Picker
-// ─────────────────────────────────────────────────────────────────────────────
-
-export interface DriveFile {
-  id:        string;
-  name:      string;
-  url:       string;
-  mimeType:  string;
-  sizeBytes: number | null;
-}
-
-declare global {
-  interface Window {
-    gapi?: any;
-    google?: any;
-  }
-}
-
-let pickerScriptLoaded = false;
-
-/** Dynamically load the Google Picker API script once. */
-async function loadPickerApi(): Promise<void> {
-  if (pickerScriptLoaded || window.gapi?.picker) return;
-  await new Promise<void>((resolve, reject) => {
-    const script = document.createElement('script');
-    script.src = 'https://apis.google.com/js/api.js';
-    script.onload = () => {
-      window.gapi!.load('picker', { callback: resolve });
-    };
-    script.onerror = () => reject(new Error('Failed to load Google Picker API script.'));
-    document.head.appendChild(script);
-  });
-  pickerScriptLoaded = true;
-}
-
-/**
- * Open the Google Drive Picker and return the selected file's metadata.
- * Returns null if the user cancels.
- *
- * Requires:
- *   - VITE_GOOGLE_CLIENT_ID and VITE_GOOGLE_API_KEY set
- *   - Google Drive is connected for the org (access token obtained via
- *     getGoogleDriveAccessToken)
- */
-export async function openGooglePicker(driveAccessToken: string): Promise<DriveFile | null> {
-  if (!API_KEY) {
-    throw new Error('VITE_GOOGLE_API_KEY is not set.');
-  }
-  if (!CLIENT_ID) {
-    throw new Error('VITE_GOOGLE_CLIENT_ID is not set.');
-  }
-
-  await loadPickerApi();
-
-  return new Promise<DriveFile | null>((resolve) => {
-    const picker = new window.google.picker.PickerBuilder()
-      .addView(window.google.picker.ViewId.DOCS)
-      .setOAuthToken(driveAccessToken)
-      .setDeveloperKey(API_KEY!)
-      .setAppId(CLIENT_ID!)
-      .setCallback((data: any) => {
-        if (data.action === window.google.picker.Action.PICKED) {
-          const doc = data.docs[0];
-          resolve({
-            id:        doc.id         as string,
-            name:      doc.name       as string,
-            url:       doc.url        as string,
-            mimeType:  doc.mimeType   as string,
-            sizeBytes: doc.sizeBytes != null ? Number(doc.sizeBytes) : null,
-          });
-        } else if (
-          data.action === window.google.picker.Action.CANCEL ||
-          data.action === window.google.picker.Action.LOADED
-        ) {
-          if (data.action === window.google.picker.Action.CANCEL) resolve(null);
-        }
-      })
-      .build();
-
-    picker.setVisible(true);
-  });
-}
-
-// ─────────────────────────────────────────────────────────────────────────────
 // Utilities
 // ─────────────────────────────────────────────────────────────────────────────
-
-/** Returns true if the Google credentials env vars are configured in this build. */
-export function isGoogleDriveConfigured(): boolean {
-  return !!(CLIENT_ID && API_KEY);
-}
 
 /** Convert Google MIME type to a short extension string. */
 export function mimeToExtension(mimeType: string): string {

--- a/supabase/migrations/022_google_drive_token_isolation.sql
+++ b/supabase/migrations/022_google_drive_token_isolation.sql
@@ -1,0 +1,38 @@
+-- ============================================================
+-- Migration 022 - Google Drive OAuth token isolation
+-- ============================================================
+
+BEGIN;
+
+-- OAuth credentials are consumed only by Netlify Functions using the service
+-- role. Browser clients must not be able to query them even when the user is an
+-- organization Owner or Admin.
+DROP POLICY IF EXISTS "admins_manage_integrations" ON organization_integrations;
+REVOKE ALL ON TABLE organization_integrations FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE organization_integrations TO service_role;
+
+COMMENT ON TABLE organization_integrations
+  IS 'Server-only OAuth credentials for cloud storage integrations. Never expose rows or token values to browser clients.';
+
+-- Store only a hash of each short-lived, single-use OAuth state. The raw state
+-- exists only in the authorization URL returned to an authenticated Owner/Admin.
+CREATE TABLE organization_oauth_states (
+  state_hash       text        PRIMARY KEY CHECK (char_length(state_hash) = 64),
+  organization_id  uuid        NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  user_id          uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  integration_type text        NOT NULL CHECK (integration_type = 'google_drive'),
+  expires_at       timestamptz NOT NULL,
+  created_at       timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_organization_oauth_states_expiry
+  ON organization_oauth_states (expires_at);
+
+ALTER TABLE organization_oauth_states ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE organization_oauth_states FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE organization_oauth_states TO service_role;
+
+COMMENT ON TABLE organization_oauth_states
+  IS 'Server-only hashes for short-lived, single-use OAuth state parameters.';
+
+COMMIT;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1047,3 +1047,37 @@ COMMENT ON COLUMN organization_ai_settings.use_byok
   IS 'When true the server uses the organization credential stored in organization_ai_secrets';
 
 COMMIT;
+
+-- ============================================================
+-- Migration 022 - Google Drive OAuth token isolation
+-- ============================================================
+
+BEGIN;
+
+DROP POLICY IF EXISTS "admins_manage_integrations" ON organization_integrations;
+REVOKE ALL ON TABLE organization_integrations FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE organization_integrations TO service_role;
+
+COMMENT ON TABLE organization_integrations
+  IS 'Server-only OAuth credentials for cloud storage integrations. Never expose rows or token values to browser clients.';
+
+CREATE TABLE organization_oauth_states (
+  state_hash       text        PRIMARY KEY CHECK (char_length(state_hash) = 64),
+  organization_id  uuid        NOT NULL REFERENCES organizations(id) ON DELETE CASCADE,
+  user_id          uuid        NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  integration_type text        NOT NULL CHECK (integration_type = 'google_drive'),
+  expires_at       timestamptz NOT NULL,
+  created_at       timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_organization_oauth_states_expiry
+  ON organization_oauth_states (expires_at);
+
+ALTER TABLE organization_oauth_states ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE organization_oauth_states FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE organization_oauth_states TO service_role;
+
+COMMENT ON TABLE organization_oauth_states
+  IS 'Server-only hashes for short-lived, single-use OAuth state parameters.';
+
+COMMIT;

--- a/tests/security/google-drive-token-isolation.test.mjs
+++ b/tests/security/google-drive-token-isolation.test.mjs
@@ -466,3 +466,15 @@ test("Settings provides role-aware Drive management through the proxy", async ()
   assert.doesNotMatch(settingsSource, /GOOGLE_CLIENT_SECRET|VITE_GOOGLE_API_KEY/);
   assert.doesNotMatch(settingsSource, /getGoogleDriveAccessToken|openGooglePicker/);
 });
+
+test("Evidence picker distinguishes a status failure from missing server configuration", async () => {
+  const evidenceSource = await readFile(
+    new URL("../../components/EvidenceBadge.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(evidenceSource, /driveStatusError/);
+  assert.match(evidenceSource, /Could not check the Google Drive connection/);
+  assert.match(evidenceSource, /Retry Google Drive status/);
+  assert.doesNotMatch(evidenceSource, /\.catch\(\(\) => \{\}\)/);
+});

--- a/tests/security/google-drive-token-isolation.test.mjs
+++ b/tests/security/google-drive-token-isolation.test.mjs
@@ -205,6 +205,25 @@ test("no organization role can receive a raw OAuth token", async () => {
   }
 });
 
+test("status returns safe connection metadata and server-derived management permission", async () => {
+  const admin = createAdminMock({ role: "Manager" });
+  const response = await createHandler(admin)(apiRequest(
+    `?action=status&organization_id=${ORG_ID}`,
+    { headers: { Authorization: "Bearer manager-token" } },
+  ));
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(body, {
+    configured: true,
+    connected: true,
+    can_manage: false,
+  });
+  assert.equal("access_token" in body, false);
+  assert.equal("refresh_token" in body, false);
+  assert.doesNotMatch(JSON.stringify(body), new RegExp(GOOGLE_ACCESS_TOKEN));
+});
+
 test("cross-tenant requests are rejected before integration credentials are read", async () => {
   const admin = createAdminMock({ role: null });
   const response = await createHandler(admin)(apiRequest(
@@ -430,4 +449,20 @@ test("platform-admin company export excludes the OAuth credential table", async 
 
   assert.ok(tableList);
   assert.doesNotMatch(tableList[1], /organization_integrations/);
+});
+
+test("Settings provides role-aware Drive management through the proxy", async () => {
+  const settingsSource = await readFile(
+    new URL("../../components/SettingsDashboard.tsx", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(settingsSource, /id: 'integrations'/);
+  assert.match(settingsSource, /getGoogleDriveStatus\(organizationId, token\)/);
+  assert.match(settingsSource, /connectGoogleDrive\(organizationId, token\)/);
+  assert.match(settingsSource, /disconnectGoogleDrive\(organizationId, token\)/);
+  assert.match(settingsSource, /roleCanManage[\s\S]+Owner[\s\S]+Admin/);
+  assert.match(settingsSource, /driveStatus\?\.canManage === true/);
+  assert.doesNotMatch(settingsSource, /GOOGLE_CLIENT_SECRET|VITE_GOOGLE_API_KEY/);
+  assert.doesNotMatch(settingsSource, /getGoogleDriveAccessToken|openGooglePicker/);
 });

--- a/tests/security/google-drive-token-isolation.test.mjs
+++ b/tests/security/google-drive-token-isolation.test.mjs
@@ -1,0 +1,433 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  createGoogleDriveHandler,
+  config as googleDriveConfig,
+} from "../../netlify/functions/google-drive.ts";
+import {
+  buildGoogleDriveFilesUrl,
+  canManageGoogleDrive,
+  hashGoogleOAuthState,
+  isValidGoogleOAuthState,
+  normalizeGoogleDriveListParams,
+  toSafeGoogleDriveList,
+} from "../../netlify/functions/_shared/googleDriveSecurity.js";
+
+const ORG_ID = "11111111-1111-4111-8111-111111111111";
+const USER_ID = "22222222-2222-4222-8222-222222222222";
+const OAUTH_STATE = "s".repeat(43);
+const GOOGLE_ACCESS_TOKEN = "google-access-token-must-not-leak";
+const GOOGLE_REFRESH_TOKEN = "google-refresh-token-must-not-leak";
+const NOW = new Date("2026-08-18T10:00:00.000Z");
+
+function createAdminMock({
+  role = "Owner",
+  integration = {
+    id: "33333333-3333-4333-8333-333333333333",
+    access_token: GOOGLE_ACCESS_TOKEN,
+    refresh_token: GOOGLE_REFRESH_TOKEN,
+    expires_at: "2026-08-18T12:00:00.000Z",
+  },
+} = {}) {
+  const calls = [];
+  const admin = {
+    calls,
+    auth: {
+      getUser: async (token) => {
+        calls.push({ operation: "getUser", token });
+        return {
+          data: { user: { id: USER_ID } },
+          error: null,
+        };
+      },
+    },
+    from(table) {
+      const filters = [];
+      let operation = null;
+      let columns = null;
+      let payload = null;
+      const query = {
+        select(value) {
+          operation = "select";
+          columns = value;
+          return query;
+        },
+        insert(value) {
+          operation = "insert";
+          payload = value;
+          calls.push({ table, operation, payload });
+          return Promise.resolve({ error: null });
+        },
+        update(value) {
+          operation = "update";
+          payload = value;
+          return query;
+        },
+        delete() {
+          operation = "delete";
+          return query;
+        },
+        eq(column, value) {
+          filters.push([column, value]);
+          return query;
+        },
+        async maybeSingle() {
+          calls.push({ table, operation, columns, filters });
+          if (table === "organization_members") {
+            return { data: role ? { role } : null, error: null };
+          }
+          if (table === "organization_integrations") {
+            return { data: integration, error: null };
+          }
+          throw new Error(`Unexpected table ${table}`);
+        },
+        then(resolve, reject) {
+          calls.push({ table, operation, columns, filters, payload });
+          return Promise.resolve({ error: null }).then(resolve, reject);
+        },
+      };
+      return query;
+    },
+  };
+  return admin;
+}
+
+function createHandler(admin, fetchImpl = async () => {
+  throw new Error("Unexpected provider request");
+}) {
+  return createGoogleDriveHandler({
+    createAdminClient: () => admin,
+    fetchImpl,
+    clientId: "google-client-id",
+    clientSecret: "google-client-secret",
+    appUrl: "https://app.example.com",
+    createState: () => OAUTH_STATE,
+    now: () => NOW,
+  });
+}
+
+function apiRequest(path, options = {}) {
+  return new Request(`https://app.example.com/.netlify/functions/google-drive${path}`, options);
+}
+
+test("only Owner and Admin roles can manage the Google Drive integration", () => {
+  assert.equal(canManageGoogleDrive("Owner"), true);
+  assert.equal(canManageGoogleDrive("Admin"), true);
+  assert.equal(canManageGoogleDrive("Manager"), false);
+  assert.equal(canManageGoogleDrive("Consultant"), false);
+  assert.equal(canManageGoogleDrive(undefined), false);
+});
+
+test("OAuth state is opaque, fixed-length, and stored as a one-way hash", () => {
+  assert.equal(isValidGoogleOAuthState(OAUTH_STATE), true);
+  assert.equal(isValidGoogleOAuthState(Buffer.from(`${ORG_ID}:${USER_ID}`).toString("base64")), false);
+  assert.match(hashGoogleOAuthState(OAUTH_STATE), /^[a-f0-9]{64}$/);
+  assert.notEqual(hashGoogleOAuthState(OAUTH_STATE), OAUTH_STATE);
+});
+
+test("Drive list inputs stay on the fixed Google API origin and escape search syntax", () => {
+  const params = normalizeGoogleDriveListParams("Q3's \\ report", "page-token");
+  const url = buildGoogleDriveFilesUrl(params);
+
+  assert.equal(url.origin, "https://www.googleapis.com");
+  assert.equal(url.pathname, "/drive/v3/files");
+  assert.match(url.searchParams.get("q"), /name contains 'Q3\\'s \\\\ report'/);
+  assert.equal(url.searchParams.get("pageToken"), "page-token");
+  assert.throws(
+    () => normalizeGoogleDriveListParams("x".repeat(101), null),
+    /search is invalid/,
+  );
+});
+
+test("provider payload is reduced to safe file metadata", () => {
+  const safe = toSafeGoogleDriveList({
+    access_token: GOOGLE_ACCESS_TOKEN,
+    refresh_token: GOOGLE_REFRESH_TOKEN,
+    nextPageToken: "next-page",
+    files: [
+      {
+        id: "safe-file-id",
+        name: "Board report.pdf",
+        mimeType: "application/pdf",
+        size: "4096",
+        modifiedTime: "2026-08-17T09:00:00.000Z",
+        owners: [{ emailAddress: "private@example.com" }],
+      },
+      { id: "../../unsafe", name: "drop-me" },
+    ],
+  });
+
+  assert.equal(safe.files.length, 1);
+  assert.deepEqual(safe.files[0], {
+    id: "safe-file-id",
+    name: "Board report.pdf",
+    url: "https://drive.google.com/open?id=safe-file-id",
+    mimeType: "application/pdf",
+    sizeBytes: 4096,
+    modifiedTime: "2026-08-17T09:00:00.000Z",
+  });
+  assert.equal(safe.next_page_token, "next-page");
+  assert.doesNotMatch(JSON.stringify(safe), /access_token|refresh_token|private@example\.com/);
+});
+
+test("Google Drive endpoint rejects cross-origin and unauthenticated requests early", async () => {
+  const admin = createAdminMock();
+  const handler = createHandler(admin);
+
+  const crossOrigin = await handler(apiRequest(
+    `?action=status&organization_id=${ORG_ID}`,
+    { headers: { Origin: "https://attacker.example" } },
+  ));
+  assert.equal(crossOrigin.status, 403);
+
+  const unauthenticated = await handler(apiRequest(
+    `?action=status&organization_id=${ORG_ID}`,
+  ));
+  assert.equal(unauthenticated.status, 401);
+  assert.equal(admin.calls.length, 0);
+});
+
+test("no organization role can receive a raw OAuth token", async () => {
+  for (const role of ["Consultant", "Manager", "Admin", "Owner"]) {
+    const admin = createAdminMock({ role });
+    const response = await createHandler(admin)(apiRequest(
+      `?action=token&organization_id=${ORG_ID}`,
+      { headers: { Authorization: `Bearer ${role.toLowerCase()}-token` } },
+    ));
+    const body = await response.json();
+
+    assert.equal(response.status, 404, role);
+    assert.equal("access_token" in body, false, role);
+    assert.equal("refresh_token" in body, false, role);
+    assert.doesNotMatch(JSON.stringify(body), /google-access-token|google-refresh-token/);
+  }
+});
+
+test("cross-tenant requests are rejected before integration credentials are read", async () => {
+  const admin = createAdminMock({ role: null });
+  const response = await createHandler(admin)(apiRequest(
+    `?action=files&organization_id=${ORG_ID}`,
+    { headers: { Authorization: "Bearer outsider-token" } },
+  ));
+
+  assert.equal(response.status, 403);
+  assert.equal(
+    admin.calls.some((call) => call.table === "organization_integrations"),
+    false,
+  );
+});
+
+test("Manager and Consultant cannot start OAuth or create state rows", async () => {
+  for (const role of ["Manager", "Consultant"]) {
+    const admin = createAdminMock({ role });
+    const response = await createHandler(admin)(apiRequest("", {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${role.toLowerCase()}-token`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ action: "connect", organization_id: ORG_ID }),
+    }));
+
+    assert.equal(response.status, 403, role);
+    assert.equal(
+      admin.calls.some((call) => call.table === "organization_oauth_states"),
+      false,
+    );
+  }
+});
+
+test("integration disconnect is denied to Manager and allowed to Owner", async () => {
+  const managerAdmin = createAdminMock({ role: "Manager" });
+  const managerResponse = await createHandler(managerAdmin)(apiRequest("", {
+    method: "DELETE",
+    headers: {
+      Authorization: "Bearer manager-token",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ organization_id: ORG_ID }),
+  }));
+  assert.equal(managerResponse.status, 403);
+  assert.equal(
+    managerAdmin.calls.some((call) =>
+      call.table === "organization_integrations" && call.operation === "delete"
+    ),
+    false,
+  );
+
+  const ownerAdmin = createAdminMock({ role: "Owner" });
+  const ownerResponse = await createHandler(ownerAdmin)(apiRequest("", {
+    method: "DELETE",
+    headers: {
+      Authorization: "Bearer owner-token",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ organization_id: ORG_ID }),
+  }));
+  assert.equal(ownerResponse.status, 200);
+  assert.equal(
+    ownerAdmin.calls.some((call) =>
+      call.table === "organization_integrations" && call.operation === "delete"
+    ),
+    true,
+  );
+});
+
+test("Owner starts OAuth with a hashed, expiring state and receives no credential", async () => {
+  const admin = createAdminMock({ role: "Owner" });
+  const response = await createHandler(admin)(apiRequest("", {
+    method: "POST",
+    headers: {
+      Authorization: "Bearer owner-token",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ action: "connect", organization_id: ORG_ID }),
+  }));
+  const body = await response.json();
+  const stateInsert = admin.calls.find(
+    (call) => call.table === "organization_oauth_states" && call.operation === "insert",
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal("access_token" in body, false);
+  assert.equal("refresh_token" in body, false);
+  assert.equal(stateInsert.payload.state_hash, hashGoogleOAuthState(OAUTH_STATE));
+  assert.equal(JSON.stringify(stateInsert.payload).includes(OAUTH_STATE), false);
+  assert.equal(stateInsert.payload.expires_at, "2026-08-18T10:10:00.000Z");
+
+  const authorizationUrl = new URL(body.authorization_url);
+  assert.equal(authorizationUrl.origin, "https://accounts.google.com");
+  assert.equal(authorizationUrl.searchParams.get("state"), OAUTH_STATE);
+  assert.equal(authorizationUrl.searchParams.get("scope"), "https://www.googleapis.com/auth/drive.readonly");
+});
+
+test("member file listing proxies the credential and returns only safe metadata", async () => {
+  const admin = createAdminMock({ role: "Consultant" });
+  let providerRequest = null;
+  const handler = createHandler(admin, async (url, options) => {
+    providerRequest = { url: url.toString(), options };
+    return Response.json({
+      access_token: GOOGLE_ACCESS_TOKEN,
+      files: [{
+        id: "drive-file-id",
+        name: "Emissions.xlsx",
+        mimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        size: "1024",
+        modifiedTime: "2026-08-18T09:00:00.000Z",
+      }],
+    });
+  });
+  const response = await handler(apiRequest(
+    `?action=files&organization_id=${ORG_ID}&search=Emissions`,
+    { headers: { Authorization: "Bearer consultant-token" } },
+  ));
+  const body = await response.json();
+
+  assert.equal(response.status, 200);
+  assert.equal(new URL(providerRequest.url).origin, "https://www.googleapis.com");
+  assert.equal(providerRequest.options.headers.Authorization, `Bearer ${GOOGLE_ACCESS_TOKEN}`);
+  assert.equal(body.files.length, 1);
+  assert.equal(body.files[0].id, "drive-file-id");
+  assert.equal("access_token" in body, false);
+  assert.equal("refresh_token" in body, false);
+  assert.doesNotMatch(JSON.stringify(body), new RegExp(GOOGLE_ACCESS_TOKEN));
+});
+
+test("provider failures do not copy response bodies or credentials into errors and logs", async (t) => {
+  const admin = createAdminMock();
+  const logs = [];
+  const originalConsoleError = console.error;
+  console.error = (...args) => logs.push(args.join(" "));
+  t.after(() => { console.error = originalConsoleError; });
+
+  const handler = createHandler(admin, async () => new Response(
+    `provider failure ${GOOGLE_ACCESS_TOKEN} ${GOOGLE_REFRESH_TOKEN}`,
+    { status: 500 },
+  ));
+  const response = await handler(apiRequest(
+    `?action=files&organization_id=${ORG_ID}`,
+    { headers: { Authorization: "Bearer owner-token" } },
+  ));
+  const body = await response.text();
+  const combined = `${body}\n${logs.join("\n")}`;
+
+  assert.equal(response.status, 502);
+  assert.doesNotMatch(combined, new RegExp(GOOGLE_ACCESS_TOKEN));
+  assert.doesNotMatch(combined, new RegExp(GOOGLE_REFRESH_TOKEN));
+  assert.doesNotMatch(combined, /provider failure/);
+});
+
+test("Google Drive endpoint has a strict per-IP rate limit", () => {
+  assert.equal(googleDriveConfig.path, "/.netlify/functions/google-drive");
+  assert.deepEqual(googleDriveConfig.rateLimit.aggregateBy, ["ip", "domain"]);
+  assert.equal(googleDriveConfig.rateLimit.windowLimit, 60);
+  assert.equal(googleDriveConfig.rateLimit.windowSize, 60);
+});
+
+test("migration denies browser roles access to OAuth credentials and state", async () => {
+  const migration = await readFile(
+    new URL("../../supabase/migrations/022_google_drive_token_isolation.sql", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(
+    migration,
+    /REVOKE ALL ON TABLE organization_integrations FROM PUBLIC, anon, authenticated/i,
+  );
+  assert.match(migration, /GRANT ALL ON TABLE organization_integrations TO service_role/i);
+  assert.match(migration, /CREATE TABLE organization_oauth_states/i);
+  assert.match(migration, /ALTER TABLE organization_oauth_states ENABLE ROW LEVEL SECURITY/i);
+  assert.match(
+    migration,
+    /REVOKE ALL ON TABLE organization_oauth_states FROM PUBLIC, anon, authenticated/i,
+  );
+  assert.doesNotMatch(migration, /CREATE POLICY[\s\S]+ON organization_oauth_states/i);
+});
+
+test("legacy callback consumes hashed state and keeps the raw-token route retired", async () => {
+  const callbackSource = await readFile(
+    new URL("../../netlify/functions/google-callback.ts", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(callbackSource, /from\('organization_oauth_states'\)[\s\S]+\.delete\(\)/);
+  assert.match(callbackSource, /hashGoogleOAuthState\(state\)/);
+  assert.match(callbackSource, /canManageGoogleDrive\(membership\.role\)/);
+  assert.doesNotMatch(callbackSource, /Buffer\.from\(state/);
+  assert.doesNotMatch(callbackSource, /return json\(200,\s*\{\s*access_token/);
+  assert.match(
+    callbackSource,
+    /qs\.action === 'token'[\s\S]{0,500}return json\(404/,
+  );
+  assert.match(
+    callbackSource,
+    /qs\.error[\s\S]{0,600}from\('organization_oauth_states'\)[\s\S]{0,300}\.delete\(\)/,
+  );
+});
+
+test("browser service contains no Google OAuth token or Picker API flow", async () => {
+  const serviceSource = await readFile(
+    new URL("../../services/googleDriveService.ts", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(serviceSource, /\.netlify\/functions\/google-drive/);
+  assert.doesNotMatch(serviceSource, /getGoogleDriveAccessToken|openGooglePicker|setOAuthToken/);
+  assert.doesNotMatch(serviceSource, /VITE_GOOGLE_API_KEY|VITE_GOOGLE_CLIENT_ID/);
+  assert.doesNotMatch(serviceSource, /action=token/);
+});
+
+test("platform-admin company export excludes the OAuth credential table", async () => {
+  const adminSource = await readFile(
+    new URL("../../netlify/functions/admin.ts", import.meta.url),
+    "utf8",
+  );
+  const tableList = adminSource.match(
+    /const ORG_SCOPED_TABLES = \[([\s\S]*?)\] as const;/,
+  );
+
+  assert.ok(tableList);
+  assert.doesNotMatch(tableList[1], /organization_integrations/);
+});


### PR DESCRIPTION
## Summary
- retire both raw Google OAuth token routes and move Drive file listing behind an authenticated server proxy
- require exact organization membership for status/list and Owner/Admin for connect/disconnect
- replace forgeable base64 OAuth state with a hashed, single-use, 10-minute state
- revoke browser grants on OAuth credential/state tables
- remove OAuth credentials from platform-admin company exports
- replace the browser Google Picker token flow with an in-app metadata picker

## Security impact
No tenant role receives `access_token` or `refresh_token`. Google API requests use the credential only inside Netlify Functions. Cross-tenant requests are rejected before integration credentials are read, provider response bodies are not copied into responses/logs, and OAuth state cannot encode caller-controlled tenant/user IDs.

## Database migration
Apply `supabase/migrations/022_google_drive_token_isolation.sql` before testing connect on the deploy preview or publishing production. The migration preserves existing integrations; users do not need to reconnect.

## Verification
- `npm run test:security` - 61 passed
- `npx tsc --noEmit`
- `npm run build`
- `npx netlify functions:build --src netlify/functions --functions /private/tmp/aeternum-functions-156`
- Netlify Dev smoke test: root 200, unauthenticated `google-drive` request 401, both Google functions bundled

## Manual preview checks
- Owner/Admin sees Connect when Drive is disconnected; Manager/Consultant does not
- connected organization can search/select a Drive file and save it as evidence
- `google-callback?action=token` returns no OAuth credential
- platform-admin company export contains no `organization_integrations` data
- production OAuth connect is tested after publish against the registered production callback URI

Closes #156