### PR TITLE
ci: verify every pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,58 @@
+# Runs the verification steps AGENTS.md requires before every merge, so they
+# cannot be skipped by forgetting to run them locally.
+#
+#   npm run test:security   security regression suite
+#   npx tsc --noEmit        type check
+#   npm run build           production build
+#   npm audit --omit=dev    runtime dependency audit
+#
+# The audit is deliberately scoped with --omit=dev: the deferred `extract-zip`
+# advisory (#152) lives in Netlify local tooling and is tracked separately by
+# tests/security/netlify-tooling-dependencies.test.mjs, which fails if it ever
+# becomes reachable from a runtime path.
+
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: Tests, types, build, audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out the branch
+        uses: actions/checkout@v4
+
+      # Node 22: tests run through --experimental-strip-types.
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Security regression tests
+        run: npm run test:security
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+      - name: Production build
+        run: npm run build
+
+      - name: Runtime dependency audit
+        run: npm audit --omit=dev --audit-level=high


### PR DESCRIPTION
## Problem

`AGENTS.md` states the delivery workflow:

> 3. Run `npm run test:security`, `npx tsc --noEmit`, and `npm run build`.
> 4. Run `npm audit --omit=dev` for dependency or release work.

Nothing enforced any of it. `.github/` contains issue and PR templates only. The security suite — thirteen files pinning ten closed findings, several Critical — runs only when a human remembers to run it. That is the weakest link in an otherwise careful security posture: the tests exist precisely so a regression cannot come back silently, and today one could.

## Change

One `verify` job on pull requests and pushes to `main`, running the four documented steps in order.

Notes on the choices:

- **Node 22**, because `test:security` runs through `--experimental-strip-types`, which needs 22.6+. Worth flagging: the README says "Node 20+", which is accurate for the app but not for the test suite. Happy to correct the README here or leave it to the docs PR.
- **`--audit-level=high`** on the runtime audit. `npm audit --omit=dev` currently reports zero vulnerabilities, so this passes today.
- **`--omit=dev`** keeps the deferred `extract-zip` advisory (#152) from blocking every PR. That one is already guarded by `tests/security/netlify-tooling-dependencies.test.mjs`, which fails if it ever becomes reachable from a runtime path — so the deferral stays honest rather than merely ignored.
- **`permissions: contents: read`** and a concurrency group that cancels superseded runs.

## Follow-up worth considering

Once this has a green run, making it a required status check on `main` is what actually closes the hole — the workflow alone still lets a merge through while it is red.

## Verification

All four steps pass locally against this branch:

```
npm run test:security   # 108 pass
npx tsc --noEmit         # clean
npm run build            # clean
npm audit --omit=dev     # found 0 vulnerabilities
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)