### PR TITLE
feat(quota): ad-hoc AI quota grants with an automatic first-breach burst

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ netlify/functions/
   google-callback.ts  OAuth callback with hashed, expiring state
   evidence.ts         Tenant-aware evidence operations
   _shared/organizationTier.js  Canonical organizations.tier resolver; fails closed to free
-  _shared/aiQuota.js           Monthly platform AI ceiling per tier
+  _shared/aiQuota.js           Monthly platform AI ceiling, grants, auto-burst
   invite.ts           Invitation CRUD + rate-limited public resend
   accept-invite.ts    Authenticated invite validation + member join
   ally-support.ts     Authenticated, tenant-bound support AI
@@ -153,6 +153,7 @@ Singleton tables (profile, canvas, SWOT) use `useOrgData` which auto-saves on st
 | `DEFAULT_MODEL` | `netlify/functions/api.ts` | `"gemini-2.5-flash"` | Used when org has no AI settings row |
 | Invite expiry | `supabase/schema.sql` | `now() + interval '7 days'` | Hardcoded in DB default |
 | `MONTHLY_AI_CALL_LIMITS` | `netlify/functions/_shared/aiQuota.js` | free 100 / starter 500 / pro 2 000 / enterprise 10 000 | Enforced monthly platform AI ceiling; `organization_ai_settings.soft_quota_monthly` overrides it per org |
+| `AUTO_BURST_RATIO` | `netlify/functions/_shared/aiQuota.js` | `0.25` | One automatic top-up per org per month on first breach, so worst-case spend is 125% of plan rather than open-ended |
 
 ---
 
@@ -168,6 +169,7 @@ Singleton tables (profile, canvas, SWOT) use `useOrgData` which auto-saves on st
 - Ally support authenticates the user and verifies organization membership before side effects.
 - Client error logs bind user and tenant identity in RLS; AI handlers do not log tenant output content.
 - Platform AI calls are capped per organization per month. Both AI entry points (`api.ts` and `ally-support.ts`) return 429 before any provider call once the ceiling is spent; BYOK tenants bypass the cap because they pay the provider directly.
+- Quota headroom can be added ad-hoc through `ai_quota_grants`, a service-role-only table of expiring, attributed top-ups. Effective ceiling is `standing limit + active grants`. One automatic burst per organization per month is allowed on first breach; a partial unique index, not application logic, is what enforces "once".
 
 ## Known gaps (track; do not introduce workarounds)
 

--- a/Docs v1.1.0/ADMIN_MANUAL.md
+++ b/Docs v1.1.0/ADMIN_MANUAL.md
@@ -44,6 +44,20 @@ The Dashboard provides a real-time, high-level summary of the entire platform's 
 
 *Use the year dropdown in the top right of each chart card to view historical data.*
 
+### AI Quota
+
+Each organization has a monthly platform AI allowance set by its tier. When it is spent, AI features return an error until the allowance resets on the 1st — so this is the screen to reach for when a customer reports that AI has stopped working.
+
+Click **Quota** on any row of *Top Companies — this month* to see where that organization stands and to adjust it:
+
+- **Grant extra calls** — a one-off top-up for the current month, with a reason that is recorded against your admin email. It expires automatically when the allowance resets, so it cannot quietly become the customer's permanent plan. This is the fastest way to unblock someone.
+- **Standing monthly limit** — replaces the tier default every month, for a customer whose normal usage genuinely exceeds their plan. Leave it blank to return to the tier default. `0` suspends platform AI for that organization.
+- **Change the tier** instead (Company Management → Tier) when the customer has actually moved plans. That changes storage entitlements too.
+
+**Automatic top-ups.** The first time an organization crosses its ceiling in a month, the platform grants a one-off 25% top-up by itself and keeps serving, so nobody is cut off before a human has looked. It appears in the grant list with an `auto` badge and a note. Treat one as a prompt to decide: raise the standing limit, move the tier, or let it lapse. An organization only ever receives one automatic top-up per month; after that it is refused until you grant more.
+
+**Organizations using their own API key (BYOK)** are not subject to platform quota, and the panel says so.
+
 ---
 
 ## 3. Company Management

--- a/components/admin/AdminAIUsagePanel.tsx
+++ b/components/admin/AdminAIUsagePanel.tsx
@@ -5,7 +5,7 @@ import {
 } from 'recharts';
 import {
   Zap, RefreshCw, Loader2, AlertCircle, TrendingUp,
-  DollarSign, AlertTriangle, Activity,
+  DollarSign, AlertTriangle, Activity, Gauge, Plus, X,
 } from 'lucide-react';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -22,12 +22,22 @@ interface TopOrg { org_id: string; name: string; tier: string; calls: number; }
 
 interface Props { adminToken: string; }
 
+interface QuotaGrant {
+  id: string; additional_calls: number; source: 'admin' | 'auto_burst';
+  reason: string | null; granted_by: string | null; expires_at: string; created_at: string;
+}
+interface OrgQuota {
+  organization_id: string; tier: string; use_byok: boolean;
+  soft_quota_monthly: number | null; base_limit: number; granted_calls: number;
+  effective_limit: number; used: number; resets_at: string; grants: QuotaGrant[];
+}
+
 // ── API helper ────────────────────────────────────────────────────────────────
-async function callAdmin(action: string, token: string) {
+async function callAdmin(action: string, token: string, body?: object) {
   const res = await fetch('/.netlify/functions/admin', {
     method:  'POST',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-    body:    JSON.stringify({ action }),
+    body:    JSON.stringify({ action, ...body }),
   });
   const json = await res.json();
   if (!res.ok) throw new Error(json.error ?? `Request failed (${res.status})`);
@@ -81,6 +91,7 @@ const AdminAIUsagePanel: React.FC<Props> = ({ adminToken }) => {
   const [topOrgs,  setTopOrgs]  = useState<TopOrg[]>([]);
   const [loading,  setLoading]  = useState(true);
   const [error,    setError]    = useState('');
+  const [quotaOrg, setQuotaOrg] = useState<{ id: string; name: string } | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -269,12 +280,220 @@ const AdminAIUsagePanel: React.FC<Props> = ({ adminToken }) => {
                     <p className="text-sm font-bold text-slate-800 dark:text-white tabular-nums">{fmt(org.calls)}</p>
                     <p className="text-xs text-slate-400">calls</p>
                   </div>
+                  <button
+                    onClick={() => setQuotaOrg({ id: org.org_id, name: org.name })}
+                    title="View and adjust this organization's AI quota"
+                    className="flex-shrink-0 inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-slate-500 dark:text-slate-400 hover:text-white hover:bg-esg-700 border border-slate-300 dark:border-slate-600 hover:border-esg-600 rounded-lg transition-all"
+                  >
+                    <Gauge className="w-3 h-3" /> Quota
+                  </button>
                 </div>
               ))}
             </div>
           )}
         </div>
 
