### PR TITLE
feat(admin): make tier changeable and show the enforced AI ceiling

### DIFF
--- a/Docs v1.1.0/ADMIN_MANUAL.md
+++ b/Docs v1.1.0/ADMIN_MANUAL.md
@@ -59,6 +59,7 @@ This module allows you to oversee all tenant organizations registered on the pla
 ### Managing Existing Companies
 - **Search & Sort:** Use the search bar to find specific companies, and click column headers to sort by Tier, Member Count, Creation Date, or Status.
 - **Detail View:** Click on any company name to view a detailed breakdown of their activity and specific platform statistics.
+- **Tier:** The tier shown in the Tier column is a dropdown. Changing it takes effect immediately and moves both the organization's monthly AI call allowance and its evidence storage quota, so you are asked to confirm. The change is recorded in the function log against your admin email.
 - **Status Toggle:** Use the **Deactivate / Reactivate** button to freeze or unfreeze an organization's access. Deactivating a company immediately revokes access for all its members.
 - **Data Export:** Click **Export** to download a comprehensive archive of the company's sustainability data (useful for manual backups or support requests).
 

--- a/components/AIUsagePanel.tsx
+++ b/components/AIUsagePanel.tsx
@@ -65,8 +65,9 @@ const ACTION_COLORS: Record<string, string> = {
   generateTasks:                 "#fb923c",
 };
 
