### PR TITLE
chore(build): drop the AI Studio import map

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,18 +41,6 @@
         }
       }
     </script>
-  <script type="importmap">
-{
-  "imports": {
-    "recharts": "https://aistudiocdn.com/recharts@^3.4.1",
-    "lucide-react": "https://aistudiocdn.com/lucide-react@^0.554.0",
-    "@google/genai": "https://aistudiocdn.com/@google/genai@^1.30.0",
-    "react-dom/": "https://aistudiocdn.com/react-dom@^19.2.0/",
-    "react/": "https://aistudiocdn.com/react@^19.2.0/",
-    "react": "https://aistudiocdn.com/react@^19.2.0"
-  }
-}
-</script>
 </head>
   <body class="bg-slate-50 text-slate-900 font-sans antialiased transition-colors duration-200">
     <div id="root"></div>


### PR DESCRIPTION
## Problem

`index.html` still carries the import map from the original AI Studio scaffold:

```html
<script type="importmap">
{ "imports": {
    "recharts":      "https://aistudiocdn.com/recharts@^3.4.1",
    "lucide-react":  "https://aistudiocdn.com/lucide-react@^0.554.0",
    "@google/genai": "https://aistudiocdn.com/@google/genai@^1.30.0",
    "react-dom/":    "https://aistudiocdn.com/react-dom@^19.2.0/",
    "react/":        "https://aistudiocdn.com/react@^19.2.0/",
    "react":         "https://aistudiocdn.com/react@^19.2.0"
} }
</script>
```

Vite bundles all five from `node_modules` and rewrites the specifiers, so **nothing actually resolves through it** — I checked the built assets and none reference `aistudiocdn`. But the map itself is copied verbatim into `dist/index.html` and ships to production, declaring a trust relationship with a third-party CDN the application does not use.

That matters for the restrictive CSP tracked under known gaps in `AGENTS.md`: writing one means either allowlisting a host we do not depend on, or shipping a policy that contradicts the page's own import map.

## Change

Delete the block. No other change.

## Verification

```
npm run build            # clean; dist/index.html now has 0 aistudiocdn references (was 6)
npx tsc --noEmit         # clean
npm run test:security    # 108 pass
```

The bundle emits no bare specifiers, so there is nothing left for an import map to resolve.

## Related

The other half of the CSP blocker — `<script src="https://cdn.tailwindcss.com">` in the same file — is a real runtime dependency and needs an actual build-pipeline migration. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)