### PR TITLE
docs: add a roadmap and repair the documentation links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ This project does not yet use semantic versioning. Entries are dated.
 
 ---
 
+## [Unreleased]
+
+### Fixed
+- **Evidence upload entitlement** — `evidence.ts` resolved the organization tier
+  from `organizations.subscription_tier`, a column that does not exist; migration
+  015 named it `tier`. Every organization therefore fell back to `free` (0 MB) and
+  direct upload returned 403 even for organizations a platform admin had set to
+  `pro` or `enterprise`. Tier resolution now goes through
+  `netlify/functions/_shared/organizationTier.js`, which reads the canonical column
+  and fails closed. The missing `starter` storage quota was added.
+
+### Added
+- **Enforced monthly AI quota** — the platform allowance was counted, logged as
+  "soft limit reached (proceeding anyway)", and then ignored, so platform AI spend
+  had no upper bound per tenant and `soft_quota_monthly` had no effect. Both AI
+  entry points (`api.ts`, `ally-support.ts`) now return HTTP 429 before any
+  provider call once the ceiling is spent. BYOK tenants are exempt.
+  `quota_type` is recorded as `platform_<tier>` rather than always `platform_free`.
+- **CI workflow** (`.github/workflows/ci.yml`) — runs the four verification steps
+  `AGENTS.md` requires (security tests, type check, build, runtime audit) on every
+  pull request and push to `main`.
+- **`ROADMAP.md`** — `CONTRIBUTING.md` referred contributors to a roadmap that did
+  not exist.
+
+### Changed
+- **Documentation links** — `README.md` and `CONTRIBUTING.md` linked into a `docs/`
+  directory that does not exist; the published documentation is in `Docs v1.1.0/`.
+  The stated Node prerequisite moved from 20+ to 22+, which is what
+  `npm run test:security` actually requires.
+- **AI Studio import map removed** from `index.html`. It pointed React, react-dom,
+  recharts, lucide-react and `@google/genai` at a third-party CDN. It was inert
+  after bundling, but it had to go before a restrictive CSP is possible.
+
+### Migrations to run (in order)
+
+| File | What it does |
+|---|---|
+| `026_ai_quota_enforcement.sql` | Adds `platform_starter` to the `ai_usage_log.quota_type` CHECK constraint (migration 015 added the tier; the constraint was never extended) and restates `soft_quota_monthly` as an enforced ceiling |
+
+---
+
 ## [1.1.0] — 2026-05-10
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ The app is available at `http://localhost:8888`.
 
 ### Environment variables
 
