### PR TITLE
feat(ai): enforce the monthly platform AI quota

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,8 @@ netlify/functions/
   google-drive.ts     Authenticated Drive proxy; never returns OAuth tokens
   google-callback.ts  OAuth callback with hashed, expiring state
   evidence.ts         Tenant-aware evidence operations
+  _shared/organizationTier.js  Canonical organizations.tier resolver; fails closed to free
+  _shared/aiQuota.js           Monthly platform AI ceiling per tier
   invite.ts           Invitation CRUD + rate-limited public resend
   accept-invite.ts    Authenticated invite validation + member join
   ally-support.ts     Authenticated, tenant-bound support AI
@@ -150,6 +152,7 @@ Singleton tables (profile, canvas, SWOT) use `useOrgData` which auto-saves on st
 | `MATERIALITY_THRESHOLD` | `constants.ts` | `40` | Topics above this on either axis are material |
 | `DEFAULT_MODEL` | `netlify/functions/api.ts` | `"gemini-2.5-flash"` | Used when org has no AI settings row |
 | Invite expiry | `supabase/schema.sql` | `now() + interval '7 days'` | Hardcoded in DB default |
+| `MONTHLY_AI_CALL_LIMITS` | `netlify/functions/_shared/aiQuota.js` | free 100 / starter 500 / pro 2 000 / enterprise 10 000 | Enforced monthly platform AI ceiling; `organization_ai_settings.soft_quota_monthly` overrides it per org |
 
 ---
 
@@ -164,6 +167,7 @@ Singleton tables (profile, canvas, SWOT) use `useOrgData` which auto-saves on st
 - Public invite resend is generic, centrally rate-limited, and has a delivery cooldown.
 - Ally support authenticates the user and verifies organization membership before side effects.
 - Client error logs bind user and tenant identity in RLS; AI handlers do not log tenant output content.
+- Platform AI calls are capped per organization per month. Both AI entry points (`api.ts` and `ally-support.ts`) return 429 before any provider call once the ceiling is spent; BYOK tenants bypass the cap because they pay the provider directly.
 
 ## Known gaps (track; do not introduce workarounds)
 

