### PR TITLE
fix(security): authenticate Ally support AI requests

### DIFF
--- a/components/AllyAssistant.tsx
+++ b/components/AllyAssistant.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { MessageCircle, X, Send, Bot, HelpCircle, AlertTriangle, Sparkles, Loader2 } from 'lucide-react';
+import { supabase } from '../lib/supabaseClient';
 
 interface AllyAssistantProps {
   userEmail?: string;
@@ -9,7 +10,26 @@ interface AllyAssistantProps {
   orgId?: string;
 }
 
-export const AllyAssistant: React.FC<AllyAssistantProps> = ({ userEmail, companyName, userRole, userId, orgId }) => {
+const ALLY_MAX_CONTEXT_MESSAGES = 30;
+const ALLY_MAX_CONTEXT_CHARS = 30_000;
+const ALLY_MAX_MESSAGE_CHARS = 4_000;
+
+function getBoundedConversation(
+  messages: Array<{ role: 'user' | 'assistant', text: string }>,
+) {
+  const bounded: typeof messages = [];
+  let remainingChars = ALLY_MAX_CONTEXT_CHARS;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    const message = messages[index];
+    if (message.text.length > remainingChars) break;
+    bounded.unshift(message);
+    remainingChars -= message.text.length;
+    if (bounded.length === ALLY_MAX_CONTEXT_MESSAGES) break;
+  }
+  return bounded;
+}
+
+export const AllyAssistant: React.FC<AllyAssistantProps> = ({ orgId }) => {
   const [isOpen, setIsOpen] = useState(false);
   const [position, setPosition] = useState({ x: 0, y: 0 });
   const [isDragging, setIsDragging] = useState(false);
@@ -21,7 +41,7 @@ export const AllyAssistant: React.FC<AllyAssistantProps> = ({ userEmail, company
   ]);
   const [inputText, setInputText] = useState("");
   const [isLoading, setIsLoading] = useState(false);
-  const [sessionId] = useState(() => Math.random().toString(36).substr(2, 9));
+  const [sessionId] = useState(() => crypto.randomUUID());
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -88,21 +108,30 @@ export const AllyAssistant: React.FC<AllyAssistantProps> = ({ userEmail, company
     setIsLoading(true);
 
     try {
+      if (!orgId) {
+        throw new Error("Ally needs an organization context. Please refresh and try again.");
+      }
+      const { data: { session } } = await supabase.auth.getSession();
+      if (!session?.access_token) {
+        throw new Error("You must be signed in to use Ally.");
+      }
+
+      const outboundMessages = getBoundedConversation([
+        ...messages,
+        { role: 'user', text: textToSend },
+      ]);
       const response = await fetch('/.netlify/functions/ally-support', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${session.access_token}`,
+        },
         body: JSON.stringify({
-          messages: [...messages, { role: 'user', text: textToSend }],
+          organization_id: orgId,
+          messages: outboundMessages,
           context: window.location.pathname,
           errors: '',
           sessionId: sessionId,
-          userInfo: {
-            email: userEmail,
-            company: companyName,
-            role: userRole,
-            userId: userId,
-            orgId: orgId
-          }
         })
       });
 
@@ -114,7 +143,10 @@ export const AllyAssistant: React.FC<AllyAssistantProps> = ({ userEmail, company
         setMessages(prev => [...prev, { role: 'assistant', text: `Error: ${errorMsg}` }]);
       }
     } catch (error) {
-      setMessages(prev => [...prev, { role: 'assistant', text: "Sorry, I couldn't connect to the support service." }]);
+      const message = error instanceof Error
+        ? error.message
+        : "Sorry, I couldn't connect to the support service.";
+      setMessages(prev => [...prev, { role: 'assistant', text: message }]);
     } finally {
       setIsLoading(false);
     }
@@ -287,6 +319,7 @@ export const AllyAssistant: React.FC<AllyAssistantProps> = ({ userEmail, company
                 value={inputText}
                 onChange={(e) => setInputText(e.target.value)}
                 onKeyPress={(e) => e.key === 'Enter' && handleSendMessage()}
+                maxLength={ALLY_MAX_MESSAGE_CHARS}
                 placeholder="Type your question..."
                 className="flex-1 px-3 py-2 text-sm bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-emerald-500 text-slate-800 dark:text-white"
                 disabled={isLoading}

--- a/netlify/functions/_shared/allySupportSecurity.js
+++ b/netlify/functions/_shared/allySupportSecurity.js
@@ -1,0 +1,96 @@
+// @ts-check
+
+export const ALLY_MAX_REQUEST_BYTES = 64 * 1024;
+export const ALLY_MAX_MESSAGES = 30;
+export const ALLY_MAX_MESSAGE_CHARS = 4_000;
+export const ALLY_MAX_TOTAL_MESSAGE_CHARS = 30_000;
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{6,64}$/;
+const MESSAGE_ROLES = new Set(["user", "assistant"]);
+
+function requestError(message, status = 400) {
+  return Object.assign(new Error(message), { status });
+}
+
+function normalizeOptionalText(value, maxLength, fieldName) {
+  if (value == null || value === "") return "";
+  if (typeof value !== "string") {
+    throw requestError(`${fieldName} must be a string.`);
+  }
+  if (value.length > maxLength || /[\u0000-\u0008\u000b\u000c\u000e-\u001f\u007f]/.test(value)) {
+    throw requestError(`${fieldName} is invalid.`);
+  }
+  return value;
+}
+
+export function parseAllySupportBody(rawBody) {
+  if (typeof rawBody !== "string") {
+    throw requestError("Invalid request body.");
+  }
+  if (Buffer.byteLength(rawBody, "utf8") > ALLY_MAX_REQUEST_BYTES) {
+    throw requestError("Request body is too large.", 413);
+  }
+
+  let body;
+  try {
+    body = JSON.parse(rawBody);
+  } catch {
+    throw requestError("Invalid request body.");
+  }
+
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    throw requestError("Invalid request body.");
+  }
+  if (typeof body.organization_id !== "string" || !UUID_PATTERN.test(body.organization_id)) {
+    throw requestError("A valid organization_id is required.");
+  }
+  if (typeof body.sessionId !== "string" || !SESSION_ID_PATTERN.test(body.sessionId)) {
+    throw requestError("A valid sessionId is required.");
+  }
+  if (!Array.isArray(body.messages) || body.messages.length === 0) {
+    throw requestError("At least one message is required.");
+  }
+  if (body.messages.length > ALLY_MAX_MESSAGES) {
+    throw requestError("Too many messages.", 413);
+  }
+
+  let totalChars = 0;
+  const messages = body.messages.map((message) => {
+    if (!message || typeof message !== "object" || Array.isArray(message)) {
+      throw requestError("Each message must be an object.");
+    }
+    if (!MESSAGE_ROLES.has(message.role)) {
+      throw requestError("Each message must have a valid role.");
+    }
+    if (typeof message.text !== "string" || message.text.trim().length === 0) {
+      throw requestError("Each message must contain text.");
+    }
+    if (message.text.length > ALLY_MAX_MESSAGE_CHARS) {
+      throw requestError("A message is too large.", 413);
+    }
+    totalChars += message.text.length;
+    if (totalChars > ALLY_MAX_TOTAL_MESSAGE_CHARS) {
+      throw requestError("Conversation is too large.", 413);
+    }
+    return { role: message.role, text: message.text };
+  });
+
+  return {
+    organizationId: body.organization_id,
+    sessionId: body.sessionId,
+    messages,
+    context: normalizeOptionalText(body.context, 256, "context"),
+    errors: normalizeOptionalText(body.errors, 2_000, "errors"),
+  };
+}
+
+export function escapeHtml(value) {
+  return String(value)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}

--- a/netlify/functions/ally-support.ts
+++ b/netlify/functions/ally-support.ts
@@ -1,16 +1,88 @@
 import { GoogleGenAI } from "@google/genai";
 import * as fs from 'fs';
 import * as path from 'path';
+import { fileURLToPath } from "node:url";
 import { createClient } from "@supabase/supabase-js";
 import { getStore } from "@netlify/blobs";
+import {
+  escapeHtml,
+  parseAllySupportBody,
+} from "./_shared/allySupportSecurity.js";
+import { withAIRequestFence } from "./_shared/aiRequestFence.js";
+import { loadOrganizationAiConfig } from "./_shared/organizationAiConfig.js";
 
-const apiKey = process.env.GEMINI_API_KEY;
-const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
-const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+const DEFAULT_MODEL = "gemini-2.5-flash";
+const FUNCTION_DIR = path.dirname(fileURLToPath(import.meta.url));
 
-const admin = createClient(supabaseUrl!, serviceKey!);
-const resendKey = process.env.RESEND_API_KEY;
-const fromEmail = process.env.RESEND_FROM_EMAIL ?? 'no-reply@aeternumally.com';
+type HandlerDependencies = {
+  createAdminClient: () => any;
+  createAIClient: (apiKey: string) => GoogleGenAI;
+  getConversationStore: () => ReturnType<typeof getStore>;
+  fetchImpl: typeof fetch;
+  platformApiKey: string;
+  resendKey: string;
+  fromEmail: string;
+  now: () => Date;
+};
+
+const json = (statusCode: number, body: unknown) => ({
+  statusCode,
+  headers: {
+    "Content-Type": "application/json",
+    "Cache-Control": "no-store",
+    "X-Content-Type-Options": "nosniff",
+  },
+  body: JSON.stringify(body),
+});
+
+function getAdminClient() {
+  const supabaseUrl = process.env.SUPABASE_URL ?? process.env.VITE_SUPABASE_URL ?? "";
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? "";
+  if (!supabaseUrl || !serviceKey) {
+    throw new Error("Supabase server credentials are unavailable.");
+  }
+  return createClient(supabaseUrl, serviceKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+function defaultDependencies(): HandlerDependencies {
+  return {
+    createAdminClient: getAdminClient,
+    createAIClient: (apiKey) => new GoogleGenAI({ apiKey }),
+    getConversationStore: () => getStore("ally-conversations"),
+    fetchImpl: fetch,
+    platformApiKey: process.env.GEMINI_API_KEY ?? "",
+    resendKey: process.env.RESEND_API_KEY ?? "",
+    fromEmail: process.env.RESEND_FROM_EMAIL ?? "no-reply@aeternumally.com",
+    now: () => new Date(),
+  };
+}
+
+async function getMembership(admin: any, organizationId: string, userId: string) {
+  const { data, error } = await admin
+    .from("organization_members")
+    .select("role")
+    .eq("organization_id", organizationId)
+    .eq("user_id", userId)
+    .maybeSingle();
+  if (error) throw new Error("Could not verify organization access.");
+  return data ?? null;
+}
+
+async function getCompanyName(admin: any, organizationId: string) {
+  try {
+    const { data, error } = await admin
+      .from("company_profiles")
+      .select("name")
+      .eq("organization_id", organizationId)
+      .maybeSingle();
+    if (error) return "";
+    return typeof data?.name === "string" ? data.name : "";
+  } catch {
+    return "";
+  }
+}
 
 function redactSecrets(text: string): string {
   if (!text) return text;
@@ -22,65 +94,114 @@ function redactSecrets(text: string): string {
   return redacted;
 }
 
-export const handler = async (event: any) => {
-  if (event.httpMethod !== "POST") {
-    return { statusCode: 405, body: "Method Not Allowed" };
-  }
+export function createAllySupportHandler(
+  overrides: Partial<HandlerDependencies> = {},
+) {
+  const deps = { ...defaultDependencies(), ...overrides };
 
-  const start = Date.now();
-  try {
-    const { messages, context, errors, userInfo, sessionId } = JSON.parse(event.body);
-    const organization_id = userInfo?.orgId;
+  return async (event: any) => {
+    if (event.httpMethod !== "POST") {
+      return json(405, { error: "Method not allowed." });
+    }
 
-    // Log the conversation for analysis and improvement
-    console.log(`[ally-support] Conversation log for user ${userInfo?.email || 'unknown'} (org: ${organization_id || 'unknown'}):`, JSON.stringify(messages));
-
-    // Save to Netlify Blobs for analysis and improvement
+    let admin: any;
     try {
-      const store = getStore("ally-conversations");
-      const conversationId = `${userInfo?.orgId || 'no-org'}_${userInfo?.userId || 'anon'}_${sessionId || 'no-session'}`;
+      admin = deps.createAdminClient();
+    } catch {
+      return json(503, { error: "Ally is temporarily unavailable." });
+    }
+
+    const authHeader = event.headers?.authorization ?? event.headers?.Authorization;
+    if (!authHeader?.startsWith("Bearer ")) {
+      return json(401, { error: "You must be signed in to use Ally." });
+    }
+    const accessToken = authHeader.slice("Bearer ".length);
+    let userResponse;
+    let userError;
+    try {
+      const authResult = await admin.auth.getUser(accessToken);
+      userResponse = authResult.data;
+      userError = authResult.error;
+    } catch {
+      return json(503, { error: "Ally could not verify your session." });
+    }
+    if (userError || !userResponse?.user) {
+      return json(401, { error: "Your session has expired. Please sign in again." });
+    }
+    const user = userResponse.user;
+
+    let requestBody;
+    try {
+      requestBody = parseAllySupportBody(event.body ?? "");
+    } catch (error: any) {
+      return json(error.status ?? 400, { error: error.message });
+    }
+    const {
+      organizationId: organization_id,
+      messages,
+      context,
+      errors,
+      sessionId,
+    } = requestBody;
+
+    let membership;
+    try {
+      membership = await getMembership(admin, organization_id, user.id);
+    } catch {
+      return json(503, { error: "Organization access could not be verified." });
+    }
+    if (!membership) {
+      return json(403, { error: "You don't have access to this organization." });
+    }
+
+    let aiConfig;
+    try {
+      aiConfig = await loadOrganizationAiConfig(
+        admin,
+        organization_id,
+        deps.platformApiKey,
+        DEFAULT_MODEL,
+      );
+    } catch {
+      return json(503, { error: "Ally's AI settings are temporarily unavailable." });
+    }
+
+    const company = await getCompanyName(admin, organization_id);
+    const userInfo = {
+      email: user.email ?? null,
+      company,
+      role: membership.role,
+      userId: user.id,
+      orgId: organization_id,
+    };
+    const start = Date.now();
+
+    try {
+      const store = deps.getConversationStore();
+      const conversationId = `${organization_id}_${user.id}_${sessionId}`;
       await store.setJSON(conversationId, {
         messages,
         context,
         errors,
         userInfo,
-        timestamp: new Date().toISOString()
+        timestamp: deps.now().toISOString(),
       });
-      console.log(`[ally-support] Saved conversation to blob: ${conversationId}`);
-    } catch (blobErr) {
-      console.error("[ally-support] Failed to save conversation to blob:", blobErr);
+    } catch {
+      console.error("[ally-support] Failed to save conversation.");
     }
 
-    let activeModel = "gemini-2.5-flash"; // Default fallback
-    if (organization_id) {
-      const { data: settings } = await admin
-        .from("organization_ai_settings")
-        .select("model")
-        .eq("organization_id", organization_id)
-        .maybeSingle();
-      
-      if (settings?.model) {
-        activeModel = settings.model;
-      }
-    }
+    const activeModel = aiConfig.model;
+    const ai = deps.createAIClient(aiConfig.resolvedApiKey);
 
-    if (!messages || !Array.isArray(messages)) {
-      return { statusCode: 400, body: "Missing or invalid messages array" };
-    }
-
-    if (!apiKey) {
-      return { statusCode: 500, body: "GEMINI_API_KEY is not configured" };
-    }
-
-    const ai = new GoogleGenAI({ apiKey: apiKey });
+    try {
     
     // Attempt to load documentation
     let docsContent = "";
     try {
       const possiblePaths = [
         path.join(process.cwd(), "Docs v1.1.0", "USER_MANUAL.md"),
-        path.join(__dirname, "Docs v1.1.0", "USER_MANUAL.md"),
-        path.join(__dirname, "..", "Docs v1.1.0", "USER_MANUAL.md"),
+        path.join(FUNCTION_DIR, "Docs v1.1.0", "USER_MANUAL.md"),
+        path.join(FUNCTION_DIR, "..", "Docs v1.1.0", "USER_MANUAL.md"),
       ];
 
       for (const p of possiblePaths) {
@@ -89,8 +210,8 @@ export const handler = async (event: any) => {
           break;
         }
       }
-    } catch (err) {
-      console.error("[ally-support] Error reading docs:", err);
+    } catch {
+      console.error("[ally-support] Could not load support documentation.");
     }
 
     const systemInstruction = `
@@ -127,14 +248,17 @@ export const handler = async (event: any) => {
       parts: [{ text: m.text }]
     }));
 
-    const response = await ai.models.generateContent({
-      model: activeModel,
-      contents: contents,
-      config: {
-        systemInstruction: systemInstruction,
-        maxOutputTokens: 1000,
-      }
-    });
+    const response = await withAIRequestFence(
+      ai.models.generateContent({
+        model: activeModel,
+        contents,
+        config: {
+          systemInstruction,
+          maxOutputTokens: 1000,
+        },
+      }),
+      "ally_support",
+    );
 
     let text = response.text ?? "";
 
@@ -144,81 +268,81 @@ export const handler = async (event: any) => {
       const outputTokens = response.usageMetadata?.candidatesTokenCount ?? 0;
 
       await admin.from("ai_usage_log").insert({
-        organization_id: userInfo?.orgId || null,
-        user_id: userInfo?.userId || null,
-        user_email: userInfo?.email || null,
+        organization_id,
+        user_id: user.id,
+        user_email: user.email ?? null,
         action: "ally_assistant",
         provider: "gemini",
         model: activeModel,
         input_tokens: inputTokens,
         output_tokens: outputTokens,
         duration_ms: Date.now() - start,
-        success: true
+        success: true,
+        quota_type: aiConfig.quotaType,
       });
-    } catch (logErr) {
-      console.error("[ally-support] Failed to log usage:", logErr);
+    } catch {
+      console.error("[ally-support] Failed to log usage.");
     }
 
     // Check for email trigger
-    if (text.includes("[SEND_EMAIL]") && resendKey) {
-      console.log("[ally-support] Trigger detected. Sending email via Resend...");
-      
+    if (text.includes("[SEND_EMAIL]") && deps.resendKey) {
       // Extract the last few messages for context
       const lastUserMessage = messages.filter((m: any) => m.role === 'user').pop()?.text || "N/A";
+      const safeConversation = messages
+        .map((m: any) => `<li><strong>${escapeHtml(m.role)}:</strong> ${escapeHtml(redactSecrets(m.text))}</li>`)
+        .join("");
       
       const emailBody = {
-        from: `Ally Assistant <${fromEmail}>`,
+        from: `Ally Assistant <${deps.fromEmail}>`,
         to: ["Support@aeternumally.com"],
         subject: `Support Request / Feedback from Ally Assistant`,
         html: `
           <h3>Support Request / Feedback</h3>
-          <p><strong>User Email:</strong> ${userInfo?.email || "N/A"}</p>
-          <p><strong>Company:</strong> ${userInfo?.company || "N/A"}</p>
-          <p><strong>Role:</strong> ${userInfo?.role || "N/A"}</p>
-          <p><strong>Latest User Input:</strong> ${redactSecrets(lastUserMessage)}</p>
-          <p><strong>Context:</strong> ${context || "N/A"}</p>
-          <p><strong>Captured Errors:</strong> ${errors || "None"}</p>
+          <p><strong>User Email:</strong> ${escapeHtml(userInfo.email || "N/A")}</p>
+          <p><strong>Company:</strong> ${escapeHtml(userInfo.company || "N/A")}</p>
+          <p><strong>Role:</strong> ${escapeHtml(userInfo.role || "N/A")}</p>
+          <p><strong>Latest User Input:</strong> ${escapeHtml(redactSecrets(lastUserMessage))}</p>
+          <p><strong>Context:</strong> ${escapeHtml(context || "N/A")}</p>
+          <p><strong>Captured Errors:</strong> ${escapeHtml(errors || "None")}</p>
           <hr/>
           <h4>Full Conversation History:</h4>
-          <ul>
-             ${messages.map((m: any) => `<li><strong>${m.role}:</strong> ${redactSecrets(m.text)}</li>`).join('')}
-          </ul>
+          <ul>${safeConversation}</ul>
         `,
       };
 
       try {
-        const resendResponse = await fetch("https://api.resend.com/emails", {
+        const resendResponse = await deps.fetchImpl("https://api.resend.com/emails", {
           method: "POST",
           headers: {
-            "Authorization": `Bearer ${resendKey}`,
+            "Authorization": `Bearer ${deps.resendKey}`,
             "Content-Type": "application/json",
           },
           body: JSON.stringify(emailBody),
         });
 
         if (!resendResponse.ok) {
-          const errData = await resendResponse.json();
-          console.error("[ally-support] Resend error:", errData);
+          console.error(`[ally-support] Support email failed status=${resendResponse.status}`);
         }
-      } catch (e) {
-        console.error("[ally-support] Failed to send email:", e);
+      } catch {
+        console.error("[ally-support] Failed to send support email.");
       }
 
       // Remove the tag from the text displayed to the user
       text = text.replace("[SEND_EMAIL]", "").trim();
     }
 
-    return {
-      statusCode: 200,
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ response: text }),
-    };
+    return json(200, { response: text });
 
   } catch (error: any) {
-    console.error("[ally-support] Error:", error);
-    return {
-      statusCode: 500,
-      body: JSON.stringify({ error: error.message || "Internal Server Error" }),
-    };
-  }
-};
+    const timedOut = error?.isTimeout === true;
+    console.error(`[ally-support] Request failed${timedOut ? " after timeout" : ""}.`);
+    return json(timedOut ? 504 : 500, {
+      error: timedOut
+        ? "Ally took too long to respond. Please try again."
+        : "Ally is temporarily unavailable. Please try again.",
+    });
+    }
+  };
+}
+
+export const handler = createAllySupportHandler();

