### PR TITLE
fix(security): prevent cross-tenant error log poisoning

### DIFF
--- a/services/errorLogService.ts
+++ b/services/errorLogService.ts
@@ -24,11 +24,12 @@ export async function logError({
     const httpStatus: number | null = (error as any)?.status ?? null;
 
     const { data: { user } } = await supabase.auth.getUser();
+    if (!user) return;
 
     await supabase.from("error_log").insert({
       organization_id: organizationId ?? null,
-      user_id: user?.id ?? null,
-      user_email: user?.email ?? null,
+      user_id: user.id,
+      user_email: user.email ?? null,
       source: "client",
       context,
       action: action ?? null,

--- a/supabase/migrations/025_secure_error_log_inserts.sql
+++ b/supabase/migrations/025_secure_error_log_inserts.sql
@@ -1,0 +1,24 @@
+-- Prevent anonymous callers and authenticated non-members from forging
+-- tenant-scoped or server-originated error records.
+
+BEGIN;
+
+DROP POLICY IF EXISTS "users_insert_errors" ON public.error_log;
+
+REVOKE INSERT ON public.error_log FROM PUBLIC, anon;
+GRANT INSERT ON public.error_log TO authenticated;
+
+CREATE POLICY "users_insert_errors" ON public.error_log
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    auth.uid() IS NOT NULL
+    AND user_id = auth.uid()
+    AND source = 'client'
+    AND (
+      organization_id IS NULL
+      OR public.is_org_member(organization_id)
+    )
+  );
+
+COMMIT;

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -422,8 +422,22 @@ CREATE POLICY "admins_read_errors" ON error_log
     organization_id IS NOT NULL
     AND user_org_role(organization_id) IN ('Owner', 'Admin')
   );
+
+REVOKE INSERT ON error_log FROM PUBLIC, anon;
+GRANT INSERT ON error_log TO authenticated;
+
 CREATE POLICY "users_insert_errors" ON error_log
-  FOR INSERT WITH CHECK (user_id = auth.uid() OR user_id IS NULL);
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (
+    auth.uid() IS NOT NULL
+    AND user_id = auth.uid()
+    AND source = 'client'
+    AND (
+      organization_id IS NULL
+      OR is_org_member(organization_id)
+    )
+  );
 
 -- ============================================================
 -- ATOMIC ORG CREATION RPC

--- a/tests/security/error-log-rls.test.mjs
+++ b/tests/security/error-log-rls.test.mjs
@@ -1,0 +1,47 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const POLICY_PATTERN = /CREATE POLICY "users_insert_errors"[\s\S]+?\n\s*\);/;
+
+test("error log inserts require an authenticated user and tenant membership", async () => {
+  const [migration, schema] = await Promise.all([
+    readFile(new URL(
+      "../../supabase/migrations/025_secure_error_log_inserts.sql",
+      import.meta.url,
+    ), "utf8"),
+    readFile(new URL("../../supabase/schema.sql", import.meta.url), "utf8"),
+  ]);
+
+  assert.match(
+    migration,
+    /DROP POLICY IF EXISTS "users_insert_errors" ON public\.error_log/,
+  );
+
+  for (const source of [migration, schema]) {
+    const policy = source.match(POLICY_PATTERN)?.[0];
+    assert.ok(policy, "users_insert_errors policy must exist");
+    assert.match(policy, /FOR INSERT\s+TO authenticated/);
+    assert.match(policy, /auth\.uid\(\) IS NOT NULL/);
+    assert.match(policy, /user_id = auth\.uid\(\)/);
+    assert.match(policy, /source = 'client'/);
+    assert.match(policy, /organization_id IS NULL/);
+    assert.match(policy, /is_org_member\(organization_id\)/);
+    assert.doesNotMatch(policy, /OR user_id IS NULL/);
+
+    assert.match(source, /REVOKE INSERT ON (?:public\.)?error_log FROM PUBLIC, anon/);
+    assert.match(source, /GRANT INSERT ON (?:public\.)?error_log TO authenticated/);
+  }
+});
+
+test("the browser logger never submits anonymous or server-originated rows", async () => {
+  const source = await readFile(
+    new URL("../../services/errorLogService.ts", import.meta.url),
+    "utf8",
+  );
+
+  assert.match(source, /if \(!user\) return/);
+  assert.match(source, /user_id: user\.id/);
+  assert.match(source, /source: "client"/);
+  assert.doesNotMatch(source, /user_id: user\?\.id \?\? null/);
+});


### PR DESCRIPTION
## Summary

- replace the permissive `error_log` INSERT policy with an authenticated, tenant-aware policy
- revoke direct INSERT from `anon` and `PUBLIC`
- require browser rows to use the current user ID and `source = 'client'`
- allow organization-scoped rows only when the caller is a member
- stop the browser logger before it attempts an anonymous/null-user insert
- update the canonical schema and add RLS contract tests

## Security impact

The public Supabase anon key can no longer be used to forge server-originated errors, write rows for another tenant, or flood null-user error records. Netlify Functions continue writing server errors with the service role, which bypasses RLS.

## Required Supabase migration

Run this file in the Supabase SQL Editor before production verification:

`supabase/migrations/025_secure_error_log_inserts.sql`

No environment variable is required.

After running it, verify the deployed policy:

```sql
select policyname, roles, cmd, with_check
from pg_policies
where schemaname = 'public'
  and tablename = 'error_log'
order by policyname;
```

The `users_insert_errors` row should show only `authenticated` and a check requiring the current user, client source, and organization membership.

## Tests

- `npm run test:security` (99 passed)
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`

## Manual verification

1. Apply migration 025.
2. Confirm the policy query above reports `{authenticated}`.
3. Sign in and exercise a normal application flow; client error logging remains best-effort and should not affect the UI.
4. Confirm an anonymous PostgREST insert into `error_log` returns an authorization/RLS error.
5. Confirm an authenticated member cannot insert with `source = 'server'` or another user's `user_id`.

Closes #171