--- a/netlify/functions/_shared/aiQuota.js
+++ b/netlify/functions/_shared/aiQuota.js
@@ -1,0 +1,110 @@
+// @ts-check
+
+import { normalizeOrganizationTier } from "./organizationTier.js";
+
+/**
+ * Monthly platform AI call ceilings, by organization tier.
+ *
+ * These are the allowances the platform pays for. A tenant using its own key
+ * (BYOK) is billed by the provider directly and is never counted here.
+ * A per-organization override lives in
+ * `organization_ai_settings.soft_quota_monthly`.
+ */
+export const MONTHLY_AI_CALL_LIMITS = {
+  free: 100,
+  starter: 500,
+  pro: 2_000,
+  enterprise: 10_000,
+};
+
+/**
+ * `ai_usage_log.quota_type` value for a platform-funded call.
+ *
+ * @param {unknown} tier
+ * @returns {string}
+ */
+export function platformQuotaType(tier) {
+  return `platform_${normalizeOrganizationTier(tier)}`;
+}
+
+/**
+ * The enforced ceiling for an organization. An explicit non-negative override
+ * always wins, including 0, which suspends platform AI for that tenant.
+ *
+ * @param {unknown} tier
+ * @param {unknown} softQuotaMonthly
+ * @returns {number}
+ */
+export function resolveMonthlyCallLimit(tier, softQuotaMonthly) {
+  if (Number.isInteger(softQuotaMonthly) && Number(softQuotaMonthly) >= 0) {
+    return Number(softQuotaMonthly);
+  }
+  return MONTHLY_AI_CALL_LIMITS[normalizeOrganizationTier(tier)]
+    ?? MONTHLY_AI_CALL_LIMITS.free;
+}
+
+/**
+ * First instant of the current calendar month, in UTC.
+ *
+ * @param {Date} [now]
+ * @returns {string}
+ */
+export function monthStartIso(now = new Date()) {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString();
+}
+
+/**
+ * Decide whether an organization may make another platform AI call this month.
+ *
+ * If the usage lookup itself fails the call is allowed: that path is a
+ * service-role read of our own telemetry, a tenant cannot induce it, and
+ * taking every AI feature offline during a database incident is worse than
+ * briefly over-serving. The `degraded` flag records that it happened.
+ *
+ * @param {any} admin Supabase service-role client
+ * @param {string} organizationId
+ * @param {unknown} tier
+ * @param {unknown} softQuotaMonthly
+ * @param {Date} [now]
+ */
+export async function checkMonthlyAiQuota(
+  admin,
+  organizationId,
+  tier,
+  softQuotaMonthly,
+  now,
+) {
+  const limit = resolveMonthlyCallLimit(tier, softQuotaMonthly);
+
+  const { count, error } = await admin
+    .from("ai_usage_log")
+    .select("id", { count: "exact", head: true })
+    .eq("organization_id", organizationId)
+    .eq("success", true)
+    .gte("created_at", monthStartIso(now));
+
+  if (error) {
+    console.warn(
+      `[quota] usage lookup failed org=${organizationId} — allowing call`,
+    );
+    return { allowed: true, used: null, limit, degraded: true };
+  }
+
+  const used = count ?? 0;
+  return { allowed: used < limit, used, limit, degraded: false };
+}
+
+/**
+ * User-facing 429 body. Deliberately free of tenant data.
+ *
+ * @param {{ used: number | null, limit: number }} quota
+ */
+export function quotaExceededResponse(quota) {
+  return {
+    error:
+      `This organization has used its ${quota.limit} AI requests for this month. `
+      + `The allowance resets on the 1st. An Owner or Admin can add the organization's `
+      + `own API key under Settings to continue immediately.`,
+    quota: { used: quota.used, limit: quota.limit },
+  };
+}

--- a/netlify/functions/ally-support.ts
+++ b/netlify/functions/ally-support.ts
@@ -9,6 +9,12 @@ import {
 } from "./_shared/allySupportSecurity.js";
 import { withAIRequestFence } from "./_shared/aiRequestFence.js";
 import { loadOrganizationAiConfig } from "./_shared/organizationAiConfig.js";
+import { loadOrganizationTier } from "./_shared/organizationTier.js";
+import {
+  checkMonthlyAiQuota,
+  platformQuotaType,
+  quotaExceededResponse,
+} from "./_shared/aiQuota.js";
 
 const DEFAULT_MODEL = "gemini-2.5-flash";
 
@@ -164,6 +170,28 @@ export function createAllySupportHandler(
       return json(503, { error: "Ally's AI settings are temporarily unavailable." });
     }
 