--- a/netlify/functions/ally-support.ts
+++ b/netlify/functions/ally-support.ts
@@ -1,7 +1,6 @@
 import { GoogleGenAI } from "@google/genai";
 import * as fs from 'fs';
 import * as path from 'path';
-import { fileURLToPath } from "node:url";
 import { createClient } from "@supabase/supabase-js";
 import { getStore } from "@netlify/blobs";
 import {
@@ -12,7 +11,6 @@ import { withAIRequestFence } from "./_shared/aiRequestFence.js";
 import { loadOrganizationAiConfig } from "./_shared/organizationAiConfig.js";
 
 const DEFAULT_MODEL = "gemini-2.5-flash";
-const FUNCTION_DIR = path.dirname(fileURLToPath(import.meta.url));
 
 type HandlerDependencies = {
   createAdminClient: () => any;
@@ -200,8 +198,6 @@ export function createAllySupportHandler(
     try {
       const possiblePaths = [
         path.join(process.cwd(), "Docs v1.1.0", "USER_MANUAL.md"),
-        path.join(FUNCTION_DIR, "Docs v1.1.0", "USER_MANUAL.md"),
-        path.join(FUNCTION_DIR, "..", "Docs v1.1.0", "USER_MANUAL.md"),
       ];
 
       for (const p of possiblePaths) {

--- a/tests/security/ally-support-auth.test.mjs
+++ b/tests/security/ally-support-auth.test.mjs
@@ -214,4 +214,6 @@ test("frontend sends bearer auth and server console does not log conversations",
   assert.match(clientSource, /organization_id: orgId/);
   assert.doesNotMatch(clientSource, /userInfo:/);
   assert.doesNotMatch(handlerSource, /Conversation log|JSON\.stringify\(messages\)/);
+  assert.doesNotMatch(handlerSource, /import\.meta\.url|__dirname/);
+  assert.match(handlerSource, /path\.join\(process\.cwd\(\), "Docs v1\.1\.0"/);
 });

--- a/tests/security/ally-support-auth.test.mjs
+++ b/tests/security/ally-support-auth.test.mjs
@@ -1,0 +1,217 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  ALLY_MAX_MESSAGE_CHARS,
+  ALLY_MAX_MESSAGES,
+  escapeHtml,
+  parseAllySupportBody,
+} from "../../netlify/functions/_shared/allySupportSecurity.js";
+import { createAllySupportHandler } from "../../netlify/functions/ally-support.ts";
+
+const ORGANIZATION_ID = "11111111-1111-4111-8111-111111111111";
+const USER_ID = "22222222-2222-4222-8222-222222222222";
+const VALID_BODY = JSON.stringify({
+  organization_id: ORGANIZATION_ID,
+  sessionId: "session_123",
+  context: "/workspace",
+  errors: "",
+  messages: [{ role: "user", text: "How do I start?" }],
+});
+
+function createQuery(result) {
+  const query = {
+    select: () => query,
+    eq: () => query,
+    maybeSingle: async () => result,
+  };
+  return query;
+}
+
+function createHarness({ authenticated = true, member = true } = {}) {
+  const state = {
+    aiCalls: 0,
+    blobWrites: [],
+    databaseReads: [],
+    inserts: [],
+  };
+  const admin = {
+    auth: {
+      getUser: async () => authenticated
+        ? { data: { user: { id: USER_ID, email: "verified@example.com" } }, error: null }
+        : { data: { user: null }, error: { message: "expired" } },
+    },
+    from: (table) => {
+      state.databaseReads.push(table);
+      if (table === "organization_members") {
+        return createQuery({ data: member ? { role: "Manager" } : null, error: null });
+      }
+      if (table === "organization_ai_settings") {
+        return createQuery({
+          data: {
+            model: "gemini-2.5-flash",
+            use_byok: false,
+            byok_provider: null,
+            soft_quota_monthly: 100,
+          },
+          error: null,
+        });
+      }
+      if (table === "company_profiles") {
+        return createQuery({ data: { name: "Verified Company" }, error: null });
+      }
+      if (table === "ai_usage_log") {
+        return {
+          insert: async (value) => {
+            state.inserts.push(value);
+            return { error: null };
+          },
+        };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    },
+  };
+
+  const handler = createAllySupportHandler({
+    createAdminClient: () => admin,
+    createAIClient: () => ({
+      models: {
+        generateContent: async () => {
+          state.aiCalls += 1;
+          return {
+            text: "Start with your company profile.",
+            usageMetadata: { promptTokenCount: 10, candidatesTokenCount: 5 },
+          };
+        },
+      },
+    }),
+    getConversationStore: () => ({
+      setJSON: async (key, value) => state.blobWrites.push({ key, value }),
+    }),
+    fetchImpl: async () => assert.fail("support email should not be sent"),
+    platformApiKey: "platform-test-key",
+    resendKey: "",
+    fromEmail: "no-reply@example.com",
+    now: () => new Date("2026-08-18T00:00:00.000Z"),
+  });
+  return { handler, state };
+}
+
+test("Ally payload validation accepts only bounded tenant-scoped conversations", () => {
+  const parsed = parseAllySupportBody(VALID_BODY);
+  assert.equal(parsed.organizationId, ORGANIZATION_ID);
+  assert.equal(parsed.messages.length, 1);
+
+  assert.throws(
+    () => parseAllySupportBody(JSON.stringify({
+      organization_id: "not-a-uuid",
+      sessionId: "session_123",
+      messages: [{ role: "user", text: "hello" }],
+    })),
+    /organization_id/,
+  );
+  assert.throws(
+    () => parseAllySupportBody(JSON.stringify({
+      organization_id: ORGANIZATION_ID,
+      sessionId: "session_123",
+      messages: Array.from({ length: ALLY_MAX_MESSAGES + 1 }, () => ({
+        role: "user",
+        text: "hello",
+      })),
+    })),
+    error => error.status === 413,
+  );
+  assert.throws(
+    () => parseAllySupportBody(JSON.stringify({
+      organization_id: ORGANIZATION_ID,
+      sessionId: "session_123",
+      messages: [{ role: "user", text: "a".repeat(ALLY_MAX_MESSAGE_CHARS + 1) }],
+    })),
+    error => error.status === 413,
+  );
+});
+
+test("Ally rejects missing authentication before parsing or side effects", async () => {
+  const { handler, state } = createHarness();
+  const response = await handler({ httpMethod: "POST", headers: {}, body: "not-json" });
+
+  assert.equal(response.statusCode, 401);
+  assert.equal(state.aiCalls, 0);
+  assert.deepEqual(state.databaseReads, []);
+  assert.deepEqual(state.blobWrites, []);
+});
+
+test("Ally rejects expired sessions and non-members", async () => {
+  const expired = createHarness({ authenticated: false });
+  assert.equal((await expired.handler({
+    httpMethod: "POST",
+    headers: { authorization: "Bearer expired" },
+    body: VALID_BODY,
+  })).statusCode, 401);
+  assert.equal(expired.state.aiCalls, 0);
+
+  const outsider = createHarness({ member: false });
+  assert.equal((await outsider.handler({
+    httpMethod: "POST",
+    headers: { authorization: "Bearer valid" },
+    body: VALID_BODY,
+  })).statusCode, 403);
+  assert.equal(outsider.state.aiCalls, 0);
+  assert.deepEqual(outsider.state.blobWrites, []);
+});
+
+test("Ally derives tenant identity from the verified session and membership", async () => {
+  const { handler, state } = createHarness();
+  const body = JSON.stringify({
+    ...JSON.parse(VALID_BODY),
+    userInfo: {
+      orgId: "33333333-3333-4333-8333-333333333333",
+      userId: "44444444-4444-4444-8444-444444444444",
+      email: "spoofed@example.com",
+      role: "Owner",
+    },
+  });
+  const response = await handler({
+    httpMethod: "POST",
+    headers: { Authorization: "Bearer valid" },
+    body,
+  });
+
+  assert.equal(response.statusCode, 200);
+  assert.equal(state.aiCalls, 1);
+  assert.equal(state.blobWrites.length, 1);
+  assert.equal(
+    state.blobWrites[0].key,
+    `${ORGANIZATION_ID}_${USER_ID}_session_123`,
+  );
+  assert.deepEqual(state.blobWrites[0].value.userInfo, {
+    email: "verified@example.com",
+    company: "Verified Company",
+    role: "Manager",
+    userId: USER_ID,
+    orgId: ORGANIZATION_ID,
+  });
+  assert.equal(state.inserts[0].organization_id, ORGANIZATION_ID);
+  assert.equal(state.inserts[0].user_id, USER_ID);
+  assert.equal(state.inserts[0].user_email, "verified@example.com");
+});
+
+test("support email HTML escaping neutralizes caller markup", () => {
+  assert.equal(
+    escapeHtml('<img src=x onerror="alert(1)">'),
+    "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;",
+  );
+});
+
+test("frontend sends bearer auth and server console does not log conversations", async () => {
+  const [clientSource, handlerSource] = await Promise.all([
+    readFile(new URL("../../components/AllyAssistant.tsx", import.meta.url), "utf8"),
+    readFile(new URL("../../netlify/functions/ally-support.ts", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(clientSource, /Authorization: `Bearer \$\{session\.access_token\}`/);
+  assert.match(clientSource, /organization_id: orgId/);
+  assert.doesNotMatch(clientSource, /userInfo:/);
+  assert.doesNotMatch(handlerSource, /Conversation log|JSON\.stringify\(messages\)/);
+});


### PR DESCRIPTION
## Summary

- require a valid Supabase bearer token for the Ally support function
- verify organization membership before tenant settings, blob storage, Gemini, usage logs, or support email
- derive user identity and role from the verified session and database instead of request body fields
- validate and bound conversation payloads before side effects
- stop logging conversation bodies and escape all user-controlled support email HTML
- send the authenticated session token from the Ally frontend

## Security impact

Unauthenticated callers can no longer consume the platform Gemini key or attribute requests and stored support conversations to another tenant. Authenticated non-members receive `403`, and caller-supplied identity values are ignored.

## Tests

- `npm run test:security` (97 passed)
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`

## Deploy Preview checks

1. Sign in as a normal organization member and ask Ally a simple question.
2. Verify Ally returns an answer and the existing conversation notice remains visible.
3. Sign out or clear the session, then verify the endpoint returns `401`.
4. In a signed-in session, send a request with another organization UUID and verify `403`.
5. Confirm Netlify function logs contain no full conversation message bodies.

No SQL migration or new environment variable is required.

Closes #169