### PR TITLE
fix(evidence): resolve upload entitlement from organizations.tier

### DIFF
--- a/netlify/functions/_shared/organizationTier.js
+++ b/netlify/functions/_shared/organizationTier.js
@@ -1,0 +1,54 @@
+// @ts-check
+
+/**
+ * Organization billing/access tier resolution.
+ *
+ * The canonical column is `organizations.tier` (migration 015). It is the only
+ * place a tier is stored — there is no `subscription_tier` column — so every
+ * server-side entitlement check must read it through this helper.
+ */
+
+/** Tier identifiers accepted by the `organizations.tier` CHECK constraint. */
+export const ORGANIZATION_TIERS = /** @type {const} */ ([
+  "free",
+  "starter",
+  "pro",
+  "enterprise",
+]);
+
+export const DEFAULT_ORGANIZATION_TIER = "free";
+
+/**
+ * Resolve an organization's tier. Fails closed to `free` when the row is
+ * missing, the value is unrecognized, or the lookup errors, so a database
+ * problem can never hand out paid capacity.
+ *
+ * @param {any} admin Supabase service-role client
+ * @param {string} organizationId
+ * @returns {Promise<string>}
+ */
+export async function loadOrganizationTier(admin, organizationId) {
+  const { data, error } = await admin
+    .from("organizations")
+    .select("tier")
+    .eq("id", organizationId)
+    .maybeSingle();
+
+  if (error) {
+    console.error(`[tier] lookup failed org=${organizationId}`);
+    return DEFAULT_ORGANIZATION_TIER;
+  }
+
+  return normalizeOrganizationTier(data?.tier);
+}
+
+/**
+ * @param {unknown} tier
+ * @returns {string}
+ */
+export function normalizeOrganizationTier(tier) {
+  return typeof tier === "string" &&
+    /** @type {readonly string[]} */ (ORGANIZATION_TIERS).includes(tier)
+    ? tier
+    : DEFAULT_ORGANIZATION_TIER;
+}

--- a/netlify/functions/evidence.ts
+++ b/netlify/functions/evidence.ts
@@ -12,21 +12,26 @@
  * Storage bucket: 'evidence-files'
  * Create it in Supabase dashboard → Storage → New bucket → evidence-files (private).
  *
- * Quota limits (MB):
+ * Quota limits (MB), keyed by `organizations.tier`:
  *   free       → 0 (link-only, no direct upload)
+ *   starter    → 1 024 (1 GB)
  *   pro        → 10 240 (10 GB)
  *   enterprise → 102 400 (100 GB)
  */
 
 import { createClient } from '@supabase/supabase-js';
+import { loadOrganizationTier } from './_shared/organizationTier.js';
 
 const SUPABASE_URL   = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL || '';
 const SERVICE_KEY    = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
 const BUCKET         = 'evidence-files';
 const MAX_MB         = 25;
 
+// One entry per tier in the `organizations.tier` CHECK constraint. An unknown
+// tier resolves to 0 MB, which blocks upload rather than granting free storage.
 const QUOTA_MAP: Record<string, number> = {
   free:       0,
+  starter:    1_024,
   pro:        10_240,
   enterprise: 102_400,
 };
