### PR TITLE
fix(security): redact tenant AI output from logs

### DIFF
--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -165,7 +165,7 @@ const handler = async (event: any) => {
   let outputTokens = 0;
   let success = true;
   let errorMessage: string | null = null;
-  let rawAiResponse: string | null = null;
+  let aiResponseChars: number | null = null;
   let upstreamStatus: number | null = null;
   let userFacingMessage = "Something went wrong while contacting the AI service.";
 
@@ -178,15 +178,20 @@ const handler = async (event: any) => {
     inputTokens = outcome.inputTokens;
     outputTokens = outcome.outputTokens;
   } catch (error: any) {
-    console.error("API Error:", error);
     success = false;
-    rawAiResponse = error?.rawAiResponse ?? null;
+    aiResponseChars = Number.isSafeInteger(error?.aiResponseChars)
+      ? error.aiResponseChars
+      : null;
     upstreamStatus =
       error?.isTimeout
         ? 504
         : (typeof error?.status === "number" && error.status) ||
           (typeof error?.error?.code === "number" && error.error.code) ||
           null;
+    const errorType = error instanceof Error ? error.name : "UnknownError";
+    console.error(
+      `[api] AI request failed action=${action} status=${upstreamStatus ?? "unknown"} type=${errorType}`,
+    );
     errorMessage = error?.error?.message || (error instanceof Error ? error.message : String(error));
     userFacingMessage =
       error?.isTimeout
@@ -242,7 +247,7 @@ const handler = async (event: any) => {
         metadata: {
           model,
           duration_ms: durationMs,
-          raw_ai_response: rawAiResponse,
+          response_chars: aiResponseChars,
         },
       });
     } catch (logErr) {
@@ -341,7 +346,9 @@ function parseAIJson<T>(text: string | undefined, fallback: T): T {
   // 3. Extract first [...] or {...} block as last resort
   const block = text.match(/(\[[\s\S]*\]|\{[\s\S]*\})/);
   if (block) try { return JSON.parse(block[0]) as T; } catch {}
-  console.warn("parseAIJson: could not parse response, returning fallback. text:", text.slice(0, 200));
+  console.warn(
+    `parseAIJson: could not parse response; returning fallback (chars=${text.length}).`,
+  );
   return fallback;
 }
 
@@ -822,9 +829,9 @@ Return ONLY valid JSON, no markdown:
     return { result: safe, ...extractTokens(response) };
 
   } catch (err: any) {
-    // Re-throw with the raw AI response attached so the handler can write it to error_log
+    // Preserve response size for diagnostics without retaining tenant content.
     const enriched = new Error(err instanceof Error ? err.message : String(err)) as any;
-    enriched.rawAiResponse = rawText.slice(0, 3000);
+    enriched.aiResponseChars = rawText.length;
     throw enriched;
   }
 }

--- a/netlify/functions/assessment-background.ts
+++ b/netlify/functions/assessment-background.ts
@@ -354,7 +354,9 @@ Return ONLY valid JSON, no markdown:
         },
       });
 
-      console.log(`[assessment-background] Scoring raw response:`, response.text);
+      console.info(
+        `[assessment-background] Scoring output chars=${response.text?.length ?? 0} finishReason=${response.candidates?.[0]?.finishReason ?? "unknown"}`,
+      );
 
       totalInputTokens += Number(response.usageMetadata?.promptTokenCount ?? 0);
       totalOutputTokens += Number(response.usageMetadata?.candidatesTokenCount ?? 0);