+    // Ally draws on the same monthly platform allowance as the rest of the app,
+    // so a long support conversation cannot bypass the tenant's ceiling.
+    let quotaType = aiConfig.quotaType;
+    if (!aiConfig.useBYOK) {
+      const tier = await loadOrganizationTier(admin, organization_id);
+      quotaType = platformQuotaType(tier);
+
+      const quota = await checkMonthlyAiQuota(
+        admin,
+        organization_id,
+        tier,
+        aiConfig.softQuotaMonthly,
+      );
+
+      if (!quota.allowed) {
+        console.warn(
+          `[quota] ally org=${organization_id} tier=${tier} used=${quota.used}/${quota.limit} — request blocked`,
+        );
+        return json(429, quotaExceededResponse(quota));
+      }
+    }
+
     const company = await getCompanyName(admin, organization_id);
     const userInfo = {
       email: user.email ?? null,
@@ -274,7 +302,7 @@ export function createAllySupportHandler(
         output_tokens: outputTokens,
         duration_ms: Date.now() - start,
         success: true,
-        quota_type: aiConfig.quotaType,
+        quota_type: quotaType,
       });
     } catch {
       console.error("[ally-support] Failed to log usage.");

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -6,6 +6,12 @@ import {
 } from "./_shared/internalJobAuth.js";
 import { withAIRequestFence } from "./_shared/aiRequestFence.js";
 import { loadOrganizationAiConfig } from "./_shared/organizationAiConfig.js";
+import { loadOrganizationTier } from "./_shared/organizationTier.js";
+import {
+  checkMonthlyAiQuota,
+  platformQuotaType,
+  quotaExceededResponse,
+} from "./_shared/aiQuota.js";
 
 const apiKey = process.env.GEMINI_API_KEY;
 const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
@@ -129,28 +135,28 @@ const handler = async (event: any) => {
   } = aiConfig;
 
   // ------------------------------------------------------------------
-  // 4a. Soft quota check (platform calls only, BYOK bypasses)
+  // 4a. Monthly AI quota (platform calls only; BYOK bills the tenant)
   // ------------------------------------------------------------------
+  // The ceiling is the org's `soft_quota_monthly` override when set, otherwise
+  // the tier default. Exceeding it returns 429 before any provider call, so
+  // platform AI spend has an upper bound per tenant per month.
+  let effectiveQuotaType = quotaType;
   if (!useBYOK) {
-    const PLATFORM_SOFT_LIMIT = softQuotaMonthly ?? 100;
-    const monthStart = new Date();
-    monthStart.setDate(1);
-    monthStart.setHours(0, 0, 0, 0);
+    const tier = await loadOrganizationTier(admin, organization_id);
+    effectiveQuotaType = platformQuotaType(tier);
 
-    const { count: monthlyCount } = await admin
-      .from("ai_usage_log")
-      .select("id", { count: "exact", head: true })
-      .eq("organization_id", organization_id)
-      .eq("success", true)
-      .gte("created_at", monthStart.toISOString());
+    const quota = await checkMonthlyAiQuota(
+      admin,
+      organization_id,
+      tier,
+      softQuotaMonthly,
+    );
 
-    const callsUsed = monthlyCount ?? 0;
-
-    // Soft limit: log a warning but do NOT block. Admins can raise via soft_quota_monthly.
-    if (callsUsed >= PLATFORM_SOFT_LIMIT) {
+    if (!quota.allowed) {
       console.warn(
-        `[quota] org=${organization_id} used=${callsUsed}/${PLATFORM_SOFT_LIMIT} — soft limit reached (proceeding anyway)`
+        `[quota] org=${organization_id} tier=${tier} used=${quota.used}/${quota.limit} — request blocked`,
       );
+      return json(429, quotaExceededResponse(quota));
     }
   }
 
@@ -225,7 +231,7 @@ const handler = async (event: any) => {
         error_message: success ? null : errorMessage,
         http_status: success ? null : upstreamStatus,
         estimated_cost_usd: success ? Number(estimateCost(model, inputTokens, outputTokens).toFixed(6)) : 0,
-        quota_type: quotaType,
+        quota_type: effectiveQuotaType,
       });
     }
   } catch (logErr) {

--- a/supabase/migrations/026_ai_quota_enforcement.sql
+++ b/supabase/migrations/026_ai_quota_enforcement.sql
@@ -1,0 +1,36 @@
+-- ============================================================
+-- Migration 026 — AI quota enforcement
+-- ============================================================
+-- The monthly platform AI allowance is now enforced (HTTP 429) rather than
+-- logged and ignored. Two supporting changes:
+--
+--   1. quota_type gains 'platform_starter'. Migration 015 introduced four
+--      tiers but the quota_type CHECK from 007 only covered three, so usage
+--      rows for a starter organization would have been rejected.
+--   2. soft_quota_monthly is documented as the enforced ceiling it now is.
+--      NULL still means "use the tier default".
+--
+-- Rollback:
+--   ALTER TABLE public.ai_usage_log DROP CONSTRAINT ai_usage_log_quota_type_check;
+--   ALTER TABLE public.ai_usage_log ADD CONSTRAINT ai_usage_log_quota_type_check
+--     CHECK (quota_type IN ('platform_free','platform_pro','platform_enterprise','byok'));
+-- ============================================================
+
+ALTER TABLE public.ai_usage_log
+  DROP CONSTRAINT IF EXISTS ai_usage_log_quota_type_check;
+
+ALTER TABLE public.ai_usage_log
+  ADD CONSTRAINT ai_usage_log_quota_type_check
+  CHECK (quota_type IN (
+    'platform_free',
+    'platform_starter',
+    'platform_pro',
+    'platform_enterprise',
+    'byok'
+  ));
+
+COMMENT ON COLUMN public.ai_usage_log.quota_type
+  IS 'Allowance the call drew from: platform_<organizations.tier> or byok';
+
+COMMENT ON COLUMN public.organization_ai_settings.soft_quota_monthly
+  IS 'Enforced monthly platform AI call ceiling for this organization. NULL = tier default from netlify/functions/_shared/aiQuota.js. 0 suspends platform AI.';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -775,13 +775,13 @@ COMMENT ON TABLE notification_delivery_log IS 'Audit trail for all notification 
 
 ALTER TABLE ai_usage_log
   ADD COLUMN IF NOT EXISTS quota_type text
-    CHECK (quota_type IN ('platform_free', 'platform_pro', 'platform_enterprise', 'byok')),
+    CHECK (quota_type IN ('platform_free', 'platform_starter', 'platform_pro', 'platform_enterprise', 'byok')),
   ADD COLUMN IF NOT EXISTS metadata jsonb;
 
 CREATE INDEX IF NOT EXISTS idx_ai_usage_quota
   ON ai_usage_log (organization_id, quota_type, created_at);
 
-COMMENT ON COLUMN ai_usage_log.quota_type IS 'Track whether call used platform quota or user BYOK key';
+COMMENT ON COLUMN ai_usage_log.quota_type IS 'Allowance the call drew from: platform_<organizations.tier> or byok';
 COMMENT ON COLUMN ai_usage_log.metadata   IS 'Optional context: { linked_to_type, linked_to_id, prompt_version }';
 -- Migration 008: Persist DMA quality checks, strategic insights, and suggested tasks
 --
@@ -932,7 +932,7 @@ COMMENT ON COLUMN organization_ai_settings.byok_provider
 COMMENT ON COLUMN organization_ai_settings.byok_api_key
   IS 'User-supplied API key; stored encrypted. Never returned to the browser.';
 COMMENT ON COLUMN organization_ai_settings.soft_quota_monthly
-  IS 'Per-org monthly call soft limit override. NULL = server default (100 for free orgs).';
+  IS 'Enforced monthly platform AI call ceiling for this organization. NULL = tier default from netlify/functions/_shared/aiQuota.js. 0 suspends platform AI.';
 -- Migration 013: user_profiles table
 -- Stores per-user profile information (display name, phone, mobile, notes).
 -- Separate from auth.users so it can be extended without touching Supabase Auth.

--- a/tests/security/ai-quota-enforcement.test.mjs
+++ b/tests/security/ai-quota-enforcement.test.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  MONTHLY_AI_CALL_LIMITS,
+  checkMonthlyAiQuota,
+  monthStartIso,
+  platformQuotaType,
+  quotaExceededResponse,
+  resolveMonthlyCallLimit,
+} from "../../netlify/functions/_shared/aiQuota.js";
+import { ORGANIZATION_TIERS } from "../../netlify/functions/_shared/organizationTier.js";
+
+/** Stub for admin.from("ai_usage_log").select(...).eq().eq().gte() */
+function stubUsage(result) {
+  const filters = [];
+  return {
+    filters,
+    from() {
+      const chain = {
+        select: (columns, options) => {
+          filters.push({ columns, options });
+          return chain;
+        },
+        eq: (column, value) => {
+          filters.push({ column, value });
+          return chain;
+        },
+        gte: async (column, value) => {
+          filters.push({ column, value });
+          return result;
+        },
+      };
+      return chain;
+    },
+  };
+}
+
+test("every tier has a monthly ceiling", () => {
+  assert.deepEqual(
+    Object.keys(MONTHLY_AI_CALL_LIMITS).sort(),
+    [...ORGANIZATION_TIERS].sort(),
+  );
+  for (const tier of ORGANIZATION_TIERS) {
+    assert.ok(MONTHLY_AI_CALL_LIMITS[tier] > 0, `${tier} needs an allowance`);
+  }
+});
+
+test("an explicit per-org override wins over the tier default", () => {
+  assert.equal(resolveMonthlyCallLimit("pro", 25), 25);
+  assert.equal(resolveMonthlyCallLimit("pro", 0), 0, "0 suspends platform AI");
+  assert.equal(resolveMonthlyCallLimit("pro", null), MONTHLY_AI_CALL_LIMITS.pro);
+  assert.equal(resolveMonthlyCallLimit("pro", undefined), MONTHLY_AI_CALL_LIMITS.pro);
+  assert.equal(resolveMonthlyCallLimit("pro", -5), MONTHLY_AI_CALL_LIMITS.pro);
+  assert.equal(resolveMonthlyCallLimit("pro", "500"), MONTHLY_AI_CALL_LIMITS.pro);
+  // An unknown tier must not inherit an enterprise-sized allowance.
+  assert.equal(resolveMonthlyCallLimit("platinum", null), MONTHLY_AI_CALL_LIMITS.free);
+});
+
+test("quota_type is derived from the tier and stays within the CHECK constraint", async () => {
+  const [migration, schema] = await Promise.all([
+    readFile(new URL("../../supabase/migrations/026_ai_quota_enforcement.sql", import.meta.url), "utf8"),
+    readFile(new URL("../../supabase/schema.sql", import.meta.url), "utf8"),
+  ]);
+
+  assert.equal(platformQuotaType("starter"), "platform_starter");
+  assert.equal(platformQuotaType("platinum"), "platform_free");
+
+  for (const source of [migration, schema]) {
+    // Ignore SQL comments so a documented rollback statement is not mistaken
+    // for the live constraint.
+    const executable = source.replace(/^\s*--.*$/gm, "");
+    const allowed = executable.match(/CHECK \(quota_type IN \(([\s\S]*?)\)\)/)?.[1];
+    assert.ok(allowed, "quota_type CHECK constraint must exist");
+    for (const tier of ORGANIZATION_TIERS) {
+      assert.ok(
+        allowed.includes(`'${platformQuotaType(tier)}'`),
+        `${platformQuotaType(tier)} must be an accepted quota_type`,
+      );
+    }
+    assert.ok(allowed.includes("'byok'"));
+  }
+});
+
+test("calls are blocked once the month's allowance is spent", async () => {
+  const under = stubUsage({ count: 99, error: null });
+  const atLimit = stubUsage({ count: 100, error: null });
+  const over = stubUsage({ count: 5_000, error: null });
+
+  assert.equal((await checkMonthlyAiQuota(under, "org-1", "free", null)).allowed, true);
+  assert.equal((await checkMonthlyAiQuota(atLimit, "org-1", "free", null)).allowed, false);
+  assert.equal((await checkMonthlyAiQuota(over, "org-1", "free", null)).allowed, false);
+
+  // The count is scoped to this org, successful calls only, this month only.
+  assert.deepEqual(under.filters, [
+    { columns: "id", options: { count: "exact", head: true } },
+    { column: "organization_id", value: "org-1" },
+    { column: "success", value: true },
+    { column: "created_at", value: monthStartIso() },
+  ]);
+
+  const now = new Date("2026-09-17T12:34:56.000Z");
+  assert.equal(monthStartIso(now), "2026-09-01T00:00:00.000Z");
+});
+
+test("a telemetry outage degrades to allow rather than taking AI offline", async () => {
+  const broken = stubUsage({ count: null, error: { message: "timeout" } });
+  const result = await checkMonthlyAiQuota(broken, "org-1", "free", null);
+
+  assert.equal(result.allowed, true);
+  assert.equal(result.degraded, true);
+  assert.equal(result.used, null);
+});
+
+test("the quota response carries no tenant data", () => {
+  const body = quotaExceededResponse({ used: 120, limit: 100 });
+  assert.match(body.error, /100 AI requests/);
+  assert.deepEqual(body.quota, { used: 120, limit: 100 });
+  assert.doesNotMatch(JSON.stringify(body), /organization_id|user_id|@/);
+});
+
+test("both AI entry points enforce the ceiling before calling the provider", async () => {
+  const [api, ally] = await Promise.all([
+    readFile(new URL("../../netlify/functions/api.ts", import.meta.url), "utf8"),
+    readFile(new URL("../../netlify/functions/ally-support.ts", import.meta.url), "utf8"),
+  ]);
+
+  for (const [name, source] of [["api.ts", api], ["ally-support.ts", ally]]) {
+    assert.match(source, /checkMonthlyAiQuota\(/, `${name} must check the quota`);
+    assert.match(source, /json\(429, quotaExceededResponse\(quota\)\)/, `${name} must return 429`);
+    assert.match(source, /platformQuotaType\(tier\)/, `${name} must log the tier-aware quota type`);
+
+    // The gate must precede the provider call in source order.
+    assert.ok(
+      source.indexOf("checkMonthlyAiQuota(") < source.indexOf("generateContent"),
+      `${name} must check the quota before calling Gemini`,
+    );
+  }
+
+  // Regression: the old handler logged the breach and continued anyway.
+  assert.doesNotMatch(api, /proceeding anyway/);
+  assert.doesNotMatch(api, /PLATFORM_SOFT_LIMIT/);
+});

--- a/tests/security/ally-support-auth.test.mjs
+++ b/tests/security/ally-support-auth.test.mjs
@@ -29,7 +29,12 @@ function createQuery(result) {
   return query;
 }
 
-function createHarness({ authenticated = true, member = true } = {}) {
+function createHarness({
+  authenticated = true,
+  member = true,
+  tier = "free",
+  monthlyAiCalls = 0,
+} = {}) {
   const state = {
     aiCalls: 0,
     blobWrites: [],
@@ -61,13 +66,20 @@ function createHarness({ authenticated = true, member = true } = {}) {
       if (table === "company_profiles") {
         return createQuery({ data: { name: "Verified Company" }, error: null });
       }
+      if (table === "organizations") {
+        return createQuery({ data: { tier }, error: null });
+      }
       if (table === "ai_usage_log") {
-        return {
+        const countQuery = {
+          select: () => countQuery,
+          eq: () => countQuery,
+          gte: async () => ({ count: monthlyAiCalls, error: null }),
           insert: async (value) => {
             state.inserts.push(value);
             return { error: null };
           },
         };
+        return countQuery;
       }
       throw new Error(`Unexpected table: ${table}`);
     },
@@ -195,6 +207,41 @@ test("Ally derives tenant identity from the verified session and membership", as
   assert.equal(state.inserts[0].organization_id, ORGANIZATION_ID);
   assert.equal(state.inserts[0].user_id, USER_ID);
   assert.equal(state.inserts[0].user_email, "verified@example.com");
+});
+
+test("Ally refuses to spend AI budget past the organization's monthly ceiling", async () => {
+  // soft_quota_monthly is 100 in the harness; 100 calls already logged.
+  const exhausted = createHarness({ monthlyAiCalls: 100 });
+  const blocked = await exhausted.handler({
+    httpMethod: "POST",
+    headers: { Authorization: "Bearer valid" },
+    body: VALID_BODY,
+  });
+
+  assert.equal(blocked.statusCode, 429);
+  assert.equal(exhausted.state.aiCalls, 0, "no provider call once the quota is spent");
+  assert.deepEqual(exhausted.state.blobWrites, [], "no conversation is stored");
+
+  const withinQuota = createHarness({ monthlyAiCalls: 99 });
+  const allowed = await withinQuota.handler({
+    httpMethod: "POST",
+    headers: { Authorization: "Bearer valid" },
+    body: VALID_BODY,
+  });
+
+  assert.equal(allowed.statusCode, 200);
+  assert.equal(withinQuota.state.aiCalls, 1);
+});
+
+test("Ally records the usage row against the organization's tier", async () => {
+  const { handler, state } = createHarness({ tier: "pro" });
+  await handler({
+    httpMethod: "POST",
+    headers: { Authorization: "Bearer valid" },
+    body: VALID_BODY,
+  });
+
+  assert.equal(state.inserts[0].quota_type, "platform_pro");
 });
 
 test("support email HTML escaping neutralizes caller markup", () => {


### PR DESCRIPTION
> **Stacked on #180** — base is `codex/fix-evidence-tier-gate`, because this reuses the `organizationTier.js` resolver added there. Merge #180 first and this retargets to `main` cleanly.

## Problem

`api.ts` counted the month's AI calls, compared them to the limit, and then logged this:

```
[quota] org=… used=…/… — soft limit reached (proceeding anyway)
```

…and ran the request anyway. So:

- platform AI spend had **no upper bound** per tenant per month;
- `organization_ai_settings.soft_quota_monthly` — the admin-facing override — did nothing at all;
- `quota_type` was hardcoded to `platform_free` for every organization, so usage analytics could not attribute spend to a plan.

The README's note asking demo users to be patient about quota errors is the downstream symptom: the ceiling was upstream at Google, not here.

## Change

New `netlify/functions/_shared/aiQuota.js`:

| Tier | Monthly platform AI calls |
|---|---|
| free | 100 |
| starter | 500 |
| pro | 2 000 |
| enterprise | 10 000 |

- A per-org `soft_quota_monthly` override always wins when set, including `0`, which suspends platform AI for that tenant.
- `api.ts` and `ally-support.ts` both return **429 before any provider call** once the ceiling is spent. Ally is included because it draws on the same allowance; a long support conversation should not be a way around the cap.
- BYOK tenants are exempt — they pay the provider directly.
- `quota_type` is now `platform_<tier>`.

**Migration 026** adds `platform_starter` to the `quota_type` CHECK constraint. Migration 015 introduced the starter tier but the constraint from 007 only ever listed three, so usage rows for a starter org would have been rejected on insert. It also restates the `soft_quota_monthly` comment as the enforced ceiling it now is.

### Deliberate design note

If the usage-count query itself errors, the call is **allowed** and the result is flagged `degraded`. A tenant cannot induce that path (it is a service-role read of our own telemetry), and taking every AI feature offline during a database incident is worse than briefly over-serving. Happy to flip this to fail-closed if you would rather cap spend hard.

## ⚠️ Before merging

Enforcement starts the moment this deploys. Any organization that has already spent its tier allowance **this month** will start getting 429s immediately — the demo org almost certainly has, since nothing has ever blocked it. Consider one of:

1. Set `soft_quota_monthly` generously for existing orgs first, then tighten; or
2. Raise the `free` default above current real usage — check with
   `select organization_id, count(*) from ai_usage_log where success and created_at >= date_trunc('month', now()) group by 1 order by 2 desc;`

The numbers in the table are my placeholders. They should be whatever the commercial plan says.

## Verification

```
npm run test:security   # 121 pass (112 before, 9 new)
npx tsc --noEmit         # clean
npm run build            # clean
```

New `tests/security/ai-quota-enforcement.test.mjs` covers the tier/override precedence, month boundary, the exact usage filters, the degraded path, the tenant-data-free 429 body, and — via source assertions — that both entry points gate *before* `generateContent`. `ally-support-auth.test.mjs` gains a stub for the new lookups plus two behavioural tests (blocked at the ceiling, tier-aware `quota_type`); its existing assertions are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)