-// Platform soft limit shown in the quota bar (same default as api.ts)
-const PLATFORM_SOFT_LIMIT_DEFAULT = 100;
+// Fallback only for the moment before settings load; the real ceiling is
+// resolved server-side and returned as `monthly_call_limit`.
+const MONTHLY_LIMIT_FALLBACK = 100;
 
 const AIUsagePanel: React.FC<Props> = ({ organizationId, currentUserRole }) => {
   const canManage = currentUserRole === "Owner" || currentUserRole === "Admin";
@@ -92,7 +93,7 @@ const AIUsagePanel: React.FC<Props> = ({ organizationId, currentUserRole }) => {
   // ── Usage data ───────────────────────────────────────────────────
   const [usage, setUsage] = useState<AiUsageRow[]>([]);
   const [monthlyCallCount, setMonthlyCallCount] = useState<number>(0);
-  const [softQuotaMonthly, setSoftQuotaMonthly] = useState<number | null>(null);
+  const [monthlyCallLimit, setMonthlyCallLimit] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   // Fetch settings + recent usage + this month's count on mount
@@ -113,7 +114,7 @@ const AIUsagePanel: React.FC<Props> = ({ organizationId, currentUserRole }) => {
         setSavedUseBYOK(settings.use_byok);
         setByokProvider(settings.byok_provider ?? "gemini");
         setHasStoredKey(settings.has_byok_key);
-        setSoftQuotaMonthly(settings.soft_quota_monthly);
+        setMonthlyCallLimit(settings.monthly_call_limit);
       }
       setUsage(log);
       setMonthlyCallCount(monthCount);
@@ -324,13 +325,14 @@ const AIUsagePanel: React.FC<Props> = ({ organizationId, currentUserRole }) => {
               <Hash className="w-4 h-4 text-esg-600" /> Monthly call quota
             </h3>
             <p className="text-sm text-slate-500 dark:text-slate-400">
-              Platform quota resets on the 1st of each month. Enable BYOK below to bypass it.
+              AI features pause when this is spent, and the allowance resets on the 1st.
+              Enable BYOK below to bypass it entirely.
             </p>
           </header>
 
           <QuotaBar
             used={monthlyCallCount}
-            limit={softQuotaMonthly ?? PLATFORM_SOFT_LIMIT_DEFAULT}
+            limit={monthlyCallLimit ?? MONTHLY_LIMIT_FALLBACK}
           />
         </section>
       )}
@@ -612,13 +614,13 @@ const QuotaBar: React.FC<{ used: number; limit: number }> = ({ used, limit }) =>
         }`}>
           <AlertCircle className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
           {isOver
-            ? "Soft quota exceeded. AI calls are still allowed but you may want to enable BYOK or contact support."
-            : "Approaching monthly quota. Consider enabling BYOK to avoid interruptions."}
+            ? "Monthly quota reached. AI features are paused until the allowance resets on the 1st. Enable BYOK below to continue now, or contact support to raise the limit."
+            : "Approaching the monthly quota. Enable BYOK, or contact support to raise the limit, before AI features pause."}
         </div>
       )}
       <div className="flex justify-between items-center text-xs text-slate-600 dark:text-slate-400">
         <span>{used.toLocaleString()} calls used</span>
-        <span>{limit.toLocaleString()} soft limit</span>
+        <span>{limit.toLocaleString()} monthly limit</span>
       </div>
       <div className="h-2 bg-slate-100 dark:bg-slate-700 rounded-full overflow-hidden">
         <div
@@ -626,7 +628,7 @@ const QuotaBar: React.FC<{ used: number; limit: number }> = ({ used, limit }) =>
           style={{ width: `${pct}%` }}
         />
       </div>
-      <p className="text-xs text-slate-400">{pct}% of monthly soft limit used</p>
+      <p className="text-xs text-slate-400">{pct}% of the monthly limit used</p>
     </div>
   );
 };

--- a/components/admin/CompanyListPanel.tsx
+++ b/components/admin/CompanyListPanel.tsx
@@ -46,12 +46,6 @@ const TIER_STYLES: Record<string, string> = {
   pro:        'bg-violet-900/60 text-violet-300 border border-violet-700/50',
   enterprise: 'bg-amber-900/60 text-amber-300 border border-amber-700/50',
 };
-const TierBadge: React.FC<{ tier: string }> = ({ tier }) => (
-  <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-semibold capitalize ${TIER_STYLES[tier] ?? TIER_STYLES.free}`}>
-    {tier}
-  </span>
-);
-
 // ── Sort header cell ──────────────────────────────────────────────────────────
 const SortTh: React.FC<{
   label: string; col: SortKey; sort: SortKey; dir: SortDir;
@@ -207,6 +201,7 @@ const CompanyListPanel: React.FC<Props> = ({ adminToken }) => {
   const [sort,         setSort]         = useState<SortKey>('created_at');
   const [dir,          setDir]          = useState<SortDir>('desc');
   const [toggling,     setToggling]     = useState<string | null>(null);
+  const [tierSaving,   setTierSaving]   = useState<string | null>(null);
   const [actionMsg,    setActionMsg]    = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [createModal,  setCreateModal]  = useState<{ open: boolean; prefillEmail: string }>({ open: false, prefillEmail: '' });
   const [exportModal,  setExportModal]  = useState<{ open: boolean; id: string; name: string }>({ open: false, id: '', name: '' });
@@ -240,6 +235,26 @@ const CompanyListPanel: React.FC<Props> = ({ adminToken }) => {
       setActionMsg({ type: 'error', text: err?.message ?? 'Failed to update status' });
     } finally {
       setToggling(null);
+    }
+  };
+
+  const handleTierChange = async (company: Company, tier: string) => {
+    if (tier === company.tier) return;
+    if (!window.confirm(
+      `Move "${company.name}" from ${company.tier} to ${tier}?\n\n`
+      + `This changes the organization's monthly AI allowance and evidence storage quota immediately.`
+    )) return;
+
+    setTierSaving(company.id);
+    setActionMsg(null);
+    try {
+      await callAdmin('set_company_tier', adminToken, { id: company.id, tier });
+      setActionMsg({ type: 'success', text: `"${company.name}" moved to ${tier}.` });
+      await load();
+    } catch (err: any) {
+      setActionMsg({ type: 'error', text: err?.message ?? 'Failed to update tier' });
+    } finally {
+      setTierSaving(null);
     }
   };
 
@@ -442,7 +457,20 @@ const CompanyListPanel: React.FC<Props> = ({ adminToken }) => {
                               </span>
                             </button>
                           </td>
-                          <td className="px-4 py-3.5 hidden md:table-cell"><TierBadge tier={company.tier} /></td>
+                          <td className="px-4 py-3.5 hidden md:table-cell">
+                            <select
+                              value={company.tier}
+                              disabled={tierSaving === company.id}
+                              onChange={e => handleTierChange(company, e.target.value)}
+                              aria-label={`Tier for ${company.name}`}
+                              title="Change tier — adjusts AI and storage entitlements"
+                              className={`px-2 py-0.5 rounded-full text-xs font-semibold capitalize border-0 cursor-pointer disabled:opacity-50 disabled:cursor-wait focus:ring-2 focus:ring-esg-500 ${TIER_STYLES[company.tier] ?? TIER_STYLES.free}`}
+                            >
+                              {TIERS.map(t => (
+                                <option key={t} value={t} className="capitalize bg-white dark:bg-slate-800 text-slate-800 dark:text-white">{t}</option>
+                              ))}
+                            </select>
+                          </td>
                           <td className="px-4 py-3.5 text-slate-500 dark:text-slate-400 hidden sm:table-cell">{company.member_count}</td>
                           <td className="px-4 py-3.5 text-slate-500 dark:text-slate-400 hidden lg:table-cell whitespace-nowrap">{formatDate(company.created_at)}</td>
                           <td className="px-4 py-3.5 text-center">

--- a/netlify/functions/_shared/byokSecurity.js
+++ b/netlify/functions/_shared/byokSecurity.js
@@ -11,13 +11,23 @@ export function canManageByok(role) {
   return role === "Owner" || role === "Admin";
 }
 
-export function toSafeByokMetadata(settings, hasSecret) {
+/**
+ * @param {any} settings
+ * @param {boolean} hasSecret
+ * @param {{ tier?: string, monthlyCallLimit?: number | null }} [quota]
+ *   Effective ceiling resolved server-side. The browser must not recompute it:
+ *   the limit depends on the org tier and any active grants, neither of which
+ *   the client can be trusted to combine correctly.
+ */
+export function toSafeByokMetadata(settings, hasSecret, quota) {
   return {
     model: settings?.model ?? "gemini-2.5-flash",
     use_byok: settings?.use_byok === true,
     byok_provider: settings?.byok_provider ?? null,
     has_byok_key: Boolean(hasSecret),
     soft_quota_monthly: settings?.soft_quota_monthly ?? null,
+    tier: quota?.tier ?? "free",
+    monthly_call_limit: quota?.monthlyCallLimit ?? null,
   };
 }
 

--- a/netlify/functions/admin.ts
+++ b/netlify/functions/admin.ts
@@ -24,6 +24,7 @@
 import type { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
 import crypto from 'crypto';
+import { ORGANIZATION_TIERS } from './_shared/organizationTier.js';
 
 // ---------------------------------------------------------------------------
 // Config
@@ -774,6 +775,26 @@ async function handleListCompanies(): Promise<object> {
 // ---------------------------------------------------------------------------
 // Post-auth: set_company_status
 // ---------------------------------------------------------------------------
+async function handleSetCompanyTier(body: any, actorEmail: string): Promise<object> {
+  const id   = (body.id   ?? '').trim();
+  const tier = (body.tier ?? '').trim();
+  if (!id)   throw Object.assign(new Error('id is required'), { status: 400 });
+  if (!(ORGANIZATION_TIERS as readonly string[]).includes(tier)) {
+    throw Object.assign(new Error('Invalid tier'), { status: 400 });
+  }
+
+  const sb = getAdminClient();
+  const { error } = await sb.from('organizations').update({ tier }).eq('id', id);
+  if (error) throw Object.assign(new Error(error.message), { status: 500 });
+
+  // Tier changes move AI and storage entitlements, so record who made the call.
+  console.info('[admin] set_company_tier:', id, '->', tier, 'by', actorEmail);
+  return { updated: true, id, tier };
+}
+
+// ---------------------------------------------------------------------------
+// Post-auth: set_company_status
+// ---------------------------------------------------------------------------
 async function handleSetCompanyStatus(body: any): Promise<object> {
   const id        = (body.id        ?? '').trim();
   const is_active = body.is_active;
@@ -1119,6 +1140,7 @@ export const handler: Handler = async (event) => {
         case 'create_company':          result = await handleCreateCompany(body);              break;
         case 'list_companies':          result = await handleListCompanies();                   break;
         case 'set_company_status':      result = await handleSetCompanyStatus(body);            break;
+        case 'set_company_tier':        result = await handleSetCompanyTier(body, actorEmail);  break;
         case 'list_pending_users':      result = await handleListPendingUsers();                break;
         case 'assign_user_to_company':  result = await handleAssignUserToCompany(body);         break;
         case 'list_admins':        result = await handleListAdmins();                            break;

--- a/netlify/functions/byok-settings.ts
+++ b/netlify/functions/byok-settings.ts
@@ -5,6 +5,8 @@ import {
   normalizeByokUpdate,
   toSafeByokMetadata,
 } from "./_shared/byokSecurity.js";
+import { loadOrganizationTier } from "./_shared/organizationTier.js";
+import { resolveMonthlyCallLimit } from "./_shared/aiQuota.js";
 
 const json = (status: number, body: object) =>
   new Response(JSON.stringify(body), {
@@ -29,6 +31,8 @@ function getAdminClient() {
 }
 
 async function loadSafeMetadata(admin: any, organizationId: string) {
+  const tier = await loadOrganizationTier(admin, organizationId);
+
   const [{ data: settings, error: settingsError }, { data: secret, error: secretError }] =
     await Promise.all([
       admin
@@ -46,7 +50,11 @@ async function loadSafeMetadata(admin: any, organizationId: string) {
   if (settingsError || secretError) {
     throw new Error("Could not load BYOK metadata.");
   }
-  return toSafeByokMetadata(settings, Boolean(secret));
+
+  return toSafeByokMetadata(settings, Boolean(secret), {
+    tier,
+    monthlyCallLimit: resolveMonthlyCallLimit(tier, settings?.soft_quota_monthly),
+  });
 }
 
 async function handleByokSettings(

--- a/services/dbService.ts
+++ b/services/dbService.ts
@@ -158,7 +158,12 @@ export interface AiSettings {
   byok_provider: string | null;
   /** API key is NEVER returned from the server for security. Only a boolean `has_byok_key` is exposed. */
   has_byok_key: boolean;
+  /** Standing per-org override, or null when the tier default applies. */
   soft_quota_monthly: number | null;
+  /** Billing/access tier this organization is on. */
+  tier: string;
+  /** Effective monthly platform AI call ceiling, resolved server-side. */
+  monthly_call_limit: number | null;
 }
 
 const BYOK_SETTINGS_ENDPOINT = "/.netlify/functions/byok-settings";

--- a/tests/security/admin-tier-management.test.mjs
+++ b/tests/security/admin-tier-management.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { toSafeByokMetadata } from "../../netlify/functions/_shared/byokSecurity.js";
+import { ORGANIZATION_TIERS } from "../../netlify/functions/_shared/organizationTier.js";
+
+const read = (path) => readFile(new URL(path, import.meta.url), "utf8");
+
+test("changing a tier requires platform-admin authentication", async () => {
+  const source = await read("../../netlify/functions/admin.ts");
+
+  const requireAdmin = source.indexOf("await requireAdmin(authHeader)");
+  const tierCase = source.indexOf("case 'set_company_tier'");
+  assert.ok(requireAdmin > 0 && tierCase > 0, "both must exist");
+  assert.ok(
+    tierCase > requireAdmin,
+    "set_company_tier must sit in the post-auth switch, not the pre-auth branch",
+  );
+});
+
+test("tier updates are validated and attributed", async () => {
+  const source = await read("../../netlify/functions/admin.ts");
+  const handler = source.match(
+    /async function handleSetCompanyTier[\s\S]*?\n}\n/,
+  )?.[0];
+  assert.ok(handler, "handleSetCompanyTier must exist");
+
+  // Caller-supplied tiers reach a CHECK-constrained column: reject anything
+  // that is not one of the four known tiers rather than relying on the DB.
+  assert.match(handler, /ORGANIZATION_TIERS[\s\S]*\.includes\(tier\)/);
+  assert.match(handler, /status: 400/);
+
+  // Only the tier column may move — not is_active, and not another tenant.
+  assert.match(handler, /\.update\(\{ tier \}\)\.eq\('id', id\)/);
+  assert.doesNotMatch(handler, /is_active/);
+
+  // Entitlement changes cost money; record who made them.
+  assert.match(handler, /set_company_tier[\s\S]*actorEmail/);
+});
+
+test("the tenant sees the ceiling the server will actually enforce", async () => {
+  const metadata = toSafeByokMetadata(
+    { model: "gemini-2.5-flash", use_byok: false, byok_api_key: "secret-key-value-abcdefgh" },
+    false,
+    { tier: "pro", monthlyCallLimit: 2_000 },
+  );
+
+  assert.equal(metadata.tier, "pro");
+  assert.equal(metadata.monthly_call_limit, 2_000);
+  assert.equal("byok_api_key" in metadata, false);
+  assert.doesNotMatch(JSON.stringify(metadata), /secret-key-value/);
+
+  // Absent quota info must not imply a paid allowance.
+  const unknown = toSafeByokMetadata(null, false);
+  assert.equal(unknown.tier, "free");
+  assert.equal(unknown.monthly_call_limit, null);
+});
+
+test("the limit is resolved server-side, not recomputed in the browser", async () => {
+  const [settingsFn, panel] = await Promise.all([
+    read("../../netlify/functions/byok-settings.ts"),
+    read("../../components/AIUsagePanel.tsx"),
+  ]);
+
+  assert.match(settingsFn, /loadOrganizationTier\(admin, organizationId\)/);
+  assert.match(settingsFn, /resolveMonthlyCallLimit\(tier, settings\?\.soft_quota_monthly\)/);
+
+  assert.match(panel, /settings\.monthly_call_limit/);
+  // Regression: the panel used to show a hardcoded 100 to every organization,
+  // which is wrong for every tier above free.
+  assert.doesNotMatch(panel, /PLATFORM_SOFT_LIMIT_DEFAULT/);
+  assert.doesNotMatch(panel, /softQuotaMonthly \?\?/);
+});
+
+test("the quota warning no longer promises calls that will be refused", async () => {
+  const panel = await read("../../components/AIUsagePanel.tsx");
+
+  assert.doesNotMatch(panel, /AI calls are still allowed/);
+  assert.doesNotMatch(panel, /soft limit|soft quota/i);
+  assert.match(panel, /AI features are paused/);
+});
+
+test("the admin console can select every tier the database accepts", async () => {
+  const panel = await read("../../components/admin/CompanyListPanel.tsx");
+
+  const declared = panel.match(/const TIERS = \[([^\]]*)\]/)?.[1];
+  assert.ok(declared, "TIERS must exist");
+  assert.deepEqual(
+    declared.split(",").map((t) => t.trim().replace(/'/g, "")).filter(Boolean),
+    [...ORGANIZATION_TIERS],
+  );
+
+  assert.match(panel, /callAdmin\('set_company_tier'/);
+  assert.match(panel, /window\.confirm\(/, "an entitlement change should be confirmed");
+});

--- a/tests/security/byok-secret-isolation.test.mjs
+++ b/tests/security/byok-secret-isolation.test.mjs
@@ -40,7 +40,7 @@ function createAdminMock(rows) {
   };
 }
 
-function createEndpointAdminMock({ role = "Owner", hasSecret = true } = {}) {
+function createEndpointAdminMock({ role = "Owner", hasSecret = true, tier = "free" } = {}) {
   const calls = [];
   let storedSecret = hasSecret;
   let useByok = hasSecret;
@@ -105,6 +105,11 @@ function createEndpointAdminMock({ role = "Owner", hasSecret = true } = {}) {
               data: storedSecret ? { organization_id: ORG_ID } : null,
               error: null,
             };
+          }
+          // The endpoint resolves the tier so it can report the ceiling the
+          // server will enforce; the browser is never asked to compute it.
+          if (table === "organizations") {
+            return { data: { tier }, error: null };
           }
           throw new Error(`Unexpected table ${table}`);
         },
@@ -307,6 +312,23 @@ test("authenticated members receive safe metadata for their organization", async
     admin.calls.some((call) => call.table === "organization_ai_secrets"),
     true,
   );
+});
+
+test("metadata reports the ceiling the server will enforce for that tier", async () => {
+  const handlerFor = (tier) =>
+    createByokSettingsHandler(() => createEndpointAdminMock({ tier }));
+  const get = (handler) => handler(new Request(
+    `https://app.example.com/.netlify/functions/byok-settings?organization_id=${ORG_ID}`,
+    { headers: { Authorization: "Bearer member-token" } },
+  ));
+
+  // soft_quota_monthly is 100 in the mock, so the override wins on every tier.
+  const overridden = await (await get(handlerFor("pro"))).json();
+  assert.equal(overridden.tier, "pro");
+  assert.equal(overridden.monthly_call_limit, 100);
+
+  // The client must never be handed the raw column to interpret for itself.
+  assert.equal(typeof overridden.monthly_call_limit, "number");
 });
 
 test("non-members are rejected before the endpoint reads secret metadata", async () => {


### PR DESCRIPTION
> **Stacked on #181.** First of two PRs answering "can an admin raise quota ad-hoc so service isn't interrupted?" This one removes the blockers; #187 adds the grants.

## Two gaps that only bite once #181 enforces the ceiling

**1. A tier could be set at creation and never changed.** `create_company` accepts a tier; `set_company_status` toggles `is_active`; nothing anywhere writes `organizations.tier` again. Moving a customer between plans meant editing SQL in Supabase. With enforcement on, that also means the only lever for an interrupted customer was a manual database edit.

**2. The tenant AI panel was about to start lying.** `AIUsagePanel.tsx` showed `soft_quota_monthly ?? 100` — a hardcoded 100 for every organization, wrong for every tier above free — labelled it a "soft limit", and told anyone over it:

> "Soft quota exceeded. AI calls are still allowed but you may want to enable BYOK or contact support."

That becomes false the moment #181 deploys. My omission in that PR; fixing it here.

## Change

**Admin**
- `set_company_tier` in the post-auth admin API. Validates against `ORGANIZATION_TIERS` before touching a CHECK-constrained column, updates only `tier`, and logs the actor's email — entitlement changes move spend, so they should be attributable.
- The Tier column in the company list becomes a select, with a confirmation naming what actually changes ("monthly AI allowance and evidence storage quota").
- `ADMIN_MANUAL.md` updated.

**Tenant**
- `byok-settings` resolves the tier and returns `tier` + `monthly_call_limit` in its existing metadata response. The browser displays the number the server will enforce instead of recomputing it — which matters more once grants land in #187, since the client cannot see those at all.
- Quota bar copy now says AI features pause, and points at BYOK or support.

## Verification

```
npm run test:security   # 128 pass (121 before, 7 new)
npx tsc --noEmit         # clean
npm run build            # clean
```

New `tests/security/admin-tier-management.test.mjs` asserts the tier action sits *after* `requireAdmin` in the handler, validates its input, touches only the tier column, and is attributed; that the panel no longer hardcodes a limit or promises calls that will be refused; and that the admin console's tier list matches `ORGANIZATION_TIERS`. `byok-secret-isolation.test.mjs` gains a `tier` option on its mock and an end-to-end assertion that the endpoint reports the enforced ceiling — its existing assertions are unchanged.

## Note on ordering

This is worth having even if you decide against grants in #187: without it, tiers are inert and the tenant sees a wrong number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)