+      </div>
+
+      {quotaOrg && (
+        <QuotaModal
+          adminToken={adminToken}
+          orgId={quotaOrg.id}
+          orgName={quotaOrg.name}
+          onClose={() => setQuotaOrg(null)}
+        />
+      )}
+    </div>
+  );
+};
+
+// ── Quota modal ───────────────────────────────────────────────────────────────
+// Raising a ceiling is the release valve for an interrupted customer, so this
+// deliberately shows where the org actually stands before offering the controls.
+const QuotaModal: React.FC<{
+  adminToken: string; orgId: string; orgName: string; onClose: () => void;
+}> = ({ adminToken, orgId, orgName, onClose }) => {
+  const [quota,   setQuota]   = useState<OrgQuota | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy,    setBusy]    = useState(false);
+  const [error,   setError]   = useState('');
+  const [notice,  setNotice]  = useState('');
+  const [grantCalls,  setGrantCalls]  = useState('');
+  const [grantReason, setGrantReason] = useState('');
+  const [override,    setOverride]    = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const data: OrgQuota = await callAdmin('org_ai_quota', adminToken, { organization_id: orgId });
+      setQuota(data);
+      setOverride(data.soft_quota_monthly === null ? '' : String(data.soft_quota_monthly));
+    } catch (err: any) {
+      setError(err?.message ?? 'Failed to load quota');
+    } finally {
+      setLoading(false);
+    }
+  }, [adminToken, orgId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const run = async (fn: () => Promise<void>, successText: string) => {
+    setBusy(true);
+    setError('');
+    setNotice('');
+    try {
+      await fn();
+      setNotice(successText);
+      await load();
+    } catch (err: any) {
+      setError(err?.message ?? 'Request failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleGrant = () => run(async () => {
+    await callAdmin('grant_ai_quota', adminToken, {
+      organization_id: orgId,
+      additional_calls: Number(grantCalls),
+      reason: grantReason,
+    });
+    setGrantCalls('');
+    setGrantReason('');
+  }, 'Grant added. It expires when the allowance resets.');
+
+  const handleOverride = () => run(async () => {
+    await callAdmin('set_ai_quota_override', adminToken, {
+      organization_id: orgId,
+      soft_quota_monthly: override.trim() === '' ? null : Number(override),
+    });
+  }, override.trim() === '' ? 'Override cleared — back to the tier default.' : 'Standing limit updated.');
+
+  const pct = quota && quota.effective_limit > 0
+    ? Math.min(100, Math.round((quota.used / quota.effective_limit) * 100))
+    : 0;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4" role="dialog" aria-modal="true">
+      <div className="w-full max-w-lg max-h-[90vh] overflow-y-auto bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-xl">
+        <div className="flex items-center justify-between px-5 py-4 border-b border-slate-200 dark:border-slate-700">
+          <div>
+            <h3 className="font-bold text-slate-800 dark:text-white">AI quota</h3>
+            <p className="text-xs text-slate-500 dark:text-slate-400 truncate max-w-[300px]">{orgName}</p>
+          </div>
+          <button onClick={onClose} aria-label="Close" className="p-1.5 rounded-lg text-slate-400 hover:text-slate-700 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-700">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="p-5 space-y-5">
+          {loading ? (
+            <div className="flex items-center gap-2 text-slate-500 dark:text-slate-400 text-sm py-6 justify-center">
+              <Loader2 className="w-4 h-4 animate-spin" /> Loading…
+            </div>
+          ) : quota && (
+            <>
+              {quota.use_byok && (
+                <p className="text-xs p-2.5 rounded-lg bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-800">
+                  This organization uses its own API key. Platform quota does not apply to it.
+                </p>
+              )}
+
+              <div>
+                <div className="flex justify-between text-xs text-slate-600 dark:text-slate-400 mb-1.5">
+                  <span>{quota.used.toLocaleString()} used</span>
+                  <span>{quota.effective_limit.toLocaleString()} available</span>
+                </div>
+                <div className="h-2 bg-slate-100 dark:bg-slate-700 rounded-full overflow-hidden">
+                  <div className={`h-full rounded-full ${pct >= 100 ? 'bg-red-500' : pct >= 80 ? 'bg-amber-500' : 'bg-esg-500'}`} style={{ width: `${pct}%` }} />
+                </div>
+                <p className="text-xs text-slate-400 mt-1.5">
+                  {quota.base_limit.toLocaleString()} from the <span className="capitalize">{quota.tier}</span> plan
+                  {quota.granted_calls > 0 && ` + ${quota.granted_calls.toLocaleString()} granted`}
+                  {' · resets '}{new Date(quota.resets_at).toLocaleDateString()}
+                </p>
+              </div>
+
+              {quota.grants.length > 0 && (
+                <div className="space-y-1.5">
+                  <p className="text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wide">Active grants</p>
+                  {quota.grants.map(g => (
+                    <div key={g.id} className="flex items-start gap-2 text-xs p-2 rounded-lg bg-slate-50 dark:bg-slate-700/40">
+                      <span className={`px-1.5 py-0.5 rounded font-semibold flex-shrink-0 ${
+                        g.source === 'auto_burst'
+                          ? 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300'
+                          : 'bg-esg-100 dark:bg-esg-900/40 text-esg-700 dark:text-esg-300'
+                      }`}>
+                        {g.source === 'auto_burst' ? 'auto' : 'admin'}
+                      </span>
+                      <span className="flex-1 text-slate-600 dark:text-slate-300">
+                        +{g.additional_calls.toLocaleString()} calls
+                        {g.reason && <span className="text-slate-400"> — {g.reason}</span>}
+                        {g.granted_by && <span className="text-slate-400"> ({g.granted_by})</span>}
+                      </span>
+                    </div>
+                  ))}
+                  {quota.grants.some(g => g.source === 'auto_burst') && (
+                    <p className="text-xs text-amber-600 dark:text-amber-400">
+                      An automatic top-up fired this month — this organization hit its ceiling. Consider a tier change or a standing limit.
+                    </p>
+                  )}
+                </div>
+              )}
+
+              <div className="pt-1 border-t border-slate-200 dark:border-slate-700 space-y-2">
+                <p className="text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wide pt-3">Grant extra calls</p>
+                <p className="text-xs text-slate-400">One-off top-up for this month only. Expires when the allowance resets.</p>
+                <div className="flex gap-2">
+                  <input
+                    type="number" min={1} value={grantCalls} placeholder="500"
+                    onChange={e => setGrantCalls(e.target.value)}
+                    className="w-28 px-3 py-2 text-sm rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-800 dark:text-white"
+                  />
+                  <input
+                    type="text" value={grantReason} placeholder="Reason (recorded)" maxLength={200}
+                    onChange={e => setGrantReason(e.target.value)}
+                    className="flex-1 px-3 py-2 text-sm rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-800 dark:text-white"
+                  />
+                  <button
+                    onClick={handleGrant}
+                    disabled={busy || !grantCalls || Number(grantCalls) < 1}
+                    className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg bg-esg-600 hover:bg-esg-700 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    <Plus className="w-3.5 h-3.5" /> Grant
+                  </button>
+                </div>
+              </div>
+
+              <div className="pt-1 border-t border-slate-200 dark:border-slate-700 space-y-2">
+                <p className="text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wide pt-3">Standing monthly limit</p>
+                <p className="text-xs text-slate-400">Replaces the tier default every month. Leave blank to use the plan default; 0 suspends platform AI.</p>
+                <div className="flex gap-2">
+                  <input
+                    type="number" min={0} value={override} placeholder={`${quota.base_limit} (tier default)`}
+                    onChange={e => setOverride(e.target.value)}
+                    className="flex-1 px-3 py-2 text-sm rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-800 dark:text-white"
+                  />
+                  <button
+                    onClick={handleOverride}
+                    disabled={busy}
+                    className="px-3 py-2 text-sm font-medium rounded-lg border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-50"
+                  >
+                    Save
+                  </button>
+                </div>
+              </div>
+            </>
+          )}
+
+          {error && (
+            <p className="text-xs p-2.5 rounded-lg bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 border border-red-200 dark:border-red-800">{error}</p>
+          )}
+          {notice && (
+            <p className="text-xs p-2.5 rounded-lg bg-esg-50 dark:bg-esg-900/20 text-esg-700 dark:text-esg-300 border border-esg-200 dark:border-esg-800">{notice}</p>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/netlify/functions/_shared/aiQuota.js
+++ b/netlify/functions/_shared/aiQuota.js
@@ -44,6 +44,14 @@ export function resolveMonthlyCallLimit(tier, softQuotaMonthly) {
 }
 
 /**
+ * Share of the base allowance granted automatically the first time an
+ * organization crosses its ceiling in a month, so nobody is hard-stopped
+ * before a human has had a chance to look. Bounds worst-case spend at
+ * 125% of plan rather than leaving it open-ended.
+ */
+export const AUTO_BURST_RATIO = 0.25;
+
+/**
  * First instant of the current calendar month, in UTC.
  *
  * @param {Date} [now]
@@ -51,6 +59,96 @@ export function resolveMonthlyCallLimit(tier, softQuotaMonthly) {
  */
 export function monthStartIso(now = new Date()) {
   return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString();
+}
+
+/**
+ * First instant of the next calendar month, in UTC — when the allowance
+ * resets, and therefore when a grant for this month stops counting.
+ *
+ * @param {Date} [now]
+ * @returns {string}
+ */
+export function monthEndIso(now = new Date()) {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1)).toISOString();
+}
+
+/**
+ * `period_month` value for the current UTC month (YYYY-MM-DD).
+ *
+ * @param {Date} [now]
+ * @returns {string}
+ */
+export function periodMonth(now = new Date()) {
+  return monthStartIso(now).slice(0, 10);
+}
+
+/**
+ * Total calls added by grants that have not expired.
+ *
+ * Returns 0 on error: a grant is extra capacity, so failing to read one costs
+ * a customer headroom rather than handing out spend that was never authorized.
+ *
+ * @param {any} admin Supabase service-role client
+ * @param {string} organizationId
+ * @param {Date} [now]
+ * @returns {Promise<number>}
+ */
+export async function loadActiveGrantTotal(admin, organizationId, now = new Date()) {
+  const { data, error } = await admin
+    .from("ai_quota_grants")
+    .select("additional_calls")
+    .eq("organization_id", organizationId)
+    .gt("expires_at", now.toISOString());
+
+  if (error) {
+    console.warn(`[quota] grant lookup failed org=${organizationId} — ignoring grants`);
+    return 0;
+  }
+
+  return (data ?? []).reduce(
+    (total, row) => total + (Number(row?.additional_calls) || 0),
+    0,
+  );
+}
+
+/**
+ * Grant the one automatic burst this organization is allowed this month.
+ *
+ * Uniqueness is enforced by the partial index in migration 027, not here: a
+ * duplicate insert loses the race and returns null, which is the correct
+ * answer for a second concurrent request.
+ *
+ * @param {any} admin Supabase service-role client
+ * @param {string} organizationId
+ * @param {number} baseLimit
+ * @param {Date} [now]
+ * @returns {Promise<number>} calls granted, or 0 when none was
+ */
+export async function grantAutoBurst(admin, organizationId, baseLimit, now = new Date()) {
+  const additionalCalls = Math.max(1, Math.ceil(baseLimit * AUTO_BURST_RATIO));
+
+  const { error } = await admin.from("ai_quota_grants").insert({
+    organization_id: organizationId,
+    additional_calls: additionalCalls,
+    source: "auto_burst",
+    reason: "Automatic one-off top-up on first monthly ceiling breach",
+    period_month: periodMonth(now),
+    expires_at: monthEndIso(now),
+  });
+
+  if (error) {
+    // 23505 = the org already used this month's burst. Anything else is a real
+    // failure; either way the caller falls through to the refusal path.
+    if (error.code !== "23505") {
+      console.error(`[quota] auto-burst insert failed org=${organizationId}`);
+    }
+    return 0;
+  }
+
+  console.warn(
+    `[quota] auto-burst granted org=${organizationId} calls=${additionalCalls} base=${baseLimit}`,
+  );
+  return additionalCalls;
 }
 
 /**
@@ -72,26 +170,71 @@ export async function checkMonthlyAiQuota(
   organizationId,
   tier,
   softQuotaMonthly,
-  now,
+  now = new Date(),
 ) {
-  const limit = resolveMonthlyCallLimit(tier, softQuotaMonthly);
+  const baseLimit = resolveMonthlyCallLimit(tier, softQuotaMonthly);
 
-  const { count, error } = await admin
-    .from("ai_usage_log")
-    .select("id", { count: "exact", head: true })
-    .eq("organization_id", organizationId)
-    .eq("success", true)
-    .gte("created_at", monthStartIso(now));
+  const [{ count, error }, grantedCalls] = await Promise.all([
+    admin
+      .from("ai_usage_log")
+      .select("id", { count: "exact", head: true })
+      .eq("organization_id", organizationId)
+      .eq("success", true)
+      .gte("created_at", monthStartIso(now)),
+    loadActiveGrantTotal(admin, organizationId, now),
+  ]);
+
+  const limit = baseLimit + grantedCalls;
 
   if (error) {
     console.warn(
       `[quota] usage lookup failed org=${organizationId} — allowing call`,
     );
-    return { allowed: true, used: null, limit, degraded: true };
+    return { allowed: true, used: null, limit, baseLimit, grantedCalls, degraded: true };
   }
 
   const used = count ?? 0;
-  return { allowed: used < limit, used, limit, degraded: false };
+  return {
+    allowed: used < limit,
+    used,
+    limit,
+    baseLimit,
+    grantedCalls,
+    degraded: false,
+  };
+}
+
+/**
+ * Full gate for one platform AI call: check the ceiling, and if it is spent,
+ * try this month's automatic burst before refusing.
+ *
+ * @param {any} admin Supabase service-role client
+ * @param {string} organizationId
+ * @param {unknown} tier
+ * @param {unknown} softQuotaMonthly
+ * @param {Date} [now]
+ */
+export async function authorizeAiCall(
+  admin,
+  organizationId,
+  tier,
+  softQuotaMonthly,
+  now = new Date(),
+) {
+  const quota = await checkMonthlyAiQuota(admin, organizationId, tier, softQuotaMonthly, now);
+  if (quota.allowed) return quota;
+
+  const burst = await grantAutoBurst(admin, organizationId, quota.baseLimit, now);
+  if (burst === 0) return quota;
+
+  const limit = quota.limit + burst;
+  return {
+    ...quota,
+    allowed: quota.used === null || quota.used < limit,
+    limit,
+    grantedCalls: quota.grantedCalls + burst,
+    autoBurstGranted: burst,
+  };
 }
 
 /**

--- a/netlify/functions/admin.ts
+++ b/netlify/functions/admin.ts
@@ -24,7 +24,14 @@
 import type { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
 import crypto from 'crypto';
-import { ORGANIZATION_TIERS } from './_shared/organizationTier.js';
+import { ORGANIZATION_TIERS, loadOrganizationTier } from './_shared/organizationTier.js';
+import {
+  loadActiveGrantTotal,
+  monthEndIso,
+  monthStartIso,
+  periodMonth,
+  resolveMonthlyCallLimit,
+} from './_shared/aiQuota.js';
 
 // ---------------------------------------------------------------------------
 // Config
@@ -773,7 +780,7 @@ async function handleListCompanies(): Promise<object> {
 }
 
 // ---------------------------------------------------------------------------
-// Post-auth: set_company_status
+// Post-auth: set_company_tier
 // ---------------------------------------------------------------------------
 async function handleSetCompanyTier(body: any, actorEmail: string): Promise<object> {
   const id   = (body.id   ?? '').trim();
@@ -790,6 +797,107 @@ async function handleSetCompanyTier(body: any, actorEmail: string): Promise<obje
   // Tier changes move AI and storage entitlements, so record who made the call.
   console.info('[admin] set_company_tier:', id, '->', tier, 'by', actorEmail);
   return { updated: true, id, tier };
+}
+
+// ---------------------------------------------------------------------------
+// Post-auth: org_ai_quota — where an organization stands this month
+// ---------------------------------------------------------------------------
+async function handleOrgAiQuota(body: any): Promise<object> {
+  const orgId = (body.organization_id ?? '').trim();
+  if (!orgId) throw Object.assign(new Error('organization_id is required'), { status: 400 });
+
+  const sb  = getAdminClient();
+  const now = new Date();
+
+  const [tier, settingsRes, usageRes, grantsRes] = await Promise.all([
+    loadOrganizationTier(sb, orgId),
+    sb.from('organization_ai_settings')
+      .select('soft_quota_monthly, use_byok')
+      .eq('organization_id', orgId).maybeSingle(),
+    sb.from('ai_usage_log')
+      .select('id', { count: 'exact', head: true })
+      .eq('organization_id', orgId).eq('success', true)
+      .gte('created_at', monthStartIso(now)),
+    sb.from('ai_quota_grants')
+      .select('id, additional_calls, source, reason, granted_by, expires_at, created_at')
+      .eq('organization_id', orgId)
+      .gt('expires_at', now.toISOString())
+      .order('created_at', { ascending: false }),
+  ]);
+
+  const softQuotaMonthly = settingsRes.data?.soft_quota_monthly ?? null;
+  const baseLimit        = resolveMonthlyCallLimit(tier, softQuotaMonthly);
+  const grantedCalls     = await loadActiveGrantTotal(sb, orgId, now);
+
+  return {
+    organization_id:    orgId,
+    tier,
+    use_byok:           settingsRes.data?.use_byok === true,
+    soft_quota_monthly: softQuotaMonthly,
+    base_limit:         baseLimit,
+    granted_calls:      grantedCalls,
+    effective_limit:    baseLimit + grantedCalls,
+    used:               usageRes.count ?? 0,
+    resets_at:          monthEndIso(now),
+    grants:             grantsRes.data ?? [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Post-auth: grant_ai_quota — ad-hoc top-up, expires at month end
+// ---------------------------------------------------------------------------
+async function handleGrantAiQuota(body: any, actorEmail: string): Promise<object> {
+  const orgId  = (body.organization_id ?? '').trim();
+  const calls  = Number(body.additional_calls);
+  const reason = typeof body.reason === 'string' ? body.reason.trim().slice(0, 500) : null;
+
+  if (!orgId) throw Object.assign(new Error('organization_id is required'), { status: 400 });
+  if (!Number.isInteger(calls) || calls < 1 || calls > 1_000_000) {
+    throw Object.assign(new Error('additional_calls must be a whole number between 1 and 1,000,000'), { status: 400 });
+  }
+
+  const sb  = getAdminClient();
+  const now = new Date();
+
+  const { data, error } = await sb.from('ai_quota_grants').insert({
+    organization_id:  orgId,
+    additional_calls: calls,
+    source:           'admin',
+    reason:           reason || null,
+    granted_by:       actorEmail,
+    period_month:     periodMonth(now),
+    expires_at:       monthEndIso(now),
+  }).select('id, additional_calls, expires_at').single();
+
+  if (error) throw Object.assign(new Error(error.message), { status: 500 });
+
+  console.info('[admin] grant_ai_quota:', orgId, '+', calls, 'by', actorEmail);
+  return { granted: true, ...data };
+}
+
+// ---------------------------------------------------------------------------
+// Post-auth: set_ai_quota_override — standing per-org ceiling
+// ---------------------------------------------------------------------------
+async function handleSetAiQuotaOverride(body: any, actorEmail: string): Promise<object> {
+  const orgId = (body.organization_id ?? '').trim();
+  if (!orgId) throw Object.assign(new Error('organization_id is required'), { status: 400 });
+
+  const raw = body.soft_quota_monthly;
+  // null clears the override and returns the org to its tier default.
+  const override = raw === null || raw === '' ? null : Number(raw);
+  if (override !== null && (!Number.isInteger(override) || override < 0 || override > 1_000_000)) {
+    throw Object.assign(new Error('soft_quota_monthly must be null or a whole number between 0 and 1,000,000'), { status: 400 });
+  }
+
+  const sb = getAdminClient();
+  const { error } = await sb.from('organization_ai_settings').upsert(
+    { organization_id: orgId, soft_quota_monthly: override },
+    { onConflict: 'organization_id' },
+  );
+  if (error) throw Object.assign(new Error(error.message), { status: 500 });
+
+  console.info('[admin] set_ai_quota_override:', orgId, '->', override, 'by', actorEmail);
+  return { updated: true, organization_id: orgId, soft_quota_monthly: override };
 }
 
 // ---------------------------------------------------------------------------
@@ -1141,6 +1249,9 @@ export const handler: Handler = async (event) => {
         case 'list_companies':          result = await handleListCompanies();                   break;
         case 'set_company_status':      result = await handleSetCompanyStatus(body);            break;
         case 'set_company_tier':        result = await handleSetCompanyTier(body, actorEmail);  break;
+        case 'org_ai_quota':            result = await handleOrgAiQuota(body);                  break;
+        case 'grant_ai_quota':          result = await handleGrantAiQuota(body, actorEmail);    break;
+        case 'set_ai_quota_override':   result = await handleSetAiQuotaOverride(body, actorEmail); break;
         case 'list_pending_users':      result = await handleListPendingUsers();                break;
         case 'assign_user_to_company':  result = await handleAssignUserToCompany(body);         break;
         case 'list_admins':        result = await handleListAdmins();                            break;

--- a/netlify/functions/ally-support.ts
+++ b/netlify/functions/ally-support.ts
@@ -11,7 +11,7 @@ import { withAIRequestFence } from "./_shared/aiRequestFence.js";
 import { loadOrganizationAiConfig } from "./_shared/organizationAiConfig.js";
 import { loadOrganizationTier } from "./_shared/organizationTier.js";
 import {
-  checkMonthlyAiQuota,
+  authorizeAiCall,
   platformQuotaType,
   quotaExceededResponse,
 } from "./_shared/aiQuota.js";
@@ -177,7 +177,7 @@ export function createAllySupportHandler(
       const tier = await loadOrganizationTier(admin, organization_id);
       quotaType = platformQuotaType(tier);
 
-      const quota = await checkMonthlyAiQuota(
+      const quota = await authorizeAiCall(
         admin,
         organization_id,
         tier,

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -8,7 +8,7 @@ import { withAIRequestFence } from "./_shared/aiRequestFence.js";
 import { loadOrganizationAiConfig } from "./_shared/organizationAiConfig.js";
 import { loadOrganizationTier } from "./_shared/organizationTier.js";
 import {
-  checkMonthlyAiQuota,
+  authorizeAiCall,
   platformQuotaType,
   quotaExceededResponse,
 } from "./_shared/aiQuota.js";
@@ -145,7 +145,9 @@ const handler = async (event: any) => {
     const tier = await loadOrganizationTier(admin, organization_id);
     effectiveQuotaType = platformQuotaType(tier);
 
-    const quota = await checkMonthlyAiQuota(
+    // Refusing is the last resort: this also spends the org's one automatic
+    // burst for the month before giving up.
+    const quota = await authorizeAiCall(
       admin,
       organization_id,
       tier,

--- a/supabase/migrations/027_ai_quota_grants.sql
+++ b/supabase/migrations/027_ai_quota_grants.sql
@@ -1,0 +1,63 @@
+-- ============================================================
+-- Migration 027 — Ad-hoc AI quota grants
+-- ============================================================
+-- Migration 026 made the monthly allowance enforceable. This adds the release
+-- valve: a temporary top-up that expires, so raising a ceiling to unblock a
+-- customer today does not silently become their permanent plan.
+--
+--   organization_ai_settings.soft_quota_monthly  standing override (deliberate)
+--   ai_quota_grants                              temporary top-up (expires)
+--
+-- Effective ceiling = standing limit + sum(active grants).
+--
+-- `source = 'auto_burst'` marks the automatic one-off top-up granted the first
+-- time an organization crosses its ceiling in a month, so a customer is never
+-- hard-stopped before a human has had a chance to look. The partial unique
+-- index is what makes that "once per organization per month" — it is the
+-- concurrency guard, not application logic.
+--
+-- Service-role only: the browser never reads or writes grants. The effective
+-- ceiling reaches the tenant through byok-settings, already computed.
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS public.ai_quota_grants;
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.ai_quota_grants (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id   uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  additional_calls  int  NOT NULL CHECK (additional_calls > 0 AND additional_calls <= 1000000),
+  source            text NOT NULL DEFAULT 'admin' CHECK (source IN ('admin', 'auto_burst')),
+  reason            text CHECK (reason IS NULL OR length(reason) <= 500),
+  granted_by        text CHECK (granted_by IS NULL OR length(granted_by) <= 320),
+  -- First day of the UTC month the grant belongs to; drives the auto-burst
+  -- uniqueness guard below.
+  period_month      date NOT NULL,
+  expires_at        timestamptz NOT NULL,
+  created_at        timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_quota_grants_active
+  ON public.ai_quota_grants (organization_id, expires_at);
+
+-- At most one automatic burst per organization per month. A second concurrent
+-- request loses this race with a unique violation and is refused, which is the
+-- intended outcome.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_quota_grants_one_auto_burst
+  ON public.ai_quota_grants (organization_id, period_month)
+  WHERE source = 'auto_burst';
+
+ALTER TABLE public.ai_quota_grants ENABLE ROW LEVEL SECURITY;
+
+-- No policies: RLS with zero policies denies every browser role. Grants are
+-- written and read only by service-role functions.
+REVOKE ALL ON public.ai_quota_grants FROM PUBLIC;
+REVOKE ALL ON public.ai_quota_grants FROM anon;
+REVOKE ALL ON public.ai_quota_grants FROM authenticated;
+
+COMMENT ON TABLE public.ai_quota_grants
+  IS 'Temporary additions to an organization monthly AI allowance. Expiring, audited, service-role only.';
+COMMENT ON COLUMN public.ai_quota_grants.source
+  IS 'admin = granted by a platform admin; auto_burst = automatic one-off top-up on first breach in a month';
+COMMENT ON COLUMN public.ai_quota_grants.period_month
+  IS 'First day of the UTC month this grant belongs to; enforces one auto_burst per org per month';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1191,3 +1191,44 @@ COMMENT ON TABLE organization_oauth_states
   IS 'Server-only hashes for short-lived, single-use OAuth state parameters.';
 
 COMMIT;
+
+-- Migration 027: ad-hoc AI quota grants (expiring, service-role only)
+
+CREATE TABLE IF NOT EXISTS public.ai_quota_grants (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id   uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  additional_calls  int  NOT NULL CHECK (additional_calls > 0 AND additional_calls <= 1000000),
+  source            text NOT NULL DEFAULT 'admin' CHECK (source IN ('admin', 'auto_burst')),
+  reason            text CHECK (reason IS NULL OR length(reason) <= 500),
+  granted_by        text CHECK (granted_by IS NULL OR length(granted_by) <= 320),
+  -- First day of the UTC month the grant belongs to; drives the auto-burst
+  -- uniqueness guard below.
+  period_month      date NOT NULL,
+  expires_at        timestamptz NOT NULL,
+  created_at        timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_quota_grants_active
+  ON public.ai_quota_grants (organization_id, expires_at);
+
+-- At most one automatic burst per organization per month. A second concurrent
+-- request loses this race with a unique violation and is refused, which is the
+-- intended outcome.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_quota_grants_one_auto_burst
+  ON public.ai_quota_grants (organization_id, period_month)
+  WHERE source = 'auto_burst';
+
+ALTER TABLE public.ai_quota_grants ENABLE ROW LEVEL SECURITY;
+
+-- No policies: RLS with zero policies denies every browser role. Grants are
+-- written and read only by service-role functions.
+REVOKE ALL ON public.ai_quota_grants FROM PUBLIC;
+REVOKE ALL ON public.ai_quota_grants FROM anon;
+REVOKE ALL ON public.ai_quota_grants FROM authenticated;
+
+COMMENT ON TABLE public.ai_quota_grants
+  IS 'Temporary additions to an organization monthly AI allowance. Expiring, audited, service-role only.';
+COMMENT ON COLUMN public.ai_quota_grants.source
+  IS 'admin = granted by a platform admin; auto_burst = automatic one-off top-up on first breach in a month';
+COMMENT ON COLUMN public.ai_quota_grants.period_month
+  IS 'First day of the UTC month this grant belongs to; enforces one auto_burst per org per month';

--- a/tests/security/ai-quota-enforcement.test.mjs
+++ b/tests/security/ai-quota-enforcement.test.mjs
@@ -12,25 +12,30 @@ import {
 } from "../../netlify/functions/_shared/aiQuota.js";
 import { ORGANIZATION_TIERS } from "../../netlify/functions/_shared/organizationTier.js";
 
-/** Stub for admin.from("ai_usage_log").select(...).eq().eq().gte() */
-function stubUsage(result) {
+/**
+ * Stub for the two reads the quota check makes:
+ *   ai_usage_log   .select(...).eq().eq().gte()   → this month's calls
+ *   ai_quota_grants.select(...).eq().gt()         → active top-ups
+ */
+function stubUsage(result, grants = []) {
   const filters = [];
   return {
     filters,
-    from() {
+    from(table) {
       const chain = {
         select: (columns, options) => {
-          filters.push({ columns, options });
+          if (table === "ai_usage_log") filters.push({ columns, options });
           return chain;
         },
         eq: (column, value) => {
-          filters.push({ column, value });
+          if (table === "ai_usage_log") filters.push({ column, value });
           return chain;
         },
         gte: async (column, value) => {
           filters.push({ column, value });
           return result;
         },
+        gt: async () => ({ data: grants, error: null }),
       };
       return chain;
     },
@@ -127,14 +132,18 @@ test("both AI entry points enforce the ceiling before calling the provider", asy
   ]);
 
   for (const [name, source] of [["api.ts", api], ["ally-support.ts", ally]]) {
-    assert.match(source, /checkMonthlyAiQuota\(/, `${name} must check the quota`);
+    // authorizeAiCall checks the ceiling and spends the monthly auto-burst
+    // before refusing, so entry points must go through it rather than the
+    // bare check.
+    assert.match(source, /authorizeAiCall\(/, `${name} must authorize the call`);
+    assert.doesNotMatch(source, /checkMonthlyAiQuota\(/, `${name} must not skip the auto-burst`);
     assert.match(source, /json\(429, quotaExceededResponse\(quota\)\)/, `${name} must return 429`);
     assert.match(source, /platformQuotaType\(tier\)/, `${name} must log the tier-aware quota type`);
 
     // The gate must precede the provider call in source order.
     assert.ok(
-      source.indexOf("checkMonthlyAiQuota(") < source.indexOf("generateContent"),
-      `${name} must check the quota before calling Gemini`,
+      source.indexOf("authorizeAiCall(") < source.indexOf("generateContent"),
+      `${name} must authorize before calling Gemini`,
     );
   }
 

--- a/tests/security/ai-quota-grants.test.mjs
+++ b/tests/security/ai-quota-grants.test.mjs
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  AUTO_BURST_RATIO,
+  authorizeAiCall,
+  grantAutoBurst,
+  loadActiveGrantTotal,
+  monthEndIso,
+  periodMonth,
+} from "../../netlify/functions/_shared/aiQuota.js";
+
+const NOW = new Date("2026-09-17T12:00:00.000Z");
+const read = (path) => readFile(new URL(path, import.meta.url), "utf8");
+
+/**
+ * @param {{ used?: number, usageError?: object, grants?: object[],
+ *           grantsError?: object, insertError?: object }} options
+ */
+function stubAdmin({ used = 0, usageError = null, grants = [], grantsError = null, insertError = null } = {}) {
+  const state = { inserts: [], grantFilters: [] };
+  return {
+    state,
+    from(table) {
+      if (table === "ai_usage_log") {
+        const chain = {
+          select: () => chain,
+          eq: () => chain,
+          gte: async () => ({ count: usageError ? null : used, error: usageError }),
+        };
+        return chain;
+      }
+      if (table === "ai_quota_grants") {
+        const chain = {
+          select: () => chain,
+          eq: (column, value) => {
+            state.grantFilters.push({ column, value });
+            return chain;
+          },
+          gt: async (column, value) => {
+            state.grantFilters.push({ column, value });
+            return { data: grantsError ? null : grants, error: grantsError };
+          },
+          insert: async (row) => {
+            state.inserts.push(row);
+            return { error: insertError };
+          },
+        };
+        return chain;
+      }
+      throw new Error(`Unexpected table ${table}`);
+    },
+  };
+}
+
+test("active grants are summed for the organization and the moment asked", async () => {
+  const admin = stubAdmin({ grants: [{ additional_calls: 300 }, { additional_calls: 200 }] });
+
+  assert.equal(await loadActiveGrantTotal(admin, "org-1", NOW), 500);
+  assert.deepEqual(admin.state.grantFilters, [
+    { column: "organization_id", value: "org-1" },
+    { column: "expires_at", value: NOW.toISOString() },
+  ]);
+});
+
+test("an unreadable grant costs headroom, never unauthorized spend", async () => {
+  const admin = stubAdmin({ grantsError: { message: "timeout" } });
+  assert.equal(await loadActiveGrantTotal(admin, "org-1", NOW), 0);
+});
+
+test("the automatic burst is a bounded share of the plan, expiring at the reset", async () => {
+  const admin = stubAdmin();
+  const granted = await grantAutoBurst(admin, "org-1", 100, NOW);
+
+  assert.equal(granted, Math.ceil(100 * AUTO_BURST_RATIO));
+  assert.equal(AUTO_BURST_RATIO, 0.25, "worst case stays at 125% of plan");
+
+  const [row] = admin.state.inserts;
+  assert.equal(row.organization_id, "org-1");
+  assert.equal(row.source, "auto_burst");
+  assert.equal(row.period_month, periodMonth(NOW));
+  assert.equal(row.expires_at, monthEndIso(NOW));
+  assert.equal(row.expires_at, "2026-10-01T00:00:00.000Z");
+});
+
+test("a second burst in the same month is refused by the database, not by chance", async () => {
+  const already = stubAdmin({ insertError: { code: "23505" } });
+  assert.equal(await grantAutoBurst(already, "org-1", 100, NOW), 0);
+
+  const broken = stubAdmin({ insertError: { code: "42501" } });
+  assert.equal(await grantAutoBurst(broken, "org-1", 100, NOW), 0);
+});
+
+test("a call under the ceiling is authorized without spending the burst", async () => {
+  const admin = stubAdmin({ used: 40 });
+  const quota = await authorizeAiCall(admin, "org-1", "free", null, NOW);
+
+  assert.equal(quota.allowed, true);
+  assert.equal(quota.limit, 100);
+  assert.deepEqual(admin.state.inserts, [], "no burst until the ceiling is actually hit");
+});
+
+test("grants raise the ceiling that authorization uses", async () => {
+  const admin = stubAdmin({ used: 120, grants: [{ additional_calls: 500 }] });
+  const quota = await authorizeAiCall(admin, "org-1", "free", null, NOW);
+
+  assert.equal(quota.baseLimit, 100);
+  assert.equal(quota.grantedCalls, 500);
+  assert.equal(quota.limit, 600);
+  assert.equal(quota.allowed, true);
+});
+
+test("first breach of the month is absorbed by the burst instead of interrupting", async () => {
+  const admin = stubAdmin({ used: 100 });
+  const quota = await authorizeAiCall(admin, "org-1", "free", null, NOW);
+
+  assert.equal(quota.allowed, true, "the customer is not hard-stopped");
+  assert.equal(quota.autoBurstGranted, 25);
+  assert.equal(quota.limit, 125);
+  assert.equal(admin.state.inserts.length, 1);
+});
+
+test("once the burst is spent the call is refused", async () => {
+  // 125 used against a 100 plan whose burst already exists: the top-up is in
+  // grants, and a second insert loses the unique index.
+  const admin = stubAdmin({
+    used: 125,
+    grants: [{ additional_calls: 25 }],
+    insertError: { code: "23505" },
+  });
+  const quota = await authorizeAiCall(admin, "org-1", "free", null, NOW);
+
+  assert.equal(quota.allowed, false);
+  assert.equal(quota.limit, 125);
+});
+
+test("grants are service-role only and one auto-burst per org per month", async () => {
+  const [migration, schema] = await Promise.all([
+    read("../../supabase/migrations/027_ai_quota_grants.sql"),
+    read("../../supabase/schema.sql"),
+  ]);
+
+  for (const source of [migration, schema]) {
+    const executable = source.replace(/^\s*--.*$/gm, "");
+
+    assert.match(executable, /ALTER TABLE public\.ai_quota_grants ENABLE ROW LEVEL SECURITY/);
+    assert.doesNotMatch(executable, /CREATE POLICY[^;]*ai_quota_grants/,
+      "RLS with no policy is what denies every browser role");
+    for (const role of ["PUBLIC", "anon", "authenticated"]) {
+      assert.match(
+        executable,
+        new RegExp(`REVOKE ALL ON public\\.ai_quota_grants FROM ${role}`),
+      );
+    }
+
+    assert.match(
+      executable,
+      /CREATE UNIQUE INDEX[\s\S]*ai_quota_grants \(organization_id, period_month\)\s*WHERE source = 'auto_burst'/,
+    );
+    assert.match(executable, /CHECK \(source IN \('admin', 'auto_burst'\)\)/);
+    assert.match(executable, /additional_calls > 0/);
+  }
+});
+
+test("admin quota actions are authenticated, validated and attributed", async () => {
+  const source = await read("../../netlify/functions/admin.ts");
+
+  const requireAdmin = source.indexOf("await requireAdmin(authHeader)");
+  for (const action of ["org_ai_quota", "grant_ai_quota", "set_ai_quota_override"]) {
+    const index = source.indexOf(`case '${action}'`);
+    assert.ok(index > requireAdmin, `${action} must sit in the post-auth switch`);
+  }
+
+  const grant = source.match(/async function handleGrantAiQuota[\s\S]*?\n}\n/)?.[0];
+  assert.ok(grant);
+  assert.match(grant, /Number\.isInteger\(calls\)/);
+  assert.match(grant, /calls < 1 \|\| calls > 1_000_000/);
+  assert.match(grant, /granted_by:\s*actorEmail/);
+  assert.match(grant, /expires_at:\s*monthEndIso\(now\)/, "an ad-hoc grant must expire");
+  assert.match(grant, /source:\s*'admin'/);
+
+  const override = source.match(/async function handleSetAiQuotaOverride[\s\S]*?\n}\n/)?.[0];
+  assert.ok(override);
+  assert.match(override, /raw === null \|\| raw === ''/, "blank must clear the override");
+  assert.match(override, /override < 0 \|\| override > 1_000_000/);
+});

--- a/tests/security/ally-support-auth.test.mjs
+++ b/tests/security/ally-support-auth.test.mjs
@@ -69,6 +69,13 @@ function createHarness({
       if (table === "organizations") {
         return createQuery({ data: { tier }, error: null });
       }
+      if (table === "ai_quota_grants") {
+        return {
+          select: () => ({ eq: () => ({ gt: async () => ({ data: [], error: null }) }) }),
+          // The auto-burst attempt on a breach; "already used this month".
+          insert: async () => ({ error: { code: "23505" } }),
+        };
+      }
       if (table === "ai_usage_log") {
         const countQuery = {
           select: () => countQuery,


### PR DESCRIPTION
> **Stacked on #186** (which is stacked on #181). Second of two PRs answering "can an admin raise quota ad-hoc so service isn't interrupted?"

## The design decision worth reviewing

The obvious implementation is "let the admin edit `soft_quota_monthly` from the UI". I didn't do that, and it's the part I'd most like you to push back on if you disagree.

`soft_quota_monthly` is a **standing** monthly override. Raise it to 5,000 to unblock a customer this afternoon and that is their ceiling every month from now on, until somebody remembers. That is how a free-tier org ends up quietly running on an enterprise allowance.

So there are two separate concepts here:

| | Lives in | Lifetime |
|---|---|---|
| **Standing limit** | `organization_ai_settings.soft_quota_monthly` | Until changed. A deliberate decision about this customer's plan. |
| **Grant** | `ai_quota_grants` (new) | Expires when the allowance resets. The exception does not outlive the incident. |

Effective ceiling = standing limit + sum of active grants. Both are editable from the admin panel; the grant is the one you reach for at 2pm on a Tuesday.

It is a table rather than a column because this is spend authorization: who granted it, how much, why, when it lapses.

## Never interrupting, while staying bounded

A manual bump still means the customer is stopped until an admin notices. So: **the first time an organization crosses its ceiling in a month, it is granted one automatic 25% burst and keeps working.**

- Worst case becomes 125% of plan, not open-ended.
- "Once per organization per month" is enforced by a partial unique index, not by application logic — a concurrent second attempt loses the race and is refused, which is the right answer.
- The burst lands in the grant list with an `auto` badge and a note telling the admin to decide: raise the standing limit, move the tier, or let it lapse.

## Admin panel

`Quota` button on each row of *Top Companies — this month* opens: usage against the effective ceiling, where the ceiling comes from (plan + grants), active grants with source and reason, and both controls. `ADMIN_MANUAL.md` documents it, framed as "the screen to reach for when a customer says AI stopped working".

## What I did not build, and why

**Email alerts on auto-burst.** I proposed this and then didn't do it. The burst fires inside the AI request path, and putting an outbound email send there adds latency and a failure mode to the request that is already having a bad day — and `PLATFORM_ADMIN_EMAIL` is a bootstrap credential, not necessarily an ops inbox.

What exists instead: a durable row, a stable `[quota] auto-burst granted org=… calls=… base=…` log line you can alert on from Netlify, and the badge in the panel. If you want push notification, the clean shape is a scheduled function emailing a daily digest of auto-bursts — off the hot path. Happy to add it; it needs you to pick a recipient.

**Revoking a grant.** Grants expire on their own and are capped at 1,000,000. Add it if you find you need it.

## ⚠️ Migration

`027_ai_quota_grants.sql` must be applied before this deploys — the quota check reads the table on every AI call. It fails soft if the table is missing (grant total 0, warning logged), but the auto-burst will not work.

## Verification

```
npm run test:security   # 138 pass (128 before, 10 new)
npx tsc --noEmit         # clean
npm run build            # clean
```

`tests/security/ai-quota-grants.test.mjs` covers the grant sum and its filters, the failure mode (unreadable grants cost headroom, never grant spend), burst size and expiry, the 23505 path, the four authorization outcomes (under ceiling / grants raise it / first breach absorbed / burst spent → refused), and the RLS-with-no-policies plus partial-index guarantees in both the migration and the schema snapshot. The admin actions are asserted to sit after `requireAdmin`, validate their inputs, and record the actor.

The modal itself is not visually verified — it needs a platform-admin session I don't have. Worth a click-through in a deploy preview.

Not touched: `CHANGELOG.md`, which lives on #183. I'll add an entry there once the stack lands, or you can.

🤖 Generated with [Claude Code](https://claude.com/claude-code)