### PR TITLE
fix(security): validate external evidence URLs

### DIFF
--- a/components/EvidenceBadge.tsx
+++ b/components/EvidenceBadge.tsx
@@ -35,6 +35,12 @@ import {
   mimeToExtension,
   type DriveFile,
 } from '../services/googleDriveService';
+import {
+  canAutoLoadEvidencePreview,
+  getSafeEvidenceUrl,
+  normalizeEvidenceUrl,
+  type ExternalEvidenceStorageType,
+} from '../services/evidenceUrlSecurity';
 import { supabase } from '../lib/supabaseClient';
 import { EvidenceAttachment, EvidenceLinkedToType, StorageType } from '../types';
 
@@ -477,7 +483,31 @@ const EvidenceItem: React.FC<{
   const ext = (item.file_type ?? '').toLowerCase();
   const isImage = IMAGE_EXTS.has(ext);
   const isPdf   = ext === 'pdf';
-  const previewUrl = item.external_url ?? null;
+  const isExternal = !['supabase_storage', 's3'].includes(item.storage_type);
+  const safeExternalUrl = isExternal
+    ? getSafeEvidenceUrl(
+        item.external_url,
+        item.storage_type as ExternalEvidenceStorageType,
+      )
+    : null;
+  const previewUrl = safeExternalUrl
+    && canAutoLoadEvidencePreview(item.storage_type as ExternalEvidenceStorageType)
+    ? safeExternalUrl
+    : null;
+  const openUrl = safeExternalUrl
+    ?? (item.storage_path ? `/.netlify/functions/evidence/download/${item.id}` : null);
+  const blockedExternalUrl = Boolean(item.external_url) && !safeExternalUrl;
+
+  const handleOpen = (event: React.MouseEvent<HTMLAnchorElement>) => {
+    event.stopPropagation();
+    if (
+      item.storage_type === 'url'
+      && safeExternalUrl
+      && !window.confirm(`Open external website ${new URL(safeExternalUrl).hostname}?`)
+    ) {
+      event.preventDefault();
+    }
+  };
 
   return (
     <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/40 overflow-hidden group">
@@ -503,7 +533,7 @@ const EvidenceItem: React.FC<{
             target="_blank"
             rel="noopener noreferrer"
             className="ml-auto text-xs text-red-500 hover:underline"
-            onClick={e => e.stopPropagation()}
+            onClick={handleOpen}
           >
             Open ↗
           </a>
@@ -527,17 +557,22 @@ const EvidenceItem: React.FC<{
           {item.notes && (
             <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5 line-clamp-2 italic">{item.notes}</p>
           )}
+          {blockedExternalUrl && (
+            <p className="text-xs text-red-600 dark:text-red-400 mt-1">
+              Unsafe or invalid external link blocked
+            </p>
+          )}
           <p className="text-xs text-slate-400 mt-0.5">Added {fmtDate(item.uploaded_at)}</p>
         </div>
         <div className="flex-shrink-0 flex items-center gap-1 opacity-0 group-hover:opacity-100 transition-opacity">
-          {(item.external_url || item.storage_path) && (
+          {openUrl && (
             <a
-              href={item.external_url ?? `/.netlify/functions/evidence/download/${item.id}`}
+              href={openUrl}
               target="_blank"
               rel="noopener noreferrer"
               className="p-1.5 rounded hover:bg-slate-200 dark:hover:bg-slate-700 text-slate-400 hover:text-blue-500 transition-colors"
               title="Open file"
-              onClick={e => e.stopPropagation()}
+              onClick={handleOpen}
             >
               <ExternalLink className="w-3.5 h-3.5" />
             </a>
@@ -599,16 +634,30 @@ const URLForm: React.FC<{
   const [fileType, setFileType] = useState('');
   const [notes,    setNotes]    = useState('');
   const [saving,   setSaving]   = useState(false);
+  const [urlError, setUrlError] = useState<string | null>(null);
+
+  const validateUrl = (): string | null => {
+    try {
+      const normalized = normalizeEvidenceUrl(url, 'url');
+      setUrlError(null);
+      return normalized;
+    } catch (e: any) {
+      setUrlError(e?.message ?? 'Enter a valid HTTPS URL.');
+      return null;
+    }
+  };
 
   const handleSave = async () => {
     if (!url.trim() || !name.trim()) return;
+    const normalizedUrl = validateUrl();
+    if (!normalizedUrl) return;
     setSaving(true);
     try {
       await linkExternalEvidence(orgId, {
         file_name:      name.trim(),
         file_type:      fileType.trim() || undefined,
         storage_type:   'url',
-        external_url:   url.trim(),
+        external_url:   normalizedUrl,
         linked_to_type: linkedToType,
         linked_to_id:   linkedToId,
         notes:          notes.trim() || undefined,
@@ -627,10 +676,18 @@ const URLForm: React.FC<{
         <input
           type="url"
           value={url}
-          onChange={e => setUrl(e.target.value)}
+          onChange={e => { setUrl(e.target.value); setUrlError(null); }}
+          onBlur={() => { if (url.trim()) validateUrl(); }}
           placeholder="https://docs.google.com/…"
+          aria-invalid={urlError ? 'true' : 'false'}
+          aria-describedby={urlError ? 'evidence-url-error' : undefined}
           className="w-full px-3 py-2 rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-700 text-slate-800 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
         />
+        {urlError && (
+          <p id="evidence-url-error" className="mt-1 text-xs text-red-600 dark:text-red-400">
+            {urlError}
+          </p>
+        )}
       </FormField>
       <FormField label="File / Link name *">
         <input
@@ -659,7 +716,7 @@ const URLForm: React.FC<{
       </FormField>
       <button
         onClick={handleSave}
-        disabled={!url.trim() || !name.trim() || saving}
+        disabled={!url.trim() || !name.trim() || Boolean(urlError) || saving}
         className="w-full py-2 bg-blue-600 text-white rounded-lg text-sm font-medium hover:bg-blue-700 transition-colors disabled:opacity-50 flex items-center justify-center gap-2"
       >
         {saving && <Loader2 className="w-4 h-4 animate-spin" />}

--- a/services/evidenceService.ts
+++ b/services/evidenceService.ts
@@ -17,6 +17,10 @@ import {
   EvidenceLinkedToType,
   StorageType,
 } from '../types';
+import {
+  normalizeEvidenceUrl,
+  type ExternalEvidenceStorageType,
+} from './evidenceUrlSecurity';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // DB ↔ TS mapping
@@ -108,8 +112,8 @@ export interface LinkEvidencePayload {
   file_name:      string;
   file_type?:     string;
   file_size_mb?:  number;
-  storage_type:   Exclude<StorageType, 'supabase_storage' | 's3'>;
-  external_url?:  string;
+  storage_type:   ExternalEvidenceStorageType;
+  external_url:   string;
   external_id?:   string;   // cloud provider file ID (Drive ID, OneDrive item ID…)
   linked_to_type: EvidenceLinkedToType;
   linked_to_id:   string;
@@ -122,6 +126,11 @@ export async function linkExternalEvidence(
   payload: LinkEvidencePayload,
   userId: string,
 ): Promise<EvidenceAttachment> {
+  const externalUrl = normalizeEvidenceUrl(
+    payload.external_url,
+    payload.storage_type,
+  );
+
   const { data, error } = await supabase
     .from('evidence_attachments')
     .insert({
@@ -130,7 +139,7 @@ export async function linkExternalEvidence(
       file_type:       payload.file_type    ?? null,
       file_size_mb:    payload.file_size_mb ?? null,
       storage_type:    payload.storage_type,
-      external_url:    payload.external_url ?? null,
+      external_url:    externalUrl,
       external_id:     payload.external_id  ?? null,
       storage_path:    null,
       linked_to_type:  payload.linked_to_type,

--- a/services/evidenceUrlSecurity.ts
+++ b/services/evidenceUrlSecurity.ts
@@ -1,0 +1,138 @@
+import type { StorageType } from '../types';
+
+export type ExternalEvidenceStorageType = Exclude<
+  StorageType,
+  'supabase_storage' | 's3'
+>;
+
+export const MAX_EVIDENCE_URL_LENGTH = 2048;
+
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/;
+
+function isSameOrSubdomain(hostname: string, domain: string): boolean {
+  return hostname === domain || hostname.endsWith(`.${domain}`);
+}
+
+function isPrivateIpv4(hostname: string): boolean {
+  const octets = hostname.split('.').map(Number);
+  if (
+    octets.length !== 4
+    || octets.some(octet => !Number.isInteger(octet) || octet < 0 || octet > 255)
+  ) {
+    return false;
+  }
+
+  const [first, second, third] = octets;
+  return first === 0
+    || first === 10
+    || first === 127
+    || (first === 100 && second >= 64 && second <= 127)
+    || (first === 169 && second === 254)
+    || (first === 172 && second >= 16 && second <= 31)
+    || (first === 192 && second === 0 && third === 0)
+    || (first === 192 && second === 0 && third === 2)
+    || (first === 192 && second === 168)
+    || (first === 198 && (second === 18 || second === 19))
+    || (first === 198 && second === 51 && third === 100)
+    || (first === 203 && second === 0 && third === 113)
+    || first >= 224;
+}
+
+function isPrivateIpv6(hostname: string): boolean {
+  const address = hostname.replace(/^\[|\]$/g, '').toLowerCase();
+  return address === '::'
+    || address === '::1'
+    || address === '0:0:0:0:0:0:0:1'
+    || address.startsWith('fc')
+    || address.startsWith('fd')
+    || /^fe[89ab]/.test(address)
+    || address.startsWith('::ffff:');
+}
+
+function isLocalOrPrivateHost(hostname: string): boolean {
+  return hostname === 'localhost'
+    || hostname.endsWith('.localhost')
+    || hostname.endsWith('.local')
+    || hostname.endsWith('.internal')
+    || isPrivateIpv4(hostname)
+    || (hostname.includes(':') && isPrivateIpv6(hostname));
+}
+
+function isAllowedProviderHost(
+  storageType: ExternalEvidenceStorageType,
+  hostname: string,
+): boolean {
+  switch (storageType) {
+    case 'google_drive':
+      return hostname === 'drive.google.com' || hostname === 'docs.google.com';
+    case 'onedrive':
+      return hostname === '1drv.ms'
+        || hostname === 'onedrive.live.com'
+        || isSameOrSubdomain(hostname, 'sharepoint.com');
+    case 'dropbox':
+      return isSameOrSubdomain(hostname, 'dropbox.com')
+        || isSameOrSubdomain(hostname, 'dropboxusercontent.com');
+    case 'url':
+      return true;
+  }
+}
+
+/** Validate and canonicalize an external evidence URL before it is stored. */
+export function normalizeEvidenceUrl(
+  value: string,
+  storageType: ExternalEvidenceStorageType,
+): string {
+  const trimmed = typeof value === 'string' ? value.trim() : '';
+  if (
+    trimmed.length === 0
+    || trimmed.length > MAX_EVIDENCE_URL_LENGTH
+    || CONTROL_CHARACTERS.test(trimmed)
+  ) {
+    throw new Error('Enter a valid HTTPS URL.');
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw new Error('Enter a valid HTTPS URL.');
+  }
+
+  if (parsed.protocol !== 'https:' || !parsed.hostname) {
+    throw new Error('Evidence links must use HTTPS.');
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error('URLs containing usernames or passwords are not allowed.');
+  }
+
+  const hostname = parsed.hostname.toLowerCase().replace(/\.$/, '');
+  if (isLocalOrPrivateHost(hostname)) {
+    throw new Error('Local or private network URLs are not allowed.');
+  }
+  if (!isAllowedProviderHost(storageType, hostname)) {
+    throw new Error('The URL is not hosted by the selected provider.');
+  }
+
+  if (parsed.hostname.endsWith('.')) parsed.hostname = hostname;
+  return parsed.href;
+}
+
+/** Return only a URL that is safe to place in href/src. */
+export function getSafeEvidenceUrl(
+  value: string | null | undefined,
+  storageType: ExternalEvidenceStorageType,
+): string | null {
+  if (!value) return null;
+  try {
+    return normalizeEvidenceUrl(value, storageType);
+  } catch {
+    return null;
+  }
+}
+
+/** Generic URLs are never fetched automatically as image previews. */
+export function canAutoLoadEvidencePreview(
+  storageType: ExternalEvidenceStorageType,
+): boolean {
+  return storageType !== 'url';
+}

--- a/supabase/migrations/023_validate_evidence_external_urls.sql
+++ b/supabase/migrations/023_validate_evidence_external_urls.sql
@@ -1,0 +1,18 @@
+-- Issue #157: prevent new unsafe external evidence URLs at the database boundary.
+-- NOT VALID preserves legacy rows while enforcing the constraint for new writes.
+
+ALTER TABLE evidence_attachments
+  ADD CONSTRAINT evidence_external_url_https
+  CHECK (
+    external_url IS NULL
+    OR (
+      char_length(external_url) BETWEEN 1 AND 2048
+      AND external_url = btrim(external_url)
+      AND external_url ~* '^https://[^/?#[:space:]]+'
+      AND external_url !~ '[[:space:][:cntrl:]]'
+      AND external_url !~* '^https://[^/?#]*@'
+    )
+  ) NOT VALID;
+
+COMMENT ON CONSTRAINT evidence_external_url_https ON evidence_attachments IS
+  'New external evidence URLs must be credential-free HTTPS URLs; application validation additionally enforces provider and public-host rules.';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -579,7 +579,17 @@ CREATE TABLE evidence_attachments (
                       'google_drive', 'onedrive', 'dropbox', 'url',
                       'supabase_storage', 's3'
                     )),
-  external_url    text,
+  external_url    text
+                    CONSTRAINT evidence_external_url_https CHECK (
+                      external_url IS NULL
+                      OR (
+                        char_length(external_url) BETWEEN 1 AND 2048
+                        AND external_url = btrim(external_url)
+                        AND external_url ~* '^https://[^/?#[:space:]]+'
+                        AND external_url !~ '[[:space:][:cntrl:]]'
+                        AND external_url !~* '^https://[^/?#]*@'
+                      )
+                    ),
   external_id     text,
   storage_path    text,
   linked_to_type  text NOT NULL

--- a/tests/security/evidence-url-security.test.mjs
+++ b/tests/security/evidence-url-security.test.mjs
@@ -1,0 +1,108 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+import {
+  MAX_EVIDENCE_URL_LENGTH,
+  canAutoLoadEvidencePreview,
+  getSafeEvidenceUrl,
+  normalizeEvidenceUrl,
+} from '../../services/evidenceUrlSecurity.ts';
+
+test('evidence URLs accept and canonicalize public HTTPS destinations', () => {
+  assert.equal(
+    normalizeEvidenceUrl(' HTTPS://Example.COM/report.pdf ', 'url'),
+    'https://example.com/report.pdf',
+  );
+  assert.equal(
+    normalizeEvidenceUrl('https://drive.google.com./open?id=file-1', 'google_drive'),
+    'https://drive.google.com/open?id=file-1',
+  );
+  assert.equal(
+    normalizeEvidenceUrl('https://tenant.sharepoint.com/report', 'onedrive'),
+    'https://tenant.sharepoint.com/report',
+  );
+  assert.equal(
+    normalizeEvidenceUrl('https://www.dropbox.com/s/file-1/report', 'dropbox'),
+    'https://www.dropbox.com/s/file-1/report',
+  );
+});
+
+test('unsafe schemes, malformed URLs, credentials, and local networks are rejected', () => {
+  const rejected = [
+    'javascript:alert(1)',
+    'data:text/html,unsafe',
+    'file:///etc/passwd',
+    'blob:https://example.com/id',
+    'http://example.com/report',
+    'not a url',
+    'https://user:secret@example.com/report',
+    'https://localhost/report',
+    'https://service.local/report',
+    'https://127.0.0.1/report',
+    'https://2130706433/report',
+    'https://10.0.0.1/report',
+    'https://172.16.0.1/report',
+    'https://192.168.1.1/report',
+    'https://[::1]/report',
+    `https://example.com/${'a'.repeat(MAX_EVIDENCE_URL_LENGTH)}`,
+  ];
+
+  for (const value of rejected) {
+    assert.throws(() => normalizeEvidenceUrl(value, 'url'));
+    assert.equal(getSafeEvidenceUrl(value, 'url'), null);
+  }
+});
+
+test('provider allowlists resist suffix and userinfo hostname bypasses', () => {
+  assert.throws(() => normalizeEvidenceUrl(
+    'https://drive.google.com.attacker.example/report',
+    'google_drive',
+  ));
+  assert.throws(() => normalizeEvidenceUrl(
+    'https://drive.google.com@attacker.example/report',
+    'google_drive',
+  ));
+  assert.throws(() => normalizeEvidenceUrl(
+    'https://drive.google.com%2eattacker.example/report',
+    'google_drive',
+  ));
+  assert.throws(() => normalizeEvidenceUrl(
+    'https://attacker.example/report',
+    'onedrive',
+  ));
+  assert.throws(() => normalizeEvidenceUrl(
+    'https://dropbox.com.attacker.example/report',
+    'dropbox',
+  ));
+});
+
+test('generic URLs are never eligible for automatic remote previews', () => {
+  assert.equal(canAutoLoadEvidencePreview('url'), false);
+  assert.equal(canAutoLoadEvidencePreview('google_drive'), true);
+});
+
+test('service, renderer, and database migration enforce the shared policy', async () => {
+  const [serviceSource, componentSource, migrationSource] = await Promise.all([
+    readFile(new URL('../../services/evidenceService.ts', import.meta.url), 'utf8'),
+    readFile(new URL('../../components/EvidenceBadge.tsx', import.meta.url), 'utf8'),
+    readFile(new URL('../../supabase/migrations/023_validate_evidence_external_urls.sql', import.meta.url), 'utf8'),
+  ]);
+
+  const linkFunction = serviceSource.match(
+    /export async function linkExternalEvidence[\s\S]+?return fromDbRow\(data\);\n}/,
+  );
+  assert.ok(linkFunction);
+  assert.match(linkFunction[0], /normalizeEvidenceUrl\([\s\S]+payload\.external_url/);
+  assert.ok(
+    linkFunction[0].indexOf('normalizeEvidenceUrl(')
+      < linkFunction[0].indexOf(".from('evidence_attachments')"),
+  );
+  assert.match(componentSource, /getSafeEvidenceUrl\(/);
+  assert.match(componentSource, /canAutoLoadEvidencePreview\(/);
+  assert.match(componentSource, /window\.confirm\(/);
+  assert.match(componentSource, /Unsafe or invalid external link blocked/);
+  assert.match(migrationSource, /evidence_external_url_https/);
+  assert.match(migrationSource, /NOT VALID/);
+  assert.ok(migrationSource.includes("external_url !~* '^https://[^/?#]*@'"));
+});


### PR DESCRIPTION
## Summary\n- add a shared URL parser that allows only public, credential-free HTTPS evidence links\n- enforce provider host allowlists for Google Drive, OneDrive, and Dropbox\n- validate before Supabase inserts and treat unsafe legacy rows as inert during rendering\n- stop generic URL evidence from loading remote image previews automatically\n- require confirmation before opening generic external links\n- add a database CHECK constraint for new external URL writes\n\n## Security behavior\n- rejects javascript, data, file, blob, and http schemes\n- rejects malformed, overlong, credential-bearing, localhost, private IP, and reserved network destinations\n- rejects provider suffix, userinfo, trailing-dot, and encoded-host bypass attempts\n- preserves legacy rows with a NOT VALID migration while preventing new unsafe writes\n\n## Verification\n- npm run test:security (84/84)\n- npx tsc --noEmit\n- npm run build\n- git diff --check\n\n## Deployment note\nApply supabase/migrations/023_validate_evidence_external_urls.sql before or with the application release. Authenticated Evidence modal behavior should also be smoke-tested on the deploy preview.\n\nCloses #157