@@ -248,14 +253,9 @@ async function isMember(admin: any, orgId: string, userId: string): Promise<bool
 }
 
 async function getOrgTier(admin: any, orgId: string): Promise<string> {
-  // Placeholder — when subscription management is added, query it here.
-  // For now: all orgs are 'free' (link-only). Set to 'pro' to unlock uploads.
-  const { data } = await admin
-    .from('organizations')
-    .select('subscription_tier')
-    .eq('id', orgId)
-    .maybeSingle();
-  return (data?.subscription_tier as string | null) ?? 'free';
+  // Reads the canonical `organizations.tier` column (migration 015), which
+  // platform admins set from the admin console. Fails closed to 'free'.
+  return loadOrganizationTier(admin, orgId);
 }
 
 async function getStorageQuota(

--- a/tests/security/evidence-tier-entitlement.test.mjs
+++ b/tests/security/evidence-tier-entitlement.test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  DEFAULT_ORGANIZATION_TIER,
+  ORGANIZATION_TIERS,
+  loadOrganizationTier,
+  normalizeOrganizationTier,
+} from "../../netlify/functions/_shared/organizationTier.js";
+
+/** Minimal service-role client stub: organizations.select().eq().maybeSingle() */
+function stubAdmin(response) {
+  const calls = [];
+  return {
+    calls,
+    from(table) {
+      calls.push({ table });
+      return {
+        select(columns) {
+          calls[calls.length - 1].columns = columns;
+          return {
+            eq(column, value) {
+              calls[calls.length - 1].filter = { column, value };
+              return { maybeSingle: async () => response };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+test("the tier helper reads the canonical organizations.tier column", async () => {
+  const admin = stubAdmin({ data: { tier: "pro" }, error: null });
+
+  assert.equal(await loadOrganizationTier(admin, "org-1"), "pro");
+  assert.deepEqual(admin.calls, [
+    { table: "organizations", columns: "tier", filter: { column: "id", value: "org-1" } },
+  ]);
+});
+
+test("tier resolution fails closed instead of granting paid capacity", async () => {
+  const missingRow = stubAdmin({ data: null, error: null });
+  assert.equal(await loadOrganizationTier(missingRow, "org-1"), "free");
+
+  const lookupError = stubAdmin({ data: null, error: { message: "boom" } });
+  assert.equal(await loadOrganizationTier(lookupError, "org-1"), "free");
+
+  const unknownTier = stubAdmin({ data: { tier: "platinum" }, error: null });
+  assert.equal(await loadOrganizationTier(unknownTier, "org-1"), "free");
+
+  assert.equal(DEFAULT_ORGANIZATION_TIER, "free");
+  for (const value of [undefined, null, "", "PRO", 3, {}]) {
+    assert.equal(normalizeOrganizationTier(value), "free");
+  }
+});
+
+test("the tier list matches the organizations.tier CHECK constraint", async () => {
+  const [migration, schema] = await Promise.all([
+    readFile(new URL("../../supabase/migrations/015_org_tier_status.sql", import.meta.url), "utf8"),
+    readFile(new URL("../../supabase/schema.sql", import.meta.url), "utf8"),
+  ]);
+
+  for (const source of [migration, schema]) {
+    const constraint = source.match(/CHECK \(tier IN \(([^)]*)\)\)/)?.[1];
+    assert.ok(constraint, "organizations.tier CHECK constraint must exist");
+    const declared = constraint.split(",").map((value) => value.trim().replace(/'/g, ""));
+    assert.deepEqual(declared, [...ORGANIZATION_TIERS]);
+  }
+});
+
+test("evidence uploads resolve entitlements from tier, with a quota for every tier", async () => {
+  const source = await readFile(
+    new URL("../../netlify/functions/evidence.ts", import.meta.url),
+    "utf8",
+  );
+
+  // Regression: the handler previously queried a column that does not exist,
+  // which silently downgraded every organization to the link-only free tier.
+  assert.doesNotMatch(source, /subscription_tier/);
+  assert.match(source, /loadOrganizationTier\(admin, orgId\)/);
+
+  const quotaMap = source.match(/const QUOTA_MAP: Record<string, number> = \{([\s\S]*?)\};/)?.[1];
+  assert.ok(quotaMap, "QUOTA_MAP must exist");
+
+  const quotas = Object.fromEntries(
+    [...quotaMap.matchAll(/^\s*(\w+):\s*([\d_]+),/gm)].map(([, tier, mb]) => [
+      tier,
+      Number(mb.replace(/_/g, "")),
+    ]),
+  );
+
+  assert.deepEqual(Object.keys(quotas).sort(), [...ORGANIZATION_TIERS].sort());
+  assert.equal(quotas.free, 0, "the free tier stays link-only");
+  for (const tier of ORGANIZATION_TIERS.filter((t) => t !== "free")) {
+    assert.ok(quotas[tier] > 0, `${tier} must receive upload capacity`);
+  }
+
+  // An unrecognized tier must map to 0 MB rather than an open-ended default.
+  assert.match(source, /QUOTA_MAP\[tier\] \?\? 0/);
+});


### PR DESCRIPTION
## Problem

`getOrgTier()` in `netlify/functions/evidence.ts` queried `organizations.subscription_tier`. That column does not exist anywhere in the schema — migration 015 named it `tier`. PostgREST returns an error, `data` is null, and the helper falls through to `'free'`, whose entry in `QUOTA_MAP` is `0` MB.

Net effect: **direct evidence upload returns 403 for every organization**, including ones a platform admin has explicitly set to `pro` or `enterprise` from the admin console. The only gated paid feature in the product cannot be switched on.

`starter` was also missing from `QUOTA_MAP` entirely, so it would have fallen back to 0 MB even after the column was fixed.

## Change

- New `netlify/functions/_shared/organizationTier.js` — one server-side resolver for `organizations.tier`, following the existing `_shared/*.js` convention. It fails closed to `free` on a missing row, an unrecognized value, or a lookup error, so a database problem can never hand out paid capacity.
- `evidence.ts` uses it, and gains a `starter` quota of 1 GB. An unknown tier still resolves to 0 MB rather than open-ended storage.
- New `tests/security/evidence-tier-entitlement.test.mjs` pins the tier list to the `organizations.tier` CHECK constraint in **both** `015_org_tier_status.sql` and `schema.sql`, and asserts every tier has a quota entry — so the map and the database cannot drift apart again. It also asserts `subscription_tier` never reappears in the handler.

No migration required; this reads a column that already exists.

## Quota values

`starter` at 1 GB is a placeholder — set it to whatever the commercial plan says before this ships. The other three are unchanged from the original header comment.

## Verification

```
npm run test:security   # 112 pass (108 before, 4 new)
npx tsc --noEmit         # clean
npm run build            # clean
```

Worth checking in a deploy preview: set one org to `pro` from the admin console and confirm upload now succeeds and the quota bar reports 10 GB.

🤖 Generated with [Claude Code](https://claude.com/claude-code)