@@ -434,7 +436,9 @@ Return ONLY valid JSON, no markdown:
     });
 
   } catch (error: any) {
-    console.error(`[assessment-background] Failed for ${action}:`, error);
+    console.error(
+      `[assessment-background] Failed action=${action} type=${error instanceof Error ? error.name : "UnknownError"}`,
+    );
     const failData: any = { updated_at: new Date().toISOString() };
     if (action === "autofill") {
       failData.autofill_status = "failed";

--- a/netlify/functions/dma-background.ts
+++ b/netlify/functions/dma-background.ts
@@ -190,7 +190,7 @@ const handler = async (event: any) => {
 
         const modelCfg = MODEL_REGISTRY[activeModel];
         if (text.length > modelCfg.maxAllowedOutputChars) {
-          console.warn("[dma-background] oversized output tail", text.slice(-1000));
+          console.warn(`[dma-background] oversized output chars=${text.length}`);
           throw new Error(`AI output too large: ${text.length} chars`);
         }
 
@@ -276,8 +276,6 @@ const handler = async (event: any) => {
       },
     });
 
-    console.log(`[dma-background] Synthesis raw response:`, synthesisResponse.text);
-
     let insight_result;
     try {
       const text = synthesisResponse.text ?? "";
@@ -297,7 +295,7 @@ const handler = async (event: any) => {
 
       const modelCfg = MODEL_REGISTRY[activeModel];
       if (text.length > modelCfg.maxAllowedOutputChars) {
-        console.warn("[dma-background] oversized synthesis output tail", text.slice(-1000));
+        console.warn(`[dma-background] oversized synthesis output chars=${text.length}`);
         throw new Error(`AI output too large: ${text.length} chars`);
       }
 
@@ -341,7 +339,9 @@ const handler = async (event: any) => {
     console.log(`[dma-background] Successfully completed and saved to DB for org=${organization_id}`);
 
   } catch (error: any) {
-    console.error("[dma-background] Failed:", error);
+    console.error(
+      `[dma-background] Failed type=${error instanceof Error ? error.name : "UnknownError"}`,
+    );
     let friendlyError = error.message || String(error);
     if (friendlyError.includes("fetch failed") || friendlyError.includes("Timeout")) {
       friendlyError = "The AI Model service timed out or failed to respond. This can happen with Gemini Pro on large tasks. Please try again or use Gemini Flash for faster results.";

--- a/netlify/functions/report-background.ts
+++ b/netlify/functions/report-background.ts
@@ -60,9 +60,10 @@ const handler = async (event: any) => {
     try {
       const cleaned = text.replace(/^```json\s*/, "").replace(/\s*```$/, "");
       return JSON.parse(cleaned);
-    } catch (e: any) {
-      console.warn("[report-background] Failed to parse AI JSON. Length:", text.length, "Error:", e.message);
-      console.warn("[report-background] Snippet of end:", text.slice(-100));
+    } catch (error: any) {
+      console.warn(
+        `[report-background] Failed to parse AI JSON chars=${text.length} type=${error instanceof Error ? error.name : "UnknownError"}`,
+      );
       return fallback;
     }
   }

--- a/tests/security/ai-log-redaction.test.mjs
+++ b/tests/security/ai-log-redaction.test.mjs
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("AI functions retain diagnostics without logging tenant response content", async () => {
+  const [api, assessment, dma, report] = await Promise.all([
+    readFile(new URL("../../netlify/functions/api.ts", import.meta.url), "utf8"),
+    readFile(new URL(
+      "../../netlify/functions/assessment-background.ts",
+      import.meta.url,
+    ), "utf8"),
+    readFile(new URL("../../netlify/functions/dma-background.ts", import.meta.url), "utf8"),
+    readFile(new URL(
+      "../../netlify/functions/report-background.ts",
+      import.meta.url,
+    ), "utf8"),
+  ]);
+
+  assert.doesNotMatch(api, /raw_ai_response|rawAiResponse/);
+  assert.doesNotMatch(api, /console\.(?:log|warn|error)\([^\n]*(?:rawText|response\.text)/);
+  assert.doesNotMatch(api, /text\.slice\(0,\s*200\)/);
+  assert.match(api, /response_chars: aiResponseChars/);
+  assert.match(api, /enriched\.aiResponseChars = rawText\.length/);
+  assert.match(api, /could not parse response; returning fallback \(chars=\$\{text\.length\}\)/);
+
+  assert.doesNotMatch(assessment, /Scoring raw response/);
+  assert.doesNotMatch(
+    assessment,
+    /console\.(?:log|info|warn|error)\([^\n]*response\.text\s*[,)]/,
+  );
+  assert.match(assessment, /Scoring output chars=\$\{response\.text\?\.length \?\? 0\}/);
+
+  assert.doesNotMatch(dma, /Synthesis raw response|output tail|slice\(-1000\)/);
+  assert.doesNotMatch(
+    dma,
+    /console\.(?:log|info|warn|error)\([^\n]*synthesisResponse\.text/,
+  );
+  assert.match(dma, /oversized output chars=\$\{text\.length\}/);
+  assert.match(dma, /oversized synthesis output chars=\$\{text\.length\}/);
+
+  assert.doesNotMatch(report, /Snippet of end|text\.slice\(-100\)/);
+  assert.doesNotMatch(report, /Failed to parse AI JSON[^\n]*error\.message/i);
+  assert.match(report, /Failed to parse AI JSON chars=\$\{text\.length\}/);
+});


### PR DESCRIPTION
## Summary

- remove complete assessment scoring and DMA synthesis responses from Netlify logs
- remove raw output prefixes and tails from all AI JSON parse and oversized-output diagnostics
- replace `raw_ai_response` in `error_log.metadata` with `response_chars`
- log only safe diagnostics such as action, model, output size, finish reason, error type, and provider status
- avoid passing complete AI/SDK error objects to the affected top-level logs
- add a regression scan covering API, assessment, DMA, and report functions

## Security impact

Company profiles, BMC/SWOT context, impact descriptions, financial descriptions, assessment reasoning, strategic synthesis, and report fragments are no longer copied into Netlify logs or AI error metadata. Normal AI results and job persistence are unchanged.

Netlify log access and retention configuration still needs manual verification as an operational follow-up.

## Tests

- `npm run test:security` (100 passed)
- `npx tsc --noEmit`
- `npm run build`
- `git diff --check`
- source scan confirms no production references to `raw_ai_response`, raw response logs, response tails, or parser snippets

## Deploy Preview checks

1. Trigger one assessment AI scoring operation and confirm the result still appears normally.
2. If practical, trigger DMA synthesis and confirm its saved result still loads.
3. Inspect Netlify function logs:
   - diagnostics may include output character counts and finish reason
   - logs must not contain scoring reasoning, strategic synthesis text, report fragments, prompts, or customer descriptions
4. Triggering an ordinary AI error should display the existing generic user-facing message.

No SQL migration or environment variable is required.

Closes #173