### PR TITLE
fix(security): rate limit unauthenticated invite resends

### DIFF
--- a/netlify/functions/_shared/inviteResendSecurity.js
+++ b/netlify/functions/_shared/inviteResendSecurity.js
@@ -1,6 +1,10 @@
 // @ts-check
 
+import { createHmac } from "node:crypto";
+
 export const INVITE_RESEND_COOLDOWN_MINUTES = 5;
+export const INVITE_RESEND_IP_LIMIT = 10;
+export const INVITE_RESEND_IP_WINDOW_SECONDS = 60;
 
 export const GENERIC_INVITE_RESEND_BODY = Object.freeze({
   success: true,
@@ -28,19 +32,47 @@ export function normalizeInviteResendEmail(value) {
 }
 
 /**
+ * Create a stable, non-reversible client key without persisting the raw IP.
+ * The service-role key is server-only and is used only as an HMAC key here.
+ *
+ * @param {unknown} value
+ * @param {unknown} secret
+ */
+export function hashInviteResendClient(value, secret) {
+  const clientIp = typeof value === "string" ? value.trim() : "";
+  if (
+    clientIp.length === 0
+    || clientIp.length > 128
+    || typeof secret !== "string"
+    || secret.length < 32
+  ) {
+    return null;
+  }
+
+  return createHmac("sha256", secret)
+    .update(`invite-resend-ip:v1\0${clientIp}`)
+    .digest("hex");
+}
+
+/**
  * Atomically reserve the latest eligible invite for a resend. The database
- * RPC owns the lock and cooldown so separate function instances cannot race.
+ * RPC owns the IP window, row lock, and email cooldown so separate function
+ * instances cannot race.
  *
  * @param {any} admin Supabase service-role client
  * @param {unknown} rawEmail
+ * @param {unknown} clientHash
  * @returns {Promise<{ id: string, email: string, organization_id: string } | null>}
  */
-export async function claimPendingInviteResend(admin, rawEmail) {
+export async function claimPendingInviteResend(admin, rawEmail, clientHash) {
   const email = normalizeInviteResendEmail(rawEmail);
-  if (!email) return null;
+  if (!email || typeof clientHash !== "string" || !/^[0-9a-f]{64}$/.test(clientHash)) {
+    return null;
+  }
 
   const { data, error } = await admin.rpc("claim_pending_invite_resend", {
     p_email: email,
+    p_client_hash: clientHash,
   });
   if (error) {
     throw new Error("Invite resend claim failed.");

--- a/netlify/functions/_shared/inviteResendSecurity.js
+++ b/netlify/functions/_shared/inviteResendSecurity.js
@@ -1,0 +1,64 @@
+// @ts-check
+
+export const INVITE_RESEND_COOLDOWN_MINUTES = 5;
+
+export const GENERIC_INVITE_RESEND_BODY = Object.freeze({
+  success: true,
+  message: "If a pending invitation exists for this email, a new link has been sent. Check your inbox.",
+});
+
+/**
+ * Normalize bounded email input before any database lookup.
+ * Invalid input deliberately maps to null so callers can return the same
+ * response as an unknown or throttled address.
+ *
+ * @param {unknown} value
+ */
+export function normalizeInviteResendEmail(value) {
+  if (typeof value !== "string") return null;
+  const email = value.trim().toLowerCase();
+  if (
+    email.length === 0
+    || email.length > 320
+    || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)
+  ) {
+    return null;
+  }
+  return email;
+}
+
+/**
+ * Atomically reserve the latest eligible invite for a resend. The database
+ * RPC owns the lock and cooldown so separate function instances cannot race.
+ *
+ * @param {any} admin Supabase service-role client
+ * @param {unknown} rawEmail
+ * @returns {Promise<{ id: string, email: string, organization_id: string } | null>}
+ */
+export async function claimPendingInviteResend(admin, rawEmail) {
+  const email = normalizeInviteResendEmail(rawEmail);
+  if (!email) return null;
+
+  const { data, error } = await admin.rpc("claim_pending_invite_resend", {
+    p_email: email,
+  });
+  if (error) {
+    throw new Error("Invite resend claim failed.");
+  }
+
+  const row = Array.isArray(data) ? data[0] : null;
+  if (
+    !row
+    || typeof row.id !== "string"
+    || typeof row.email !== "string"
+    || typeof row.organization_id !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    id: row.id,
+    email: row.email,
+    organization_id: row.organization_id,
+  };
+}

--- a/netlify/functions/invite.ts
+++ b/netlify/functions/invite.ts
@@ -3,6 +3,7 @@ import type { Context } from "@netlify/functions";
 import {
   claimPendingInviteResend,
   GENERIC_INVITE_RESEND_BODY,
+  hashInviteResendClient,
 } from "./_shared/inviteResendSecurity.js";
 
 const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
@@ -152,7 +153,7 @@ async function deliverClaimedInviteResend(
 
 const handleInviteRequest = async (
   event: any,
-  waitUntil?: (promise: Promise<unknown>) => void,
+  requestContext?: Pick<Context, "ip" | "waitUntil">,
 ) => {
   if (event.httpMethod !== "POST") {
     return { statusCode: 405, body: "Method Not Allowed" };
@@ -182,15 +183,11 @@ const handleInviteRequest = async (
   // Always returns the same 200 response (no email enumeration).
   if (action === "request_resend") {
     try {
-      const invite = await claimPendingInviteResend(admin, email);
-      if (invite) {
+      const clientHash = hashInviteResendClient(requestContext?.ip, serviceKey);
+      const invite = await claimPendingInviteResend(admin, email, clientHash);
+      if (invite && requestContext) {
         const delivery = deliverClaimedInviteResend(admin, invite);
-        if (waitUntil) {
-          waitUntil(delivery);
-        } else {
-          // Direct unit calls do not have a Netlify request context.
-          await delivery;
-        }
+        requestContext.waitUntil(delivery);
       }
     } catch {
       console.error("[invite] resend claim failed");
@@ -344,7 +341,7 @@ export default async (request: Request, context: Context) => {
     body: request.method === "GET" || request.method === "HEAD"
       ? null
       : await request.text(),
-  }, promise => context.waitUntil(promise));
+  }, context);
 
   const headers = new Headers();
   const legacyHeaders = "headers" in legacyResponse ? legacyResponse.headers : {};
@@ -359,9 +356,4 @@ export default async (request: Request, context: Context) => {
 
 export const config = {
   path: "/.netlify/functions/invite",
-  rateLimit: {
-    windowLimit: 10,
-    windowSize: 60,
-    aggregateBy: ["ip", "domain"],
-  },
 } as const;

--- a/netlify/functions/invite.ts
+++ b/netlify/functions/invite.ts
@@ -1,4 +1,9 @@
 import { createClient } from "@supabase/supabase-js";
+import type { Context } from "@netlify/functions";
+import {
+  claimPendingInviteResend,
+  GENERIC_INVITE_RESEND_BODY,
+} from "./_shared/inviteResendSecurity.js";
 
 const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
 const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -120,7 +125,35 @@ async function sendInviteEmail(
   return { link: null };
 }
 
-const handler = async (event: any) => {
+async function deliverClaimedInviteResend(
+  admin: any,
+  invite: { id: string; email: string; organization_id: string },
+) {
+  try {
+    const { data: profile } = await admin
+      .from("company_profiles")
+      .select("name")
+      .eq("organization_id", invite.organization_id)
+      .maybeSingle();
+    const companyName = profile?.name ?? "your team";
+    const { link } = await sendInviteEmail(
+      admin,
+      invite.email,
+      invite.id,
+      companyName,
+      invite.organization_id,
+      null,
+    );
+    void link;
+  } catch {
+    console.error("[invite] resend delivery failed");
+  }
+}
+
+const handleInviteRequest = async (
+  event: any,
+  waitUntil?: (promise: Promise<unknown>) => void,
+) => {
   if (event.httpMethod !== "POST") {
     return { statusCode: 405, body: "Method Not Allowed" };
   }
@@ -145,36 +178,25 @@ const handler = async (event: any) => {
 
   // ── REQUEST_RESEND (unauthenticated) ──────────────────────────────────────
   // Called from the sign-in page when a user's invite link has expired.
-  // Looks up any pending invite for the email and fires a fresh link.
-  // Always returns 200 (no email enumeration).
+  // Atomically claims an eligible invite, then sends after the response.
+  // Always returns the same 200 response (no email enumeration).
   if (action === "request_resend") {
-    if (!email) return json(400, { error: "Missing email." });
-
-    const { data: invite } = await admin
-      .from("organization_invites")
-      .select("id, email, organization_id")
-      .eq("email", email.trim().toLowerCase())
-      .gt("expires_at", new Date().toISOString())
-      .order("created_at", { ascending: false })
-      .limit(1)
-      .maybeSingle();
-
-    if (invite) {
-      const { data: profile } = await admin
-        .from("company_profiles")
-        .select("name")
-        .eq("organization_id", invite.organization_id)
-        .maybeSingle();
-      const companyName = profile?.name ?? "your team";
-      const { link } = await sendInviteEmail(admin, invite.email, invite.id, companyName, invite.organization_id, null);
-      void link;
+    try {
+      const invite = await claimPendingInviteResend(admin, email);
+      if (invite) {
+        const delivery = deliverClaimedInviteResend(admin, invite);
+        if (waitUntil) {
+          waitUntil(delivery);
+        } else {
+          // Direct unit calls do not have a Netlify request context.
+          await delivery;
+        }
+      }
+    } catch {
+      console.error("[invite] resend claim failed");
     }
 
-    // Always return the same message to prevent email enumeration.
-    return json(200, {
-      success: true,
-      message: "If a pending invitation exists for this email, a new link has been sent. Check your inbox.",
-    });
+    return json(200, GENERIC_INVITE_RESEND_BODY);
   }
 
   // All other actions require authentication.
@@ -315,4 +337,31 @@ const handler = async (event: any) => {
   });
 };
 
-export { handler };
+export default async (request: Request, context: Context) => {
+  const legacyResponse = await handleInviteRequest({
+    httpMethod: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    body: request.method === "GET" || request.method === "HEAD"
+      ? null
+      : await request.text(),
+  }, promise => context.waitUntil(promise));
+
+  const headers = new Headers();
+  const legacyHeaders = "headers" in legacyResponse ? legacyResponse.headers : {};
+  for (const [name, value] of Object.entries(legacyHeaders)) {
+    headers.set(name, String(value));
+  }
+  return new Response(legacyResponse.body ?? "", {
+    status: legacyResponse.statusCode,
+    headers,
+  });
+};
+
+export const config = {
+  path: "/.netlify/functions/invite",
+  rateLimit: {
+    windowLimit: 10,
+    windowSize: 60,
+    aggregateBy: ["ip", "domain"],
+  },
+} as const;

--- a/supabase/migrations/024_rate_limit_invite_resends.sql
+++ b/supabase/migrations/024_rate_limit_invite_resends.sql
@@ -3,16 +3,70 @@
 ALTER TABLE public.organization_invites
   ADD COLUMN IF NOT EXISTS last_email_sent_at timestamptz NOT NULL DEFAULT now();
 
+CREATE TABLE IF NOT EXISTS public.invite_resend_rate_limits (
+  client_hash       text PRIMARY KEY
+                    CHECK (client_hash ~ '^[0-9a-f]{64}$'),
+  window_started_at timestamptz NOT NULL DEFAULT now(),
+  request_count     integer NOT NULL DEFAULT 1
+                    CHECK (request_count > 0),
+  updated_at        timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.invite_resend_rate_limits ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE public.invite_resend_rate_limits
+  FROM PUBLIC, anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.invite_resend_rate_limits
+  TO service_role;
+
 CREATE INDEX IF NOT EXISTS idx_organization_invites_resend_lookup
   ON public.organization_invites (email, expires_at DESC, created_at DESC);
 
-CREATE OR REPLACE FUNCTION public.claim_pending_invite_resend(p_email text)
+DROP FUNCTION IF EXISTS public.claim_pending_invite_resend(text);
+
+CREATE OR REPLACE FUNCTION public.claim_pending_invite_resend(
+  p_email text,
+  p_client_hash text
+)
 RETURNS TABLE (id uuid, email text, organization_id uuid)
-LANGUAGE sql
+LANGUAGE plpgsql
 VOLATILE
 SECURITY INVOKER
 SET search_path = pg_catalog, public
 AS $function$
+DECLARE
+  request_allowed boolean;
+BEGIN
+  IF p_client_hash IS NULL OR p_client_hash !~ '^[0-9a-f]{64}$' THEN
+    RETURN;
+  END IF;
+
+  INSERT INTO public.invite_resend_rate_limits AS rate_limit (
+    client_hash,
+    window_started_at,
+    request_count,
+    updated_at
+  )
+  VALUES (p_client_hash, now(), 1, now())
+  ON CONFLICT (client_hash) DO UPDATE
+  SET
+    window_started_at = CASE
+      WHEN rate_limit.window_started_at <= now() - interval '60 seconds'
+        THEN now()
+      ELSE rate_limit.window_started_at
+    END,
+    request_count = CASE
+      WHEN rate_limit.window_started_at <= now() - interval '60 seconds'
+        THEN 1
+      ELSE LEAST(rate_limit.request_count::bigint + 1, 2147483647)::integer
+    END,
+    updated_at = now()
+  RETURNING rate_limit.request_count <= 10 INTO request_allowed;
+
+  IF NOT request_allowed THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
   WITH candidate AS (
     SELECT invite.id
     FROM public.organization_invites AS invite
@@ -28,14 +82,15 @@ AS $function$
   FROM candidate
   WHERE invite.id = candidate.id
   RETURNING invite.id, invite.email, invite.organization_id;
+END;
 $function$;
 
-REVOKE ALL ON FUNCTION public.claim_pending_invite_resend(text)
+REVOKE ALL ON FUNCTION public.claim_pending_invite_resend(text, text)
   FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION public.claim_pending_invite_resend(text)
+GRANT EXECUTE ON FUNCTION public.claim_pending_invite_resend(text, text)
   TO service_role;
 
 COMMENT ON COLUMN public.organization_invites.last_email_sent_at IS
   'Atomic cooldown marker for invitation email delivery attempts.';
-COMMENT ON FUNCTION public.claim_pending_invite_resend(text) IS
-  'Claims at most one pending invite for resend after a five-minute cooldown; service role only.';
+COMMENT ON FUNCTION public.claim_pending_invite_resend(text, text) IS
+  'Applies a per-client request limit and claims at most one pending invite after its email cooldown.';

--- a/supabase/migrations/024_rate_limit_invite_resends.sql
+++ b/supabase/migrations/024_rate_limit_invite_resends.sql
@@ -1,0 +1,41 @@
+-- Issue #167: centrally rate-limit unauthenticated invite resend requests.
+
+ALTER TABLE public.organization_invites
+  ADD COLUMN IF NOT EXISTS last_email_sent_at timestamptz NOT NULL DEFAULT now();
+
+CREATE INDEX IF NOT EXISTS idx_organization_invites_resend_lookup
+  ON public.organization_invites (email, expires_at DESC, created_at DESC);
+
+CREATE OR REPLACE FUNCTION public.claim_pending_invite_resend(p_email text)
+RETURNS TABLE (id uuid, email text, organization_id uuid)
+LANGUAGE sql
+VOLATILE
+SECURITY INVOKER
+SET search_path = pg_catalog, public
+AS $function$
+  WITH candidate AS (
+    SELECT invite.id
+    FROM public.organization_invites AS invite
+    WHERE invite.email = lower(btrim(p_email))
+      AND invite.expires_at > now()
+      AND invite.last_email_sent_at <= now() - interval '5 minutes'
+    ORDER BY invite.created_at DESC
+    LIMIT 1
+    FOR UPDATE SKIP LOCKED
+  )
+  UPDATE public.organization_invites AS invite
+  SET last_email_sent_at = now()
+  FROM candidate
+  WHERE invite.id = candidate.id
+  RETURNING invite.id, invite.email, invite.organization_id;
+$function$;
+
+REVOKE ALL ON FUNCTION public.claim_pending_invite_resend(text)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_pending_invite_resend(text)
+  TO service_role;
+
+COMMENT ON COLUMN public.organization_invites.last_email_sent_at IS
+  'Atomic cooldown marker for invitation email delivery attempts.';
+COMMENT ON FUNCTION public.claim_pending_invite_resend(text) IS
+  'Claims at most one pending invite for resend after a five-minute cooldown; service role only.';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -40,8 +40,41 @@ CREATE TABLE organization_invites (
                   CHECK (role IN ('Admin', 'Manager', 'Consultant')),
   invited_by      uuid NOT NULL REFERENCES auth.users(id),
   expires_at      timestamptz NOT NULL DEFAULT (now() + interval '7 days'),
-  created_at      timestamptz NOT NULL DEFAULT now()
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  last_email_sent_at timestamptz NOT NULL DEFAULT now()
 );
+
+CREATE INDEX idx_organization_invites_resend_lookup
+  ON organization_invites (email, expires_at DESC, created_at DESC);
+
+CREATE OR REPLACE FUNCTION claim_pending_invite_resend(p_email text)
+RETURNS TABLE (id uuid, email text, organization_id uuid)
+LANGUAGE sql
+VOLATILE
+SECURITY INVOKER
+SET search_path = pg_catalog, public
+AS $function$
+  WITH candidate AS (
+    SELECT invite.id
+    FROM public.organization_invites AS invite
+    WHERE invite.email = lower(btrim(p_email))
+      AND invite.expires_at > now()
+      AND invite.last_email_sent_at <= now() - interval '5 minutes'
+    ORDER BY invite.created_at DESC
+    LIMIT 1
+    FOR UPDATE SKIP LOCKED
+  )
+  UPDATE public.organization_invites AS invite
+  SET last_email_sent_at = now()
+  FROM candidate
+  WHERE invite.id = candidate.id
+  RETURNING invite.id, invite.email, invite.organization_id;
+$function$;
+
+REVOKE ALL ON FUNCTION claim_pending_invite_resend(text)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION claim_pending_invite_resend(text)
+  TO service_role;
 
 -- ============================================================
 -- COMPANY PROFILES  (1 per org)

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -47,13 +47,65 @@ CREATE TABLE organization_invites (
 CREATE INDEX idx_organization_invites_resend_lookup
   ON organization_invites (email, expires_at DESC, created_at DESC);
 
-CREATE OR REPLACE FUNCTION claim_pending_invite_resend(p_email text)
+CREATE TABLE invite_resend_rate_limits (
+  client_hash       text PRIMARY KEY
+                    CHECK (client_hash ~ '^[0-9a-f]{64}$'),
+  window_started_at timestamptz NOT NULL DEFAULT now(),
+  request_count     integer NOT NULL DEFAULT 1
+                    CHECK (request_count > 0),
+  updated_at        timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE invite_resend_rate_limits ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON TABLE invite_resend_rate_limits
+  FROM PUBLIC, anon, authenticated;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE invite_resend_rate_limits
+  TO service_role;
+
+CREATE OR REPLACE FUNCTION claim_pending_invite_resend(
+  p_email text,
+  p_client_hash text
+)
 RETURNS TABLE (id uuid, email text, organization_id uuid)
-LANGUAGE sql
+LANGUAGE plpgsql
 VOLATILE
 SECURITY INVOKER
 SET search_path = pg_catalog, public
 AS $function$
+DECLARE
+  request_allowed boolean;
+BEGIN
+  IF p_client_hash IS NULL OR p_client_hash !~ '^[0-9a-f]{64}$' THEN
+    RETURN;
+  END IF;
+
+  INSERT INTO public.invite_resend_rate_limits AS rate_limit (
+    client_hash,
+    window_started_at,
+    request_count,
+    updated_at
+  )
+  VALUES (p_client_hash, now(), 1, now())
+  ON CONFLICT (client_hash) DO UPDATE
+  SET
+    window_started_at = CASE
+      WHEN rate_limit.window_started_at <= now() - interval '60 seconds'
+        THEN now()
+      ELSE rate_limit.window_started_at
+    END,
+    request_count = CASE
+      WHEN rate_limit.window_started_at <= now() - interval '60 seconds'
+        THEN 1
+      ELSE LEAST(rate_limit.request_count::bigint + 1, 2147483647)::integer
+    END,
+    updated_at = now()
+  RETURNING rate_limit.request_count <= 10 INTO request_allowed;
+
+  IF NOT request_allowed THEN
+    RETURN;
+  END IF;
+
+  RETURN QUERY
   WITH candidate AS (
     SELECT invite.id
     FROM public.organization_invites AS invite
@@ -69,11 +121,12 @@ AS $function$
   FROM candidate
   WHERE invite.id = candidate.id
   RETURNING invite.id, invite.email, invite.organization_id;
+END;
 $function$;
 
-REVOKE ALL ON FUNCTION claim_pending_invite_resend(text)
+REVOKE ALL ON FUNCTION claim_pending_invite_resend(text, text)
   FROM PUBLIC, anon, authenticated;
-GRANT EXECUTE ON FUNCTION claim_pending_invite_resend(text)
+GRANT EXECUTE ON FUNCTION claim_pending_invite_resend(text, text)
   TO service_role;
 
 -- ============================================================

--- a/tests/security/invite-resend-rate-limit.test.mjs
+++ b/tests/security/invite-resend-rate-limit.test.mjs
@@ -5,7 +5,10 @@ import test from "node:test";
 import {
   GENERIC_INVITE_RESEND_BODY,
   INVITE_RESEND_COOLDOWN_MINUTES,
+  INVITE_RESEND_IP_LIMIT,
+  INVITE_RESEND_IP_WINDOW_SECONDS,
   claimPendingInviteResend,
+  hashInviteResendClient,
   normalizeInviteResendEmail,
 } from "../../netlify/functions/_shared/inviteResendSecurity.js";
 import { config as inviteConfig } from "../../netlify/functions/invite.ts";
@@ -15,6 +18,7 @@ const CLAIMED_INVITE = {
   email: "member@example.com",
   organization_id: "22222222-2222-4222-8222-222222222222",
 };
+const CLIENT_HASH = "a".repeat(64);
 
 test("invite resend email validation is bounded and normalized", () => {
   assert.equal(normalizeInviteResendEmail(" Member@Example.COM "), "member@example.com");
@@ -29,8 +33,23 @@ test("invalid resend input never reaches the database claim", async () => {
     rpc: async () => assert.fail("invalid input must not query the database"),
   };
 
-  assert.equal(await claimPendingInviteResend(admin, null), null);
-  assert.equal(await claimPendingInviteResend(admin, "invalid"), null);
+  assert.equal(await claimPendingInviteResend(admin, null, CLIENT_HASH), null);
+  assert.equal(await claimPendingInviteResend(admin, "invalid", CLIENT_HASH), null);
+  assert.equal(await claimPendingInviteResend(admin, CLAIMED_INVITE.email, null), null);
+});
+
+test("client identifiers are HMACed and fail closed without trusted inputs", () => {
+  const secret = "server-only-secret-material-1234567890";
+  const first = hashInviteResendClient("203.0.113.10", secret);
+  const second = hashInviteResendClient("203.0.113.10", secret);
+
+  assert.match(first, /^[0-9a-f]{64}$/);
+  assert.equal(first, second);
+  assert.notEqual(first, hashInviteResendClient("203.0.113.11", secret));
+  assert.equal(hashInviteResendClient(undefined, secret), null);
+  assert.equal(hashInviteResendClient("   ", secret), null);
+  assert.equal(hashInviteResendClient("203.0.113.10", "short"), null);
+  assert.doesNotMatch(first, /203\.0\.113\.10/);
 });
 
 test("resend claims use one bounded RPC and expose no database errors", async () => {
@@ -43,18 +62,21 @@ test("resend claims use one bounded RPC and expose no database errors", async ()
   };
 
   assert.deepEqual(
-    await claimPendingInviteResend(admin, "Member@Example.com"),
+    await claimPendingInviteResend(admin, "Member@Example.com", CLIENT_HASH),
     CLAIMED_INVITE,
   );
   assert.deepEqual(calls, [{
     name: "claim_pending_invite_resend",
-    params: { p_email: "member@example.com" },
+    params: {
+      p_email: "member@example.com",
+      p_client_hash: CLIENT_HASH,
+    },
   }]);
 
   await assert.rejects(
     claimPendingInviteResend({
       rpc: async () => ({ data: null, error: { message: "sensitive database detail" } }),
-    }, "member@example.com"),
+    }, "member@example.com", CLIENT_HASH),
     error => {
       assert.equal(error.message, "Invite resend claim failed.");
       assert.doesNotMatch(error.message, /sensitive|database detail/i);
@@ -75,22 +97,21 @@ test("concurrent callers can observe only the single claim returned by the RPC",
   };
 
   const claims = await Promise.all([
-    claimPendingInviteResend(admin, CLAIMED_INVITE.email),
-    claimPendingInviteResend(admin, CLAIMED_INVITE.email),
+    claimPendingInviteResend(admin, CLAIMED_INVITE.email, CLIENT_HASH),
+    claimPendingInviteResend(admin, CLAIMED_INVITE.email, CLIENT_HASH),
   ]);
   assert.equal(claims.filter(Boolean).length, 1);
 });
 
-test("the public response and Netlify edge limit do not reveal claim state", () => {
+test("the public response and distributed limits do not reveal claim state", () => {
   assert.deepEqual(GENERIC_INVITE_RESEND_BODY, {
     success: true,
     message: "If a pending invitation exists for this email, a new link has been sent. Check your inbox.",
   });
   assert.equal(INVITE_RESEND_COOLDOWN_MINUTES, 5);
+  assert.equal(INVITE_RESEND_IP_LIMIT, 10);
+  assert.equal(INVITE_RESEND_IP_WINDOW_SECONDS, 60);
   assert.equal(inviteConfig.path, "/.netlify/functions/invite");
-  assert.deepEqual(inviteConfig.rateLimit.aggregateBy, ["ip", "domain"]);
-  assert.equal(inviteConfig.rateLimit.windowLimit, 10);
-  assert.equal(inviteConfig.rateLimit.windowSize, 60);
 });
 
 test("handler schedules delivery after its generic response and migration is atomic", async () => {
@@ -104,16 +125,20 @@ test("handler schedules delivery after its generic response and migration is ato
     /if \(action === "request_resend"\)[\s\S]+?return json\(200, GENERIC_INVITE_RESEND_BODY\);\n  }/,
   );
   assert.ok(resendBranch);
-  assert.match(resendBranch[0], /claimPendingInviteResend\(admin, email\)/);
-  assert.match(resendBranch[0], /waitUntil\(delivery\)/);
+  assert.match(resendBranch[0], /hashInviteResendClient\(requestContext\?\.ip, serviceKey\)/);
+  assert.match(resendBranch[0], /claimPendingInviteResend\(admin, email, clientHash\)/);
+  assert.match(resendBranch[0], /requestContext\.waitUntil\(delivery\)/);
   assert.doesNotMatch(resendBranch[0], /return json\(400/);
   assert.match(handlerSource, /export default async \(request: Request, context: Context\)/);
   assert.doesNotMatch(handlerSource, /export\s+(?:const\s+handler|\{\s*handler\s*\})/);
-  assert.match(handlerSource, /context\.waitUntil\(promise\)/);
   assert.match(migrationSource, /last_email_sent_at/);
   assert.match(migrationSource, /interval '5 minutes'/);
+  assert.match(migrationSource, /invite_resend_rate_limits/);
+  assert.match(migrationSource, /interval '60 seconds'/);
+  assert.match(migrationSource, /request_count <= 10/);
   assert.match(migrationSource, /FOR UPDATE SKIP LOCKED/);
-  assert.match(migrationSource, /REVOKE ALL[\s\S]+FROM PUBLIC, anon, authenticated/);
+  assert.match(migrationSource, /REVOKE ALL ON TABLE[\s\S]+FROM PUBLIC, anon, authenticated/);
+  assert.match(migrationSource, /REVOKE ALL ON FUNCTION[\s\S]+FROM PUBLIC, anon, authenticated/);
   assert.match(migrationSource, /GRANT EXECUTE[\s\S]+TO service_role/);
   assert.match(authSource, /action: "request_resend"/);
 });

--- a/tests/security/invite-resend-rate-limit.test.mjs
+++ b/tests/security/invite-resend-rate-limit.test.mjs
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  GENERIC_INVITE_RESEND_BODY,
+  INVITE_RESEND_COOLDOWN_MINUTES,
+  claimPendingInviteResend,
+  normalizeInviteResendEmail,
+} from "../../netlify/functions/_shared/inviteResendSecurity.js";
+import { config as inviteConfig } from "../../netlify/functions/invite.ts";
+
+const CLAIMED_INVITE = {
+  id: "11111111-1111-4111-8111-111111111111",
+  email: "member@example.com",
+  organization_id: "22222222-2222-4222-8222-222222222222",
+};
+
+test("invite resend email validation is bounded and normalized", () => {
+  assert.equal(normalizeInviteResendEmail(" Member@Example.COM "), "member@example.com");
+  assert.equal(normalizeInviteResendEmail(undefined), null);
+  assert.equal(normalizeInviteResendEmail(""), null);
+  assert.equal(normalizeInviteResendEmail("not-an-email"), null);
+  assert.equal(normalizeInviteResendEmail("a".repeat(321)), null);
+});
+
+test("invalid resend input never reaches the database claim", async () => {
+  const admin = {
+    rpc: async () => assert.fail("invalid input must not query the database"),
+  };
+
+  assert.equal(await claimPendingInviteResend(admin, null), null);
+  assert.equal(await claimPendingInviteResend(admin, "invalid"), null);
+});
+
+test("resend claims use one bounded RPC and expose no database errors", async () => {
+  const calls = [];
+  const admin = {
+    rpc: async (name, params) => {
+      calls.push({ name, params });
+      return { data: [CLAIMED_INVITE], error: null };
+    },
+  };
+
+  assert.deepEqual(
+    await claimPendingInviteResend(admin, "Member@Example.com"),
+    CLAIMED_INVITE,
+  );
+  assert.deepEqual(calls, [{
+    name: "claim_pending_invite_resend",
+    params: { p_email: "member@example.com" },
+  }]);
+
+  await assert.rejects(
+    claimPendingInviteResend({
+      rpc: async () => ({ data: null, error: { message: "sensitive database detail" } }),
+    }, "member@example.com"),
+    error => {
+      assert.equal(error.message, "Invite resend claim failed.");
+      assert.doesNotMatch(error.message, /sensitive|database detail/i);
+      return true;
+    },
+  );
+});
+
+test("concurrent callers can observe only the single claim returned by the RPC", async () => {
+  let available = true;
+  const admin = {
+    rpc: async () => {
+      await Promise.resolve();
+      if (!available) return { data: [], error: null };
+      available = false;
+      return { data: [CLAIMED_INVITE], error: null };
+    },
+  };
+
+  const claims = await Promise.all([
+    claimPendingInviteResend(admin, CLAIMED_INVITE.email),
+    claimPendingInviteResend(admin, CLAIMED_INVITE.email),
+  ]);
+  assert.equal(claims.filter(Boolean).length, 1);
+});
+
+test("the public response and Netlify edge limit do not reveal claim state", () => {
+  assert.deepEqual(GENERIC_INVITE_RESEND_BODY, {
+    success: true,
+    message: "If a pending invitation exists for this email, a new link has been sent. Check your inbox.",
+  });
+  assert.equal(INVITE_RESEND_COOLDOWN_MINUTES, 5);
+  assert.equal(inviteConfig.path, "/.netlify/functions/invite");
+  assert.deepEqual(inviteConfig.rateLimit.aggregateBy, ["ip", "domain"]);
+  assert.equal(inviteConfig.rateLimit.windowLimit, 10);
+  assert.equal(inviteConfig.rateLimit.windowSize, 60);
+});
+
+test("handler schedules delivery after its generic response and migration is atomic", async () => {
+  const [handlerSource, migrationSource, authSource] = await Promise.all([
+    readFile(new URL("../../netlify/functions/invite.ts", import.meta.url), "utf8"),
+    readFile(new URL("../../supabase/migrations/024_rate_limit_invite_resends.sql", import.meta.url), "utf8"),
+    readFile(new URL("../../components/AuthScreen.tsx", import.meta.url), "utf8"),
+  ]);
+
+  const resendBranch = handlerSource.match(
+    /if \(action === "request_resend"\)[\s\S]+?return json\(200, GENERIC_INVITE_RESEND_BODY\);\n  }/,
+  );
+  assert.ok(resendBranch);
+  assert.match(resendBranch[0], /claimPendingInviteResend\(admin, email\)/);
+  assert.match(resendBranch[0], /waitUntil\(delivery\)/);
+  assert.doesNotMatch(resendBranch[0], /return json\(400/);
+  assert.match(handlerSource, /export default async \(request: Request, context: Context\)/);
+  assert.doesNotMatch(handlerSource, /export\s+(?:const\s+handler|\{\s*handler\s*\})/);
+  assert.match(handlerSource, /context\.waitUntil\(promise\)/);
+  assert.match(migrationSource, /last_email_sent_at/);
+  assert.match(migrationSource, /interval '5 minutes'/);
+  assert.match(migrationSource, /FOR UPDATE SKIP LOCKED/);
+  assert.match(migrationSource, /REVOKE ALL[\s\S]+FROM PUBLIC, anon, authenticated/);
+  assert.match(migrationSource, /GRANT EXECUTE[\s\S]+TO service_role/);
+  assert.match(authSource, /action: "request_resend"/);
+});


### PR DESCRIPTION
## Summary
- derive a stable client key from Netlify Context.ip using a server-side HMAC; raw IP addresses are never stored
- enforce 10 resend attempts per client per 60 seconds in a distributed Supabase counter
- atomically claim at most one pending invite per email every five minutes in the same server-only RPC
- return the same response for invalid, unknown, throttled, and eligible addresses
- deliver claimed email asynchronously with context.waitUntil to reduce timing-based enumeration
- add migration 024, canonical schema changes, and regression coverage

## Verification
- npm run test:security (91 passed)
- npx tsc --noEmit
- npm run build
- Netlify Functions bundle: invite runtime API v2, streaming invocation
- PostgreSQL 15 migration apply succeeded against a temporary database
- PostgreSQL behavior: attempts 1-10 allowed, attempt 11 denied, immediate same-email resend denied
- authenticated database role denied access to the RPC

## Rollout
Apply supabase/migrations/024_rate_limit_invite_resends.sql before testing or publishing the deploy. Without the migration, public resend requests fail closed and return the generic response without sending email.

Closes #167