-Open `.env` and fill in all five values. See [docs/DEPLOYMENT.md](./docs/DEPLOYMENT.md#environment-variables) for what each variable does and where to find the values.
+Open `.env` and fill in all five values. See [docs/DEPLOYMENT.md](./Docs%20v1.1.0/DEPLOYMENT.md#environment-variables) for what each variable does and where to find the values.
 
 ### Database setup
 
@@ -341,7 +341,7 @@ See [SECURITY.md](./SECURITY.md) for our full security policy.
  
 **Want to help but don't know where to start?**
 - Look for issues labeled `good first issue`
-- Check the roadmap for upcoming features
+- Check the [roadmap](./ROADMAP.md) for upcoming features
 - Improve documentation — it's always appreciated!
  
 ---

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Generates a report compliant with **ESRS 2 (General Disclosures)** and **Topical
 
 ## 🛠️ Quick start
 
-Prerequisites: **Node 20+**, **npm**, a **Supabase** project, a **Google Gemini API key**.
+Prerequisites: **Node 22+**, **npm**, a **Supabase** project, a **Google Gemini API key**.
 
 ```bash
 git clone <this-repo>
@@ -89,7 +89,7 @@ npm install
 npm run dev:netlify           # Vite + Netlify Functions on http://localhost:8888
 ```
 
-Full setup (Supabase project, schema, migrations, Netlify deploy) is in [`docs/DEPLOYMENT.md`](./docs/DEPLOYMENT.md).
+Full setup (Supabase project, schema, migrations, Netlify deploy) is in [`Docs v1.1.0/DEPLOYMENT.md`](./Docs%20v1.1.0/DEPLOYMENT.md).
 
 > ⚠️ Always use `npm run dev:netlify` (not `npm run dev`) when working on API code — the latter does not expose `/.netlify/functions/*`.
 
@@ -97,8 +97,9 @@ Full setup (Supabase project, schema, migrations, Netlify deploy) is in [`docs/D
 
 ## 📚 Documentation
 
-*   **[Tech Stack](./docs/TECH_STACK.md)** — Architecture, frontend/backend stack, database schema, RLS, security model
-*   **[Deployment](./docs/DEPLOYMENT.md)** — Setup, environment variables, deploy flow, schema migrations, local development, troubleshooting
+*   **[Tech Stack](./Docs%20v1.1.0/TECH_STACK.md)** — Architecture, frontend/backend stack, database schema, RLS, security model
+*   **[Deployment](./Docs%20v1.1.0/DEPLOYMENT.md)** — Setup, environment variables, deploy flow, schema migrations, local development, troubleshooting
+*   **[Roadmap](./ROADMAP.md)** — What is planned next, what is deliberately not planned, and the open questions behind both
 
 ---
 ## Live Demo
@@ -109,7 +110,7 @@ You can try the live version of AeternumAlly at: [demo.aeternumally.com](https:/
 ---
 ## ⚠️ Known Limitations
 - **AI Quota:** The live demo uses a shared API quota. During peak times, you may encounter rate limiting.
-- **Self-Hosting:** For heavy usage, we recommend self-hosting AeternumAlly and providing your own API keys (refer to [`docs/DEPLOYMENT.md`](./docs/DEPLOYMENT.md).).
+- **Self-Hosting:** For heavy usage, we recommend self-hosting AeternumAlly and providing your own API keys (refer to [`Docs v1.1.0/DEPLOYMENT.md`](./Docs%20v1.1.0/DEPLOYMENT.md).).
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,143 @@
+<!-- Version: 1.0.0 — Last updated: 2026-09-05 -->
+
+# Roadmap
+
+What is planned, what is deliberately not planned, and why. `CONTRIBUTING.md`
+points contributors here before they pick up work.
+
+This file states intent. It is not a commitment to dates. Confirmed security
+findings are tracked separately in
+[`Docs v1.1.0/known issue - security review.md`](./Docs%20v1.1.0/known%20issue%20-%20security%20review.md);
+shipped work is in [`CHANGELOG.md`](./CHANGELOG.md).
+
+---
+
+## Where the product stands
+
+Phase 1 (v1.0.0) delivered the core reporting workflow. Phase 2 delivered the
+DMA Insight Hub, Task Management, Carbon Accounting, and the Evidence Vault —
+the planning package is archived under
+`Archived/docs/phase-2-planning-2026-05/`. An unplanned platform-admin console,
+the Ally support assistant, the Start Here onboarding paths, and the Company
+Strategic Report were added alongside them.
+
+The August 2026 security cycle closed ten findings, each with a named
+regression test.
+
+So the product surface is broad. What is thin is everything that turns that
+surface into a business: the commercial loop is not closed, correctness of the
+generated numbers is not covered by tests, and the output is not yet something
+an assurance provider could sign.
+
+That shapes the ordering below.
+
+---
+
+## Now
+
+Closing the gap between what the product does and what it can charge for or
+guarantee. Small, mostly unglamorous, all blocking.
+
+| Item | Why it is first |
+|---|---|
+| **Enforce the AI ceiling** | Platform AI spend had no upper bound per tenant. Fixed; ceilings still need commercial numbers rather than placeholders. |
+| **Working tier entitlements** | The evidence upload gate read a column that does not exist, so the only paid feature could not be switched on for anyone. |
+| **CI on every pull request** | `AGENTS.md` mandates four verification steps before merge. Until now all four ran only if someone remembered. |
+| **This file, and accurate docs** | `CONTRIBUTING.md` sent contributors to a roadmap that did not exist; `README.md` linked to a `docs/` directory that does not exist. |
+| **Drop the AI Studio import map** | `index.html` still carries a scaffold import map pointing React, recharts and lucide at a third-party CDN. Inert after bundling, but it has to go before a restrictive CSP is possible. |
+
+### Also in this bucket, not yet started
+
+- **Set the real quota and storage numbers.** The tier limits currently in
+  `_shared/aiQuota.js` and `evidence.ts` are placeholders.
+- **Resolve the duplicate `008_` migration prefix.** Two files share it, while
+  the documented rule is "apply in filename order". Ordering is currently
+  decided by alphabetical luck.
+- **Decide what to do with `notification_channels`.** The table and its
+  delivery log exist in the schema with no product code behind them. Either
+  build the reminder feature Phase 2 implied, or drop the tables.
+
+---
+
+## Next
+
+### 1. Close the commercial loop
+
+Tiers exist in the database and in the admin console. There is no billing, no
+self-serve upgrade, and no way for an organization to move between plans
+without a platform admin editing a row. The Phase 2 success metric — 18% free
+to Pro conversion — cannot be measured, let alone hit, until this exists.
+
+Deliberately staged: an admin-activated paid tier with manual invoicing is a
+legitimate first version and answers the question that matters, which is
+whether anyone pays at all. Self-serve checkout can follow the evidence.
+
+### 2. Test the numbers, not just the boundaries
+
+The security suite is strong. There is no test anywhere for the arithmetic the
+product exists to produce:
+
+- the impact score formula and the materiality threshold in `constants.ts`
+- emission factor selection and Scope 1/2/3 totals
+- spreadsheet import column mapping and unit conversion
+- GRI ↔ ESRS index mapping
+
+For a compliance tool the calculations *are* the product. A wrong materiality
+score is a worse failure than an outage.
+
+### 3. Trust and provenance
+
+Before anything generated here goes in front of an auditor, a reader needs to
+know where each statement came from:
+
+- per-field provenance — AI-drafted vs. human-edited, by whom, when
+- report versioning, so a published statement can be reproduced later
+- evidence linked to the specific disclosure it supports, not just the topic
+- a tenant-visible audit trail
+
+This is also the most defensible thing to charge for.
+
+### 4. Systematic AI trust boundaries
+
+Tracked in `AGENTS.md` under known gaps. Tenant-supplied text is interpolated
+into prompts whose output becomes a published compliance statement. Prompt
+trust boundaries, structured output validation on every action, and an
+explicit human approval step before AI text is persisted.
+
+---
+
+## Later
+
+- **Assurance-ready export.** Structured/tagged output rather than
+  print-to-PDF, and multi-year comparatives.
+- **Build-time Tailwind and a restrictive CSP.** Blocked on removing the CDN
+  script tag; tracked in `AGENTS.md` known gaps.
+- **Centralized origin/CORS policy** across Netlify Functions.
+- **Multi-organization membership.** `fetchMembership()` takes the first row it
+  finds and there is no organization switcher, so a user belongs to exactly one
+  organization in practice. The README names ESG consultants as a target user;
+  a consultant with two clients cannot currently serve both from one account.
+- **Internationalization.** There is no i18n layer. The Tailwind font stack
+  already lists `Noto Sans Thai`, so the intent exists; the decision is whether
+  the market justifies the cost before the string count grows further.
+
+---
+
+## Open questions
+
+These are unresolved, and the answers change the ordering above.
+
+**Which standard should an SME be pushed toward?** The product assumes full
+ESRS topical reporting with double materiality. If most SMEs are now outside
+mandatory CSRD scope and are being pulled in instead by supply-chain and bank
+requests, the standard they are actually asked for may be materially lighter
+than what the workflow produces. The "Stakeholder Request Readiness" path in
+Start Here is the closest thing to an answer already in the product. Validate
+against the current directive text before committing engineering to it.
+
+**Is the surface already too wide for the team?** Nineteen views and
+twenty-nine tables. Every new feature is a permanent maintenance obligation.
+The bar for adding another one should be higher than the bar was for the last.
+
+**What is the smallest paid thing someone would buy today?** Worth answering
+before building the billing system that assumes the answer.


### PR DESCRIPTION
## Problem

Two separate things, both about a contributor's or self-hoster's first ten minutes.

**1. There is no roadmap.** `CONTRIBUTING.md` says:

> - Check the roadmap for upcoming features

There isn't one. Phase 2 planning is archived under `Archived/docs/phase-2-planning-2026-05/` and explicitly marked historical — "Do not use this archive as an implementation specification". So nothing in the repository states what comes next. Given how carefully `known issue - security review.md` tracks security work, the absence is conspicuous.

**2. Every link into `./docs/` is a 404.** The published documentation lives in `Docs v1.1.0/`. Broken links, all previously live:

| File | Link |
|---|---|
| `README.md` | `./docs/DEPLOYMENT.md` ×3 — including the Quick start line a new self-hoster follows first |
| `README.md` | `./docs/TECH_STACK.md` |
| `CONTRIBUTING.md` | `./docs/DEPLOYMENT.md#environment-variables` |

## Change

- **`ROADMAP.md`** — Now / Next / Later, with the reasoning behind the ordering rather than just a list. It states what is deliberately *not* planned, and ends with three open questions that would change the ordering if answered differently. Notably it does not invent dates.
- All `./docs/` links repointed to `./Docs%20v1.1.0/`, and `CONTRIBUTING.md`'s roadmap mention now actually links here.
- Node prerequisite corrected from 20+ to 22+: `npm run test:security` runs through `--experimental-strip-types`, which needs 22.6+, so the stated minimum could not run the test suite.
- `CHANGELOG.md` gains an `Unreleased` section covering this and the four sibling PRs, including migration 026.

## Please read the roadmap critically

It is my reading of the repository after going through the code, schema, security register and archived planning — not a decision. The parts most worth your disagreement:

- **It puts closing the commercial loop ahead of new features.** Tiers exist in the database and admin console; billing, self-serve upgrade and measurable conversion do not. The Phase 2 metric of 18% free→Pro cannot be evaluated as things stand.
- **It flags that nothing tests the arithmetic** — impact scores, the materiality threshold, emission factor selection, GRI mapping. The security suite is strong; the calculations the product exists to produce are untested.
- **It raises whether ESRS topical + double materiality is the right depth for the SME buyer**, versus what supply-chain and bank requests actually ask for. I have not verified the current directive text and say so in the file; the Start Here "Stakeholder Request Readiness" path suggests you have already been thinking about this.

Cut or rewrite anything you disagree with — the file is more useful accurate than complete.

## Verification

No code changes. Every relative link in the three touched documents was checked to resolve against a real file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)