### PR TITLE
[Security] Replace and isolate vulnerable spreadsheet parsing

### DIFF
--- a/components/CarbonDashboard.tsx
+++ b/components/CarbonDashboard.tsx
@@ -22,7 +22,6 @@ import {
   AreaChart, Area, XAxis, YAxis, CartesianGrid, Tooltip as RTooltip,
   ResponsiveContainer, BarChart, Bar, Legend, Cell,
 } from 'recharts';
-import * as XLSX from 'xlsx';
 import { EmissionSource, EmissionEntry } from '../types';
 import {
   fetchEmissionSources,
@@ -33,6 +32,7 @@ import {
   calculateEmissions,
   deleteEmissionSource,
 } from '../services/emissionFactorService';
+import { downloadSpreadsheet, parseSpreadsheetFile } from '../services/spreadsheetService';
 import EvidenceBadge from './EvidenceBadge';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -791,9 +791,11 @@ const BulkUploadModal: React.FC<{
   const fileRef = useRef<HTMLInputElement>(null);
   const [preview, setPreview] = useState<BulkRow[]>([]);
   const [uploading, setUploading] = useState(false);
+  const [parsingFile, setParsingFile] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
   const [result, setResult] = useState<{ success: number; failed: number } | null>(null);
 
-  const downloadTemplate = () => {
+  const downloadTemplate = async () => {
     const headers = [
       'Source Name',
       'Source ID',
@@ -822,49 +824,62 @@ const BulkUploadModal: React.FC<{
       ''
     ]);
     
-    const ws = XLSX.utils.aoa_to_sheet([headers, ...data]);
-    ws['!cols'] = [{ wch: 25 }, { wch: 36 }, { wch: 8 }, { wch: 8 }, { wch: 20 }, { wch: 20 }, { wch: 20 }, { wch: 22 }, { wch: 22 }, { wch: 16 }, { wch: 30 }];
-    const wb = XLSX.utils.book_new();
-    XLSX.utils.book_append_sheet(wb, ws, 'Emissions');
-    XLSX.writeFile(wb, `carbon-bulk-template-${new Date().toISOString().slice(0, 10)}.xlsx`);
+    try {
+      await downloadSpreadsheet(
+        `carbon-bulk-template-${new Date().toISOString().slice(0, 10)}.xlsx`,
+        [{
+          name: 'Emissions',
+          rows: [headers, ...data],
+          columnWidths: [25, 36, 8, 8, 20, 20, 20, 22, 22, 16, 30],
+        }],
+      );
+    } catch (e: any) {
+      setImportError(e?.message ?? 'Could not create the spreadsheet template.');
+    }
   };
 
   const handleFile = async (file: File) => {
-    const buf = await file.arrayBuffer();
-    let rawRows: Record<string, any>[];
-    const wb = XLSX.read(buf, { type: 'array' });
-    rawRows = XLSX.utils.sheet_to_json<Record<string, any>>(wb.Sheets[wb.SheetNames[0]]);
+    setParsingFile(true);
+    setImportError(null);
+    setPreview([]);
+    try {
+      const rawRows = await parseSpreadsheetFile(file);
 
-    const sourceById = Object.fromEntries(sources.map(s => [s.id, s]));
-    const sourceByName = Object.fromEntries(sources.map(s => [s.source_name.toLowerCase(), s]));
+      const sourceById = Object.fromEntries(sources.map(s => [s.id, s]));
+      const sourceByName = Object.fromEntries(sources.map(s => [s.source_name.toLowerCase(), s]));
 
-    const rows: BulkRow[] = rawRows.map(r => {
-      const srcId = String(r['Source ID'] ?? '').trim();
-      const srcName = String(r['Source Name'] ?? '').trim();
+      const rows: BulkRow[] = rawRows.map(r => {
+        const srcId = String(r['Source ID'] ?? '').trim();
+        const srcName = String(r['Source Name'] ?? '').trim();
       
-      let src;
-      if (srcId) {
-        src = sourceById[srcId];
-        if (!src) return { source_id: '', source_name: srcName, period_start: '', period_end: '', activity_data: 0, calculated_emissions_kgco2e: 0, notes: '', error: `Source with ID "${srcId}" not found` };
-      } else if (srcName) {
-        src = sourceByName[srcName.toLowerCase()];
-        if (!src) return { source_id: '', source_name: srcName, period_start: '', period_end: '', activity_data: 0, calculated_emissions_kgco2e: 0, notes: '', error: `Source with name "${srcName}" not found` };
-      } else {
-        return { source_id: '', source_name: '', period_start: '', period_end: '', activity_data: 0, calculated_emissions_kgco2e: 0, notes: '', error: 'Either Source ID or Source Name is required' };
-      }
+        let src;
+        if (srcId) {
+          src = sourceById[srcId];
+          if (!src) return { source_id: '', source_name: srcName, period_start: '', period_end: '', activity_data: 0, calculated_emissions_kgco2e: 0, notes: '', error: `Source with ID "${srcId}" not found` };
+        } else if (srcName) {
+          src = sourceByName[srcName.toLowerCase()];
+          if (!src) return { source_id: '', source_name: srcName, period_start: '', period_end: '', activity_data: 0, calculated_emissions_kgco2e: 0, notes: '', error: `Source with name "${srcName}" not found` };
+        } else {
+          return { source_id: '', source_name: '', period_start: '', period_end: '', activity_data: 0, calculated_emissions_kgco2e: 0, notes: '', error: 'Either Source ID or Source Name is required' };
+        }
 
-      const start = String(r['Period Start (YYYY-MM-DD)'] ?? '').trim();
-      const end   = String(r['Period End (YYYY-MM-DD)'] ?? '').trim();
-      const act   = Number(r['Activity Data'] ?? 0);
+        const start = String(r['Period Start (YYYY-MM-DD)'] ?? '').trim();
+        const end   = String(r['Period End (YYYY-MM-DD)'] ?? '').trim();
+        const act   = Number(r['Activity Data'] ?? 0);
 
-      if (!start || !end) return { source_id: src.id, source_name: src.source_name, period_start: start, period_end: end, activity_data: act, calculated_emissions_kgco2e: 0, notes: '', error: 'Period Start and Period End are required' };
-      if (!/^\d{4}-\d{2}-\d{2}$/.test(start) || !/^\d{4}-\d{2}-\d{2}$/.test(end)) return { source_id: src.id, source_name: src.source_name, period_start: start, period_end: end, activity_data: act, calculated_emissions_kgco2e: 0, notes: '', error: 'Date format must be YYYY-MM-DD' };
-      if (!act || act <= 0) return { source_id: src.id, source_name: src.source_name, period_start: start, period_end: end, activity_data: act, calculated_emissions_kgco2e: 0, notes: '', error: 'Activity Data must be a positive number' };
+        if (!start || !end) return { source_id: src.id, source_name: src.source_name, period_start: start, period_end: end, activity_data: act, calculated_emissions_kgco2e: 0, notes: '', error: 'Period Start and Period End are required' };
+        if (!/^\d{4}-\d{2}-\d{2}$/.test(start) || !/^\d{4}-\d{2}-\d{2}$/.test(end)) return { source_id: src.id, source_name: src.source_name, period_start: start, period_end: end, activity_data: act, calculated_emissions_kgco2e: 0, notes: '', error: 'Date format must be YYYY-MM-DD' };
+        if (!act || act <= 0) return { source_id: src.id, source_name: src.source_name, period_start: start, period_end: end, activity_data: act, calculated_emissions_kgco2e: 0, notes: '', error: 'Activity Data must be a positive number' };
 
-      const kgco2e = calculateEmissions(act, src.emission_factor_value ?? 0);
-      return { source_id: src.id, source_name: src.source_name, period_start: start, period_end: end, activity_data: act, calculated_emissions_kgco2e: kgco2e, notes: String(r['Notes'] ?? '').trim() };
-    });
-    setPreview(rows);
+        const kgco2e = calculateEmissions(act, src.emission_factor_value ?? 0);
+        return { source_id: src.id, source_name: src.source_name, period_start: start, period_end: end, activity_data: act, calculated_emissions_kgco2e: kgco2e, notes: String(r['Notes'] ?? '').trim() };
+      });
+      setPreview(rows);
+    } catch (e: any) {
+      setImportError(e?.message ?? 'Could not parse the spreadsheet.');
+    } finally {
+      setParsingFile(false);
+    }
   };
 
   const handleUpload = async () => {
@@ -912,17 +927,35 @@ const BulkUploadModal: React.FC<{
               <div className="flex items-center gap-3 p-4 bg-slate-50 dark:bg-slate-900/50 rounded-xl border border-slate-200 dark:border-slate-700">
                 <Download className="w-5 h-5 text-indigo-500 flex-shrink-0" />
                 <div className="flex-1 text-sm text-slate-600 dark:text-slate-300">Download the template with your sources pre-filled.</div>
-                <button onClick={downloadTemplate} className="flex-shrink-0 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium rounded-lg transition-colors">Download Template</button>
+                <button onClick={() => void downloadTemplate()} className="flex-shrink-0 px-4 py-2 bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium rounded-lg transition-colors">Download Template</button>
               </div>
 
+              {importError && (
+                <div className="flex items-start gap-2 rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700 dark:border-red-800 dark:bg-red-900/20 dark:text-red-300">
+                  <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
+                  <span>{importError}</span>
+                </div>
+              )}
+
               <div
-                className="border-2 border-dashed border-slate-300 dark:border-slate-600 rounded-xl p-8 text-center cursor-pointer hover:border-indigo-400 transition-colors"
-                onClick={() => fileRef.current?.click()}
+                className={`border-2 border-dashed border-slate-300 dark:border-slate-600 rounded-xl p-8 text-center transition-colors ${parsingFile ? 'cursor-wait opacity-60' : 'cursor-pointer hover:border-indigo-400'}`}
+                onClick={() => !parsingFile && fileRef.current?.click()}
               >
-                <Upload className="w-8 h-8 text-slate-400 mx-auto mb-2" />
-                <p className="text-sm text-slate-600 dark:text-slate-300 font-medium">Click to upload Excel or CSV</p>
-                <p className="text-xs text-slate-400 mt-1">.xlsx or .csv</p>
-                <input ref={fileRef} type="file" accept=".xlsx,.csv" className="hidden" onChange={e => e.target.files?.[0] && handleFile(e.target.files[0])} />
+                {parsingFile ? <Loader2 className="w-8 h-8 text-indigo-500 mx-auto mb-2 animate-spin" /> : <Upload className="w-8 h-8 text-slate-400 mx-auto mb-2" />}
+                <p className="text-sm text-slate-600 dark:text-slate-300 font-medium">{parsingFile ? 'Checking spreadsheet…' : 'Click to upload Excel or CSV'}</p>
+                <p className="text-xs text-slate-400 mt-1">.xlsx or .csv · maximum 2 MB and 1,000 rows</p>
+                <input
+                  ref={fileRef}
+                  type="file"
+                  accept=".xlsx,.csv"
+                  className="hidden"
+                  disabled={parsingFile}
+                  onChange={e => {
+                    const file = e.target.files?.[0];
+                    e.target.value = '';
+                    if (file) void handleFile(file);
+                  }}
+                />
               </div>
 
               {preview.length > 0 && (

--- a/components/TaskManagement.tsx
+++ b/components/TaskManagement.tsx
@@ -1,5 +1,4 @@
 import React, { useState, useEffect, useCallback, useRef } from 'react';
-import * as XLSX from 'xlsx';
 import {
   Task, SuggestedTask, TaskType, TaskStatus, TaskPriority,
   AssessmentData, KPI, SwotAnalysis, CompanyProfile, InsightHubResponse, OrgMember, QualityCheck,
@@ -10,6 +9,7 @@ import {
   restoreSuggestedTask, fetchDismissedSuggestedTasks,
 } from '../services/dbService';
 import { generateTasks } from '../services/geminiService';
+import { downloadSpreadsheet, parseSpreadsheetFile } from '../services/spreadsheetService';
 import EvidenceBadge from './EvidenceBadge';
 import {
   Sparkles, ListChecks, RefreshCw, CheckCircle2, Circle, Clock,
@@ -536,6 +536,7 @@ const ManagerTab: React.FC<ManagerProps> = ({
   const [noteDrafts, setNoteDrafts] = useState<Record<string, string>>({});
   // Import/export
   const [importing, setImporting] = useState(false);
+  const [exporting, setExporting] = useState(false);
   const [importResult, setImportResult] = useState<ImportResult | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -570,31 +571,29 @@ const ManagerTab: React.FC<ManagerProps> = ({
 
   // ── Export ──────────────────────────────────────────────────────────────────
 
-  const handleExport = () => {
-    const rows = tasks.map(t => ({
-      'Task ID': t.id,
-      'Title': t.title,
-      'Description': t.description ?? '',
-      'Type': t.type,
-      'Status': t.status,
-      'Priority': t.priority,
-      'Assignee Email': members.find(m => m.id === t.assignee_id)?.email ?? '',
-      'Due Date': t.due_date ?? '',
-      'ESRS Reference': t.esrs_ref ?? '',
-      'Source': t.source_type,
-      'Notes': t.notes ?? '',
-      'Created At': t.created_at.slice(0, 10),
-      'Completed At': t.completed_at?.slice(0, 10) ?? '',
-    }));
-
-    const ws = XLSX.utils.json_to_sheet(rows);
-    ws['!cols'] = [
-      { wch: 36 }, { wch: 40 }, { wch: 60 }, { wch: 10 }, { wch: 12 },
-      { wch: 10 }, { wch: 28 }, { wch: 12 }, { wch: 15 }, { wch: 12 },
-      { wch: 40 }, { wch: 12 }, { wch: 12 },
+  const handleExport = async () => {
+    const headers = [
+      'Task ID', 'Title', 'Description', 'Type', 'Status', 'Priority',
+      'Assignee Email', 'Due Date', 'ESRS Reference', 'Source', 'Notes',
+      'Created At', 'Completed At',
     ];
+    const rows = tasks.map(t => [
+      t.id,
+      t.title,
+      t.description ?? '',
+      t.type,
+      t.status,
+      t.priority,
+      members.find(m => m.id === t.assignee_id)?.email ?? '',
+      t.due_date ?? '',
+      t.esrs_ref ?? '',
+      t.source_type,
+      t.notes ?? '',
+      t.created_at.slice(0, 10),
+      t.completed_at?.slice(0, 10) ?? '',
+    ]);
 
-    const instructions = XLSX.utils.aoa_to_sheet([
+    const instructions = [
       ['AeternumAlly — Task Export/Import'],
       [''],
       ['HOW TO UPDATE TASKS:'],
@@ -609,14 +608,28 @@ const ManagerTab: React.FC<ManagerProps> = ({
       ['- Rows with a blank Task ID are skipped'],
       ['- Invalid rows are skipped and listed in the results summary'],
       ['- Completed At is set automatically when Status = done'],
-    ]);
-
-    const wb = XLSX.utils.book_new();
-    XLSX.utils.book_append_sheet(wb, ws, 'Tasks');
-    XLSX.utils.book_append_sheet(wb, instructions, 'Instructions');
+    ];
 
     const date = new Date().toISOString().slice(0, 10);
-    XLSX.writeFile(wb, `aeternumally-tasks-${date}.xlsx`);
+    setExporting(true);
+    try {
+      await downloadSpreadsheet(`aeternumally-tasks-${date}.xlsx`, [
+        {
+          name: 'Tasks',
+          rows: [headers, ...rows],
+          columnWidths: [36, 40, 60, 10, 12, 10, 28, 12, 15, 12, 40, 12, 12],
+        },
+        { name: 'Instructions', rows: instructions, columnWidths: [80] },
+      ]);
+    } catch (err: any) {
+      setImportResult({
+        success: 0,
+        failed: 0,
+        errors: [{ row: 0, taskId: '', error: err?.message ?? 'Export failed' }],
+      });
+    } finally {
+      setExporting(false);
+    }
   };
 
   // ── Import ──────────────────────────────────────────────────────────────────
@@ -787,12 +800,13 @@ const ManagerTab: React.FC<ManagerProps> = ({
         </div>
         <div className="flex-1" />
         <button
-          onClick={handleExport}
-          disabled={tasks.length === 0}
+          onClick={() => void handleExport()}
+          disabled={tasks.length === 0 || exporting}
           className="flex items-center gap-1.5 px-3 py-1.5 border border-slate-200 dark:border-slate-600 text-slate-600 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-700 disabled:opacity-40 text-sm font-medium rounded-lg transition-colors"
           title="Export tasks to Excel"
         >
-          <Download className="w-4 h-4" />Export
+          {exporting ? <Loader2 className="w-4 h-4 animate-spin" /> : <Download className="w-4 h-4" />}
+          Export
         </button>
         <button
           onClick={() => fileInputRef.current?.click()}
@@ -1029,30 +1043,7 @@ async function parseAndApplyImport(
   members: OrgMember[],
   orgId: string,
 ): Promise<ImportResult> {
-  const buffer = await file.arrayBuffer();
-  let rows: Record<string, any>[];
-
-  if (file.name.toLowerCase().endsWith('.csv')) {
-    const text = new TextDecoder().decode(buffer);
-    const lines = text.split(/\r?\n/).filter(l => l.trim());
-    if (lines.length < 2) throw new Error('CSV is empty');
-    const headers = lines[0].split(',').map(h => h.replace(/^"|"$/g, '').trim());
-    rows = lines.slice(1).map(line => {
-      // Simple CSV parse — handles quoted fields
-      const vals: string[] = [];
-      let cur = '', inQ = false;
-      for (const ch of line) {
-        if (ch === '"') { inQ = !inQ; }
-        else if (ch === ',' && !inQ) { vals.push(cur.trim()); cur = ''; }
-        else cur += ch;
-      }
-      vals.push(cur.trim());
-      return Object.fromEntries(headers.map((h, i) => [h, vals[i] ?? '']));
-    });
-  } else {
-    const wb = XLSX.read(buffer, { type: 'array' });
-    rows = XLSX.utils.sheet_to_json<Record<string, any>>(wb.Sheets[wb.SheetNames[0]]);
-  }
+  const rows = await parseSpreadsheetFile(file);
 
   const required = ['Task ID', 'Status'];
   const missing = required.filter(c => !Object.keys(rows[0] ?? {}).includes(c));

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,14 +12,17 @@
         "@netlify/blobs": "^10.7.13",
         "@supabase/supabase-js": "^2.45.0",
         "lucide-react": "^0.554.0",
+        "papaparse": "^5.6.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "read-excel-file": "^9.3.10",
         "recharts": "^3.4.1",
-        "xlsx": "^0.18.5"
+        "write-excel-file": "^4.1.1"
       },
       "devDependencies": {
         "@netlify/functions": "^3.0.0",
         "@types/node": "^22.14.0",
+        "@types/papaparse": "^5.5.2",
         "@vitejs/plugin-react": "^5.0.0",
         "netlify-cli": "^27.1.1",
         "typescript": "~5.8.2",
@@ -7453,6 +7456,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/papaparse": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.5.2.tgz",
+      "integrity": "sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/retry": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
@@ -7892,15 +7905,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/adler-32": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/adler-32/-/adler-32-1.3.1.tgz",
-      "integrity": "sha512-ynZ4w/nUUv5rrsR8UUGoe1VC9hZj6V5hU9Qw1HlMDJGEJw5S7TfTErWTjMys6M7vr0YWcPqs3qAr4ss0nDfP+A==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/agent-base": {
@@ -8833,19 +8837,6 @@
       ],
       "license": "CC-BY-4.0"
     },
-    "node_modules/cfb": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/cfb/-/cfb-1.2.2.tgz",
-      "integrity": "sha512-KfdUZsSOw19/ObEWasvBP/Ac4reZvAGauZhs6S/gqNhXhI7cKwvlH7ulj+dOEYnca4bm4SGo8C1bTAQvnTjgQA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "crc-32": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/chalk": {
       "version": "5.6.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.6.2.tgz",
@@ -9101,15 +9092,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/codepage": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/codepage/-/codepage-1.15.0.tgz",
-      "integrity": "sha512-3g6NUTPd/YtuuGrhMnOMRjFc+LJw/bnMp3+0r/Wcz3IXUuCosKRJvMphm5+Q+bvTVGcJJuRvVLuYba+WojaFaA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/color": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/color/-/color-5.0.3.tgz",
@@ -9359,6 +9341,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
       "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "crc32": "bin/crc32.njs"
@@ -11041,6 +11024,12 @@
         "node": "^12.20 || >= 14.13"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
+    },
     "node_modules/figures": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
@@ -11239,15 +11228,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
-      }
-    },
-    "node_modules/frac": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/frac/-/frac-1.1.2.tgz",
-      "integrity": "sha512-w/XBfkibaTl3YDqASwfDUqkna4Z2p9cFSr1aHDt0WoMTECnRfBOv2WArlZILlqgWlmdIlALXGpM2AOhEk5W3IA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/fresh": {
@@ -11654,7 +11634,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/h3": {
@@ -17141,6 +17120,12 @@
         "node-gyp-build-test": "build-test.js"
       }
     },
+    "node_modules/node-int64": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/node-int64/-/node-int64-0.4.0.tgz",
+      "integrity": "sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==",
+      "license": "MIT"
+    },
     "node_modules/node-mock-http": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/node-mock-http/-/node-mock-http-1.0.4.tgz",
@@ -17765,6 +17750,12 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "dev": true,
       "license": "BlueOak-1.0.0"
+    },
+    "node_modules/papaparse": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.6.0.tgz",
+      "integrity": "sha512-N2vuNQAYGK1/4vs6HJX86+VYU6OkiSTgdJz3JQfTk1y51cFCO/U8gnaeTF4iNE4r57Tt0sV47dUua1/19pxO6Q==",
+      "license": "MIT"
     },
     "node_modules/parse-duration": {
       "version": "2.1.6",
@@ -18584,6 +18575,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/read-excel-file": {
+      "version": "9.3.10",
+      "resolved": "https://registry.npmjs.org/read-excel-file/-/read-excel-file-9.3.10.tgz",
+      "integrity": "sha512-zFcBdzunLCGBmLRT4Q3mLPJnhKPAXXfGAZ83feODlEqX2aRUbgF1h/n2oY0UF7I8tVwnJNRas6fTRD5veDUs+g==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.8.3",
+        "saxen": "^11.1.0",
+        "unzipper-esm": "^0.13.3",
+        "worker-f": "^0.1.12"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/read-package-up": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/read-package-up/-/read-package-up-11.0.0.tgz",
@@ -19203,6 +19209,15 @@
         "node": ">=11.0.0"
       }
     },
+    "node_modules/saxen": {
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/saxen/-/saxen-11.1.1.tgz",
+      "integrity": "sha512-J4BkmJFaM7VgE7pgkFGsNEcqqM3h7+Mz80vfLWFhx7uNOCOXIu6LLjQHYWNejdst3pf/3JUaBIG9+pkk1umlow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20.12"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -19669,18 +19684,6 @@
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
-      }
-    },
-    "node_modules/ssf": {
-      "version": "0.11.2",
-      "resolved": "https://registry.npmjs.org/ssf/-/ssf-0.11.2.tgz",
-      "integrity": "sha512-+idbmIXoYET47hH+d7dfm2epdOMUDjqcB4648sTZ+t2JwoyBFL/insLfB/racrDmsKB3diwsDA696pZMieAC5g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "frac": "~1.1.2"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/stack-generator": {
@@ -20730,6 +20733,19 @@
         "untun": "dist/cli.mjs"
       }
     },
+    "node_modules/unzipper-esm": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/unzipper-esm/-/unzipper-esm-0.13.3.tgz",
+      "integrity": "sha512-LUO6VZ6fCzkDbdMev0/fOhoIeVGKaOkTIOoYxVLE0SQjfvmAHK+oywl7lfhloSZIsdGJ25mJ18Mtd9CyTASjrA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.2",
+        "node-int64": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
@@ -21185,22 +21201,13 @@
         "node": ">= 6"
       }
     },
-    "node_modules/wmf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/wmf/-/wmf-1.0.2.tgz",
-      "integrity": "sha512-/p9K7bEh0Dj6WbXg4JG0xvLQmIadrner1bi45VMJTfnbVHsc7yIajZyoSoK60/dtVBs12Fm6WkUI5/3WAVsNMw==",
-      "license": "Apache-2.0",
+    "node_modules/worker-f": {
+      "version": "0.1.20",
+      "resolved": "https://registry.npmjs.org/worker-f/-/worker-f-0.1.20.tgz",
+      "integrity": "sha512-7z5K5z4x++FykhpDTfriT/dOu7CmSap9BBv38DVFU3CD38obopq+DoFH75yBV3butpGm+OeqR9BKdSvYJSnUfQ==",
+      "license": "MIT",
       "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/word": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/word/-/word-0.3.0.tgz",
-      "integrity": "sha512-OELeY0Q61OXpdUfTp+oweA/vtLVg5VDOXh+3he3PNzLGG/y0oylSOC1xRVj0+l4vQ3tj/bB1HVHv1ocXkQceFA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=0.8"
+        "node": ">=12"
       }
     },
     "node_modules/wrap-ansi": {
@@ -21321,6 +21328,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/write-excel-file": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/write-excel-file/-/write-excel-file-4.1.1.tgz",
+      "integrity": "sha512-MUnCnNtQrcZek832ZcU24uU0rSphFmKPD1DvIjXOlygVb93CV7Tme6H3jUTkxsMmjB2W7HIzERzjqTi5kui71A==",
+      "license": "MIT",
+      "dependencies": {
+        "fflate": "^0.8.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/write-file-atomic": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-6.0.0.tgz",
@@ -21371,27 +21390,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/xlsx": {
-      "version": "0.18.5",
-      "resolved": "https://registry.npmjs.org/xlsx/-/xlsx-0.18.5.tgz",
-      "integrity": "sha512-dmg3LCjBPHZnQp5/F/+nnTa+miPJxUXB6vtk42YjBBKayDNagxGEeIdWApkYPOf3Z3pm3k62Knjzp7lMeTEtFQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "adler-32": "~1.3.0",
-        "cfb": "~1.2.1",
-        "codepage": "~1.15.0",
-        "crc-32": "~1.2.1",
-        "ssf": "~0.11.2",
-        "wmf": "~1.0.1",
-        "word": "~0.3.0"
-      },
-      "bin": {
-        "xlsx": "bin/xlsx.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
       }
     },
     "node_modules/xss": {

--- a/package.json
+++ b/package.json
@@ -15,14 +15,17 @@
     "@netlify/blobs": "^10.7.13",
     "@supabase/supabase-js": "^2.45.0",
     "lucide-react": "^0.554.0",
+    "papaparse": "^5.6.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "read-excel-file": "^9.3.10",
     "recharts": "^3.4.1",
-    "xlsx": "^0.18.5"
+    "write-excel-file": "^4.1.1"
   },
   "devDependencies": {
     "@netlify/functions": "^3.0.0",
     "@types/node": "^22.14.0",
+    "@types/papaparse": "^5.5.2",
     "@vitejs/plugin-react": "^5.0.0",
     "netlify-cli": "^27.1.1",
     "typescript": "~5.8.2",

--- a/services/spreadsheetImport.worker.ts
+++ b/services/spreadsheetImport.worker.ts
@@ -1,0 +1,25 @@
+/// <reference lib="webworker" />
+
+import readXlsxFile from 'read-excel-file/web-worker';
+import { spreadsheetLimitError } from './spreadsheetPolicy.ts';
+
+declare const self: DedicatedWorkerGlobalScope;
+
+self.onmessage = async (event: MessageEvent<{ buffer: ArrayBuffer }>) => {
+  try {
+    const sheets = await readXlsxFile(event.data.buffer);
+    const limitError = spreadsheetLimitError(sheets);
+    if (limitError) {
+      self.postMessage({ ok: false, error: limitError });
+      return;
+    }
+    self.postMessage({ ok: true, sheets });
+  } catch {
+    self.postMessage({
+      ok: false,
+      error: 'Spreadsheet is malformed or uses an unsupported format.',
+    });
+  }
+};
+
+export {};

--- a/services/spreadsheetPolicy.ts
+++ b/services/spreadsheetPolicy.ts
@@ -1,0 +1,32 @@
+export const SPREADSHEET_LIMITS = Object.freeze({
+  maxBytes: 2 * 1024 * 1024,
+  maxSheets: 2,
+  maxRows: 1_000,
+  maxColumns: 50,
+  maxCellCharacters: 10_000,
+  parseTimeoutMs: 8_000,
+});
+
+export interface ParsedSpreadsheetSheet {
+  sheet: string;
+  data: unknown[][];
+}
+
+export function spreadsheetLimitError(sheets: ParsedSpreadsheetSheet[]): string | null {
+  if (sheets.length === 0) return 'Spreadsheet contains no worksheets.';
+  if (sheets.length > SPREADSHEET_LIMITS.maxSheets) {
+    return `Spreadsheet exceeds the ${SPREADSHEET_LIMITS.maxSheets} sheet limit.`;
+  }
+  if (sheets.some(sheet => sheet.data.length - 1 > SPREADSHEET_LIMITS.maxRows)) {
+    return `Spreadsheet exceeds the ${SPREADSHEET_LIMITS.maxRows.toLocaleString()} row limit.`;
+  }
+  if (sheets.some(sheet => sheet.data.some(row => row.length > SPREADSHEET_LIMITS.maxColumns))) {
+    return `Spreadsheet exceeds the ${SPREADSHEET_LIMITS.maxColumns} column limit.`;
+  }
+  if (sheets.some(sheet => sheet.data.some(row => row.some(
+    value => typeof value === 'string' && value.length > SPREADSHEET_LIMITS.maxCellCharacters,
+  )))) {
+    return 'Spreadsheet contains a cell that is too long.';
+  }
+  return null;
+}

--- a/services/spreadsheetService.ts
+++ b/services/spreadsheetService.ts
@@ -1,0 +1,226 @@
+import Papa from 'papaparse';
+import writeXlsxFile, {
+  type Cell,
+  type Sheet,
+  type SheetData,
+} from 'write-excel-file/browser';
+import {
+  SPREADSHEET_LIMITS,
+  spreadsheetLimitError,
+  type ParsedSpreadsheetSheet,
+} from './spreadsheetPolicy.ts';
+
+export { SPREADSHEET_LIMITS } from './spreadsheetPolicy.ts';
+
+export type SpreadsheetCellValue = string | number | boolean | Date | null;
+export type SpreadsheetRow = SpreadsheetCellValue[];
+export type SpreadsheetRecord = Record<string, SpreadsheetCellValue>;
+
+export interface SpreadsheetFileMetadata {
+  name: string;
+  size: number;
+  type?: string;
+}
+
+export interface SpreadsheetExportSheet {
+  name: string;
+  rows: SpreadsheetRow[];
+  columnWidths?: number[];
+}
+
+type ParsedSheet = ParsedSpreadsheetSheet;
+
+type SpreadsheetWorkerResponse =
+  | { ok: true; sheets: ParsedSheet[] }
+  | { ok: false; error: string };
+
+const ALLOWED_MIME_TYPES: Record<'xlsx' | 'csv', Set<string>> = {
+  xlsx: new Set([
+    'application/octet-stream',
+    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    'application/zip',
+  ]),
+  csv: new Set([
+    'application/csv',
+    'application/octet-stream',
+    'application/vnd.ms-excel',
+    'text/csv',
+    'text/plain',
+  ]),
+};
+
+const DANGEROUS_HEADERS = new Set(['__proto__', 'constructor', 'prototype']);
+
+function extensionFor(name: string): 'xlsx' | 'csv' | null {
+  const normalized = name.trim().toLowerCase();
+  if (normalized.endsWith('.xlsx')) return 'xlsx';
+  if (normalized.endsWith('.csv')) return 'csv';
+  return null;
+}
+
+export function validateSpreadsheetFile(file: SpreadsheetFileMetadata): 'xlsx' | 'csv' {
+  const extension = extensionFor(file.name);
+  if (!extension) {
+    throw new Error('Only .xlsx and .csv files are supported.');
+  }
+  if (!Number.isSafeInteger(file.size) || file.size <= 0) {
+    throw new Error('The selected spreadsheet is empty or invalid.');
+  }
+  if (file.size > SPREADSHEET_LIMITS.maxBytes) {
+    throw new Error('Spreadsheet files must be 2 MB or smaller.');
+  }
+
+  const mimeType = file.type?.trim().toLowerCase();
+  if (mimeType && !ALLOWED_MIME_TYPES[extension].has(mimeType)) {
+    throw new Error(`The selected file type does not match a .${extension} spreadsheet.`);
+  }
+  return extension;
+}
+
+function normalizeCell(value: unknown): SpreadsheetCellValue {
+  if (value == null) return null;
+  if (value instanceof Date) {
+    if (Number.isNaN(value.getTime())) throw new Error('Spreadsheet contains an invalid date.');
+    return value.toISOString().slice(0, 10);
+  }
+  if (typeof value === 'string') {
+    if (value.length > SPREADSHEET_LIMITS.maxCellCharacters) {
+      throw new Error('Spreadsheet contains a cell that is too long.');
+    }
+    return value;
+  }
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new Error('Spreadsheet contains an invalid number.');
+    return value;
+  }
+  if (typeof value === 'boolean') return value;
+  throw new Error('Spreadsheet contains an unsupported cell value.');
+}
+
+function hasValue(row: SpreadsheetRow): boolean {
+  return row.some(value => value !== null && String(value).trim() !== '');
+}
+
+function normalizeRows(rows: unknown[][]): SpreadsheetRow[] {
+  return rows
+    .map(row => row.map(normalizeCell))
+    .filter(hasValue);
+}
+
+export function spreadsheetRowsToRecords(inputRows: unknown[][]): SpreadsheetRecord[] {
+  const rows = normalizeRows(inputRows);
+  if (rows.length < 2) throw new Error('Spreadsheet is empty.');
+  if (rows.length - 1 > SPREADSHEET_LIMITS.maxRows) {
+    throw new Error(`Spreadsheet exceeds the ${SPREADSHEET_LIMITS.maxRows.toLocaleString()} row limit.`);
+  }
+
+  const headerRow = rows[0];
+  if (headerRow.length === 0 || headerRow.length > SPREADSHEET_LIMITS.maxColumns) {
+    throw new Error(`Spreadsheet must contain between 1 and ${SPREADSHEET_LIMITS.maxColumns} columns.`);
+  }
+
+  const headers = headerRow.map(value => String(value ?? '').trim());
+  if (headers.some(header => !header)) throw new Error('Spreadsheet contains a blank column header.');
+
+  const normalizedHeaders = headers.map(header => header.toLowerCase());
+  if (new Set(normalizedHeaders).size !== normalizedHeaders.length) {
+    throw new Error('Spreadsheet contains duplicate column headers.');
+  }
+  if (normalizedHeaders.some(header => DANGEROUS_HEADERS.has(header))) {
+    throw new Error('Spreadsheet contains a reserved column header.');
+  }
+
+  return rows.slice(1).map(row => {
+    if (row.length > SPREADSHEET_LIMITS.maxColumns) {
+      throw new Error(`Spreadsheet exceeds the ${SPREADSHEET_LIMITS.maxColumns} column limit.`);
+    }
+    const record = Object.create(null) as SpreadsheetRecord;
+    headers.forEach((header, index) => {
+      record[header] = row[index] ?? null;
+    });
+    return record;
+  });
+}
+
+export function parseCsvText(text: string): SpreadsheetRecord[] {
+  const result = Papa.parse<unknown[]>(text, {
+    delimiter: ',',
+    skipEmptyLines: 'greedy',
+  });
+  if (result.errors.length > 0) {
+    throw new Error(`CSV could not be parsed: ${result.errors[0].message}`);
+  }
+  return spreadsheetRowsToRecords(result.data);
+}
+
+export function spreadsheetSheetsToRecords(sheets: ParsedSheet[]): SpreadsheetRecord[] {
+  const limitError = spreadsheetLimitError(sheets);
+  if (limitError) throw new Error(limitError);
+  return spreadsheetRowsToRecords(sheets[0].data);
+}
+
+function parseXlsxInWorker(buffer: ArrayBuffer): Promise<ParsedSheet[]> {
+  return new Promise((resolve, reject) => {
+    const worker = new Worker(
+      new URL('./spreadsheetImport.worker.ts', import.meta.url),
+      { type: 'module' },
+    );
+    const timer = window.setTimeout(() => {
+      worker.terminate();
+      reject(new Error('Spreadsheet parsing timed out. Try a smaller file.'));
+    }, SPREADSHEET_LIMITS.parseTimeoutMs);
+
+    const cleanup = () => {
+      window.clearTimeout(timer);
+      worker.terminate();
+    };
+
+    worker.onmessage = (event: MessageEvent<SpreadsheetWorkerResponse>) => {
+      cleanup();
+      const response = event.data;
+      if (response.ok === true) resolve(response.sheets);
+      else reject(new Error(response.error));
+    };
+    worker.onerror = () => {
+      cleanup();
+      reject(new Error('Spreadsheet could not be parsed safely.'));
+    };
+    worker.postMessage({ buffer }, [buffer]);
+  });
+}
+
+export async function parseSpreadsheetFile(file: File): Promise<SpreadsheetRecord[]> {
+  const extension = validateSpreadsheetFile(file);
+  const buffer = await file.arrayBuffer();
+  if (extension === 'csv') {
+    return parseCsvText(new TextDecoder('utf-8', { fatal: true }).decode(buffer));
+  }
+
+  const sheets = await parseXlsxInWorker(buffer);
+  return spreadsheetSheetsToRecords(sheets);
+}
+
+function exportCell(value: SpreadsheetCellValue): Cell {
+  if (typeof value === 'string') return { value, type: String };
+  return value;
+}
+
+export async function downloadSpreadsheet(
+  fileName: string,
+  sheets: SpreadsheetExportSheet[],
+): Promise<void> {
+  if (!fileName.toLowerCase().endsWith('.xlsx')) {
+    throw new Error('Spreadsheet exports must use an .xlsx file name.');
+  }
+  if (sheets.length === 0 || sheets.length > SPREADSHEET_LIMITS.maxSheets) {
+    throw new Error(`Spreadsheet exports must contain 1 to ${SPREADSHEET_LIMITS.maxSheets} sheets.`);
+  }
+
+  const output: Sheet<File>[] = sheets.map(sheet => ({
+    sheet: sheet.name,
+    data: sheet.rows.map(row => row.map(exportCell)) as SheetData,
+    columns: sheet.columnWidths?.map(width => ({ width })),
+    stickyRowsCount: 1,
+  }));
+  await writeXlsxFile(output).toFile(fileName);
+}

--- a/tests/security/spreadsheet-import-security.test.mjs
+++ b/tests/security/spreadsheet-import-security.test.mjs
@@ -1,0 +1,209 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import readXlsxFile from "read-excel-file/node";
+import writeXlsxFile from "write-excel-file/node";
+
+import {
+  SPREADSHEET_LIMITS,
+  parseCsvText,
+  parseSpreadsheetFile,
+  spreadsheetRowsToRecords,
+  spreadsheetSheetsToRecords,
+  validateSpreadsheetFile,
+} from "../../services/spreadsheetService.ts";
+
+const XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+
+test("spreadsheet metadata validation rejects unsupported, empty, oversized, and mismatched files", () => {
+  assert.throws(
+    () => validateSpreadsheetFile({ name: "tasks.xls", size: 100, type: "application/vnd.ms-excel" }),
+    /Only \.xlsx and \.csv/,
+  );
+  assert.throws(
+    () => validateSpreadsheetFile({ name: "tasks.xlsx", size: 0, type: XLSX_MIME }),
+    /empty or invalid/,
+  );
+  assert.throws(
+    () => validateSpreadsheetFile({
+      name: "tasks.xlsx",
+      size: SPREADSHEET_LIMITS.maxBytes + 1,
+      type: XLSX_MIME,
+    }),
+    /2 MB or smaller/,
+  );
+  assert.throws(
+    () => validateSpreadsheetFile({ name: "tasks.xlsx", size: 100, type: "text/csv" }),
+    /does not match/,
+  );
+});
+
+test("oversized files are rejected before arrayBuffer reads untrusted bytes", async () => {
+  let arrayBufferCalls = 0;
+  const oversizedFile = {
+    name: "oversized.xlsx",
+    size: SPREADSHEET_LIMITS.maxBytes + 1,
+    type: XLSX_MIME,
+    async arrayBuffer() {
+      arrayBufferCalls++;
+      return new ArrayBuffer(0);
+    },
+  };
+
+  await assert.rejects(
+    parseSpreadsheetFile(oversizedFile),
+    /2 MB or smaller/,
+  );
+  assert.equal(arrayBufferCalls, 0);
+});
+
+test("spreadsheet records reject empty, excessive, duplicate, and prototype-sensitive input", () => {
+  assert.throws(() => spreadsheetRowsToRecords([]), /empty/);
+  assert.throws(
+    () => spreadsheetRowsToRecords([["A", "a"], ["1", "2"]]),
+    /duplicate column headers/,
+  );
+  assert.throws(
+    () => spreadsheetRowsToRecords([["__proto__"], ["polluted"]]),
+    /reserved column header/,
+  );
+  assert.throws(
+    () => spreadsheetRowsToRecords([
+      ["Task ID"],
+      ...Array.from({ length: SPREADSHEET_LIMITS.maxRows + 1 }, (_, index) => [String(index)]),
+    ]),
+    /row limit/,
+  );
+  assert.throws(
+    () => spreadsheetRowsToRecords([
+      Array.from({ length: SPREADSHEET_LIMITS.maxColumns + 1 }, (_, index) => `Column ${index}`),
+      ["value"],
+    ]),
+    /columns/,
+  );
+  assert.equal(Object.prototype.polluted, undefined);
+});
+
+test("record conversion uses null-prototype objects and normalizes spreadsheet dates", () => {
+  const records = spreadsheetRowsToRecords([
+    ["Task ID", "Due Date", "Notes"],
+    ["task-1", new Date("2026-08-18T00:00:00.000Z"), "line one"],
+  ]);
+
+  assert.equal(Object.getPrototypeOf(records[0]), null);
+  assert.deepEqual({ ...records[0] }, {
+    "Task ID": "task-1",
+    "Due Date": "2026-08-18",
+    Notes: "line one",
+  });
+});
+
+test("workbook validation enforces sheet count before records are returned", () => {
+  const validSheet = { sheet: "Tasks", data: [["Task ID"], ["task-1"]] };
+  assert.equal(spreadsheetSheetsToRecords([validSheet]).length, 1);
+  assert.throws(
+    () => spreadsheetSheetsToRecords([validSheet, validSheet, validSheet]),
+    /sheet limit/,
+  );
+  assert.throws(
+    () => spreadsheetSheetsToRecords([{
+      sheet: "Tasks",
+      data: [["Task ID"], ["x".repeat(SPREADSHEET_LIMITS.maxCellCharacters + 1)]],
+    }]),
+    /cell that is too long/,
+  );
+});
+
+test("CSV parser handles quoted commas and newlines without ad hoc splitting", () => {
+  const records = parseCsvText([
+    "Task ID,Status,Notes",
+    'task-1,todo,"First line, with comma',
+    'and a second line"',
+  ].join("\n"));
+
+  assert.equal(records.length, 1);
+  assert.equal(records[0]["Task ID"], "task-1");
+  assert.equal(records[0].Notes, "First line, with comma\nand a second line");
+});
+
+test("replacement XLSX libraries preserve Carbon and Task export/import contracts", async () => {
+  const taskWorkbook = await writeXlsxFile([
+    {
+      sheet: "Tasks",
+      data: [
+        ["Task ID", "Status", "Notes"],
+        ["task-1", "in_progress", "Quarterly evidence"],
+      ],
+    },
+    {
+      sheet: "Instructions",
+      data: [["AeternumAlly Task Export/Import"]],
+    },
+  ]).toBuffer();
+
+  const taskSheets = await readXlsxFile(taskWorkbook);
+  const taskRecords = spreadsheetSheetsToRecords(taskSheets);
+  assert.equal(taskSheets.length, 2);
+  assert.equal(taskSheets[0].sheet, "Tasks");
+  assert.deepEqual({ ...taskRecords[0] }, {
+    "Task ID": "task-1",
+    Status: "in_progress",
+    Notes: "Quarterly evidence",
+  });
+
+  const carbonWorkbook = await writeXlsxFile([{
+    sheet: "Emissions",
+    data: [
+      ["Source Name", "Source ID", "Period Start (YYYY-MM-DD)", "Period End (YYYY-MM-DD)", "Activity Data", "Notes"],
+      ["Grid electricity", "source-1", "2026-01-01", "2026-01-31", 250, "January bill"],
+    ],
+  }]).toBuffer();
+  const carbonRecords = spreadsheetSheetsToRecords(await readXlsxFile(carbonWorkbook));
+  assert.deepEqual({ ...carbonRecords[0] }, {
+    "Source Name": "Grid electricity",
+    "Source ID": "source-1",
+    "Period Start (YYYY-MM-DD)": "2026-01-01",
+    "Period End (YYYY-MM-DD)": "2026-01-31",
+    "Activity Data": 250,
+    Notes: "January bill",
+  });
+});
+
+test("malformed XLSX input rejects without exposing parser internals", async () => {
+  await assert.rejects(
+    readXlsxFile(Buffer.from("not-an-xlsx")),
+  );
+});
+
+test("runtime source and dependency manifest no longer use vulnerable SheetJS xlsx", async () => {
+  const [carbonSource, taskSource, workerSource, packageSource, lockSource] = await Promise.all([
+    readFile(new URL("../../components/CarbonDashboard.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../../components/TaskManagement.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../../services/spreadsheetImport.worker.ts", import.meta.url), "utf8"),
+    readFile(new URL("../../package.json", import.meta.url), "utf8"),
+    readFile(new URL("../../package-lock.json", import.meta.url), "utf8"),
+  ]);
+  const packageJson = JSON.parse(packageSource);
+  const packageLock = JSON.parse(lockSource);
+
+  assert.match(carbonSource, /parseSpreadsheetFile\(file\)/);
+  assert.match(taskSource, /parseSpreadsheetFile\(file\)/);
+  assert.match(workerSource, /read-excel-file\/web-worker/);
+  assert.doesNotMatch(`${carbonSource}\n${taskSource}`, /from ['"]xlsx['"]|XLSX\./);
+  assert.equal(packageJson.dependencies.xlsx, undefined);
+  assert.equal(packageLock.packages["node_modules/xlsx"], undefined);
+});
+
+test("spreadsheet rejection occurs before task import database writes", async () => {
+  const taskSource = await readFile(
+    new URL("../../components/TaskManagement.tsx", import.meta.url),
+    "utf8",
+  );
+  const helper = taskSource.match(
+    /async function parseAndApplyImport[\s\S]+?return result;\n}/,
+  );
+
+  assert.ok(helper);
+  assert.ok(helper[0].indexOf("parseSpreadsheetFile(file)") < helper[0].indexOf("upsertTask(orgId"));
+});


### PR DESCRIPTION
## Summary
- replace the vulnerable direct `xlsx` dependency with maintained read/write libraries and Papa Parse
- reject unsupported, empty, mismatched, or over-2-MB files before reading their bytes
- enforce 2-sheet, 1,000-row, 50-column, and 10,000-character cell limits
- parse XLSX files in a dedicated Web Worker with an 8-second timeout and controlled errors
- reject duplicate and prototype-sensitive headers and build imported records with null prototypes
- preserve Carbon template and Task two-sheet export/import behavior

## Security impact
This removes the unpatched SheetJS dependency behind Dependabot alerts #59 and #60. Malicious workbooks are isolated from the UI thread, bounded before database writes, and rejected without parser internals.

## Verification
- `npm ci`
- `npm run test:security` (74 passed)
- `npx tsc --noEmit`
- `npm run build`
- `npm audit --omit=dev --json` (0 production vulnerabilities)
- production build emits a separate `spreadsheetImport.worker` chunk

## Deploy Preview checks
- Carbon: download a template, upload a valid edited copy, and confirm the preview before writing
- Task Management: export tasks, import an allowed update, and confirm the update
- both paths: reject an oversized, malformed, or unsupported file with no writes

Closes #151
