### PR TITLE
docs: describe tier entitlements and enforced AI quota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ This project does not yet use semantic versioning. Entries are dated.
 ## [Unreleased]
 
 ### Fixed
+- **Organization tier was write-once** — a tier could be chosen when a company was
+  created and never changed; nothing wrote `organizations.tier` again. Platform admins
+  can now change it from the company list (`set_company_tier`), which moves both the AI
+  allowance and the evidence storage quota.
+- **Tenant AI panel showed a limit that did not exist** — the quota bar displayed a
+  hardcoded 100 to every organization regardless of tier, called it a "soft limit", and
+  told anyone over it that "AI calls are still allowed". The panel now shows the ceiling
+  the server will actually enforce, resolved server-side.
 - **Evidence upload entitlement** — `evidence.ts` resolved the organization tier
   from `organizations.subscription_tier`, a column that does not exist; migration
   015 named it `tier`. Every organization therefore fell back to `free` (0 MB) and
@@ -28,6 +36,13 @@ This project does not yet use semantic versioning. Entries are dated.
 - **CI workflow** (`.github/workflows/ci.yml`) — runs the four verification steps
   `AGENTS.md` requires (security tests, type check, build, runtime audit) on every
   pull request and push to `main`.
+- **Ad-hoc AI quota grants** (`ai_quota_grants`) — expiring, attributed top-ups that a
+  platform admin can add from **AI Usage → Quota** without changing an organization's
+  standing plan. The effective ceiling is `standing limit + active grants`.
+- **Automatic first-breach burst** — the first time an organization crosses its ceiling
+  in a month it receives one automatic 25% top-up and the call proceeds, so service is
+  not interrupted before a human can look. Worst case is 125% of plan; "once per month"
+  is enforced by a partial unique index, not application logic.
 - **`ROADMAP.md`** — `CONTRIBUTING.md` referred contributors to a roadmap that did
   not exist.
 
@@ -45,6 +60,11 @@ This project does not yet use semantic versioning. Entries are dated.
 | File | What it does |
 |---|---|
 | `026_ai_quota_enforcement.sql` | Adds `platform_starter` to the `ai_usage_log.quota_type` CHECK constraint (migration 015 added the tier; the constraint was never extended) and restates `soft_quota_monthly` as an enforced ceiling |
+| `027_ai_quota_grants.sql` | Creates the service-role-only `ai_quota_grants` table and the one-auto-burst-per-organization-per-month index |
+
+> Before deploying quota enforcement, follow **Enabling AI quota enforcement** in
+> [`Docs v1.1.0/DEPLOYMENT.md`](./Docs%20v1.1.0/DEPLOYMENT.md). Organizations already over
+> their tier default start receiving HTTP 429 on the first deploy otherwise.
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,8 @@ netlify/functions/
   google-drive.ts     Authenticated Drive proxy; never returns OAuth tokens
   google-callback.ts  OAuth callback with hashed, expiring state
   evidence.ts         Tenant-aware evidence operations
+  _shared/organizationTier.js  Canonical organizations.tier resolver; fails closed to free
+  _shared/aiQuota.js           Monthly platform AI ceiling, grants, auto-burst
   invite.ts           Invitation CRUD + rate-limited public resend
   accept-invite.ts    Authenticated invite validation + member join
   ally-support.ts     Authenticated, tenant-bound support AI
@@ -93,7 +95,10 @@ Member-readable org-scoped tables normally follow this policy shape:
 - INSERT/UPDATE/DELETE: `user_org_role(organization_id) IN ('Owner', 'Admin', 'Manager')`
 Use the helper functions rather than duplicating membership SQL.
 
-Server-only credential tables are exceptions. `organization_ai_secrets`, `organization_integrations`, and `organization_oauth_states` revoke browser grants and are accessed only through authenticated Netlify Functions using `service_role`.
+Server-only credential tables are exceptions. `organization_ai_secrets`, `organization_integrations`, `organization_oauth_states`, and `ai_quota_grants` revoke browser grants and are accessed only through authenticated Netlify Functions using `service_role`.
+
+### Entitlements and quota
+`organizations.tier` is the single source of truth for what a tenant is entitled to; resolve it through `_shared/organizationTier.js`, never by reading the column ad hoc, and never invent a second column for it. Platform AI calls are capped per organization per month by `_shared/aiQuota.js`; both AI entry points must go through `authorizeAiCall()` so the automatic burst is attempted before a tenant is refused. BYOK tenants are exempt because they pay the provider directly.
 
 ### Dark mode
 Toggle via `dark` class on `<html>`. Every UI component should have `dark:` Tailwind variants. Dark mode preference is stored in `localStorage` (per-device, not in DB).
@@ -143,6 +148,8 @@ The complete delivery workflow and security review requirements are maintained i
 | `MATERIALITY_THRESHOLD` | `constants.ts` | `40` | Topics above this on either axis are material |
 | `DEFAULT_MODEL` | `netlify/functions/api.ts` | `"gemini-2.5-flash"` | Used when org has no AI settings row |
 | Invite expiry | `supabase/schema.sql` | `now() + interval '7 days'` | Hardcoded in DB default |
+| `MONTHLY_AI_CALL_LIMITS` | `netlify/functions/_shared/aiQuota.js` | free 100 / starter 500 / pro 2 000 / enterprise 10 000 | Enforced monthly platform AI ceiling; `organization_ai_settings.soft_quota_monthly` overrides it per org |
+| `AUTO_BURST_RATIO` | `netlify/functions/_shared/aiQuota.js` | `0.25` | One automatic top-up per org per month on first breach; caps worst case at 125% of plan |
 
 ---
 

--- a/Docs v1.1.0/ADMIN_MANUAL.md
+++ b/Docs v1.1.0/ADMIN_MANUAL.md
@@ -1,4 +1,4 @@
-<!-- Version: 1.1.0 — Last updated: 2026-05-09 -->
+<!-- Version: 1.1.0 — Last updated: 2026-09-05 -->
 
 # AeternumAlly - Admin Portal Manual (v1.1.0)
 

--- a/Docs v1.1.0/ARCHITECTURE.md
+++ b/Docs v1.1.0/ARCHITECTURE.md
@@ -1,4 +1,4 @@
-<!-- Version: 1.1.0 - Last updated: 2026-08-18 -->
+<!-- Version: 1.1.0 - Last updated: 2026-09-05 -->
 
 # Architecture Overview
 
@@ -152,6 +152,11 @@ User clicks "Auto-Fill"
     → POST /.netlify/functions/api  (Bearer JWT in header)
       → api.ts validates JWT with Supabase
       → api.ts verifies organization membership and resolves server-side AI settings
+      → api.ts authorizes the call against the monthly AI ceiling
+          (tier default or standing override, plus active grants;
+           first breach of the month is absorbed by one automatic burst,
+           otherwise 429 is returned before any provider call.
+           BYOK organizations skip this step)
       → api.ts calls Google Gemini with prompt built from user data
       → Response streamed back as JSON
       → ai_usage_log row inserted (tokens, model, org_id)

--- a/Docs v1.1.0/CONFIGURATION.md
+++ b/Docs v1.1.0/CONFIGURATION.md
@@ -1,4 +1,4 @@
-<!-- Version: 1.1.0 - Last updated: 2026-08-18 -->
+<!-- Version: 1.1.0 - Last updated: 2026-09-05 -->
 
 # Configuration Reference
 
@@ -81,9 +81,31 @@ Each organization can select a Gemini model and optionally use its own credentia
 | `model` | `text` | `"gemini-2.5-flash"` | Gemini model to use for this org's AI calls |
 | `use_byok` | `boolean` | `false` | Whether the server should use the organization's stored key |
 | `byok_provider` | `text` | `null` | Credential provider; currently only `gemini` is accepted by the function |
-| `soft_quota_monthly` | `integer` | `null` | Optional monthly call allowance override; the current quota is a soft warning, not a hard block |
+| `soft_quota_monthly` | `integer` | `null` | Standing monthly call ceiling for this organization. `null` uses the tier default below; `0` suspends platform AI. Despite the column name this is enforced, not advisory. |
 
 `organization_ai_secrets.byok_api_key` is not selectable by browser roles. The settings endpoint returns `has_byok_key`, never the key. Owners and Admins can configure/rotate it; other members can use AI according to organization settings without reading the credential.
+
+### Monthly AI allowance
+
+Platform AI calls are capped per organization per month. Exceeding the ceiling returns HTTP 429 before any provider call, from both `api.ts` and `ally-support.ts`. Organizations using their own key (BYOK) are exempt — they are billed by the provider directly.
+
+Defaults by `organizations.tier`, defined in `netlify/functions/_shared/aiQuota.js`:
+
+| Tier | Monthly platform AI calls |
+|---|---|
+| `free` | 100 |
+| `starter` | 500 |
+| `pro` | 2 000 |
+| `enterprise` | 10 000 |
+
+The effective ceiling is `standing limit + active grants`:
+
+- **Standing limit** — `soft_quota_monthly` when set, otherwise the tier default. A deliberate, indefinite decision about this customer.
+- **Grants** — rows in `ai_quota_grants` that expire when the allowance resets. Use these for one-off relief so a temporary exception does not become a permanent plan. The table is service-role only; grants are created from the admin console or by the automatic burst.
+
+The first time an organization crosses its ceiling in a month it receives one automatic top-up of `AUTO_BURST_RATIO` (25%) of its base limit and the call proceeds, so a customer is never hard-stopped before a human has looked. Worst-case monthly spend is therefore 125% of plan. A partial unique index on `(organization_id, period_month) WHERE source = 'auto_burst'` is what limits this to once per month.
+
+Adjust both from the admin console: **AI Usage → Quota**. See [ADMIN_MANUAL.md](./ADMIN_MANUAL.md#ai-quota).
 
 The database `CHECK` restricts `model` values. Repeating the allowlist at the function boundary remains defense-in-depth work; see [TECH_STACK.md](./TECH_STACK.md#known-gaps--hardening-backlog).
 

--- a/Docs v1.1.0/DEPLOYMENT.md
+++ b/Docs v1.1.0/DEPLOYMENT.md
@@ -1,4 +1,4 @@
-<!-- Version: 1.1.0 - Last updated: 2026-08-18 -->
+<!-- Version: 1.1.0 - Last updated: 2026-09-05 -->
 
 # Deployment Guide
 
@@ -162,8 +162,55 @@ Security migration sequence introduced in the August 2026 remediation:
 | `023_validate_evidence_external_urls.sql` | Add the external evidence HTTPS constraint |
 | `024_rate_limit_invite_resends.sql` | Add the service-role-only rate-limit table and atomic resend RPC |
 | `025_secure_error_log_inserts.sql` | Replace the client insert policy and revoke anonymous inserts |
+| `026_ai_quota_enforcement.sql` | Add `platform_starter` to the `ai_usage_log.quota_type` constraint and restate `soft_quota_monthly` as an enforced ceiling |
+| `027_ai_quota_grants.sql` | Create the service-role-only `ai_quota_grants` table and the one-auto-burst-per-month index |
 
 > ⚠️ Run schema migrations **before** merging the code PR if the new code depends on the schema change. Otherwise the deploy will fail at runtime.
+
+### Enabling AI quota enforcement (one-off)
+
+Before the release that enforces the monthly AI allowance, decide what happens to organizations that are *already* over it. Nothing blocked AI calls previously, so any organization above its tier default starts receiving HTTP 429 the moment the deploy goes live — the demo organization is the likely candidate.
+
+**1. Measure first.** This also tells you whether the tier defaults in `_shared/aiQuota.js` are set anywhere near real usage:
+
+```sql
+select o.id,
+       coalesce(cp.name, '(unnamed)') as company,
+       o.tier,
+       count(l.id) filter (where l.success) as calls_this_month
+from organizations o
+left join company_profiles cp on cp.organization_id = o.id
+left join ai_usage_log l on l.organization_id = o.id
+     and l.created_at >= date_trunc('month', now() at time zone 'utc')
+group by o.id, cp.name, o.tier
+order by calls_this_month desc;
+```
+
+**2. Seed a generous standing limit** for existing organizations, then tighten once you have watched a full month. Organizations that never opened AI settings have no row in `organization_ai_settings`, so this must insert rather than update:
+
+```sql
+insert into organization_ai_settings (organization_id, soft_quota_monthly)
+select id, 5000 from organizations
+on conflict (organization_id) do update
+  set soft_quota_monthly = coalesce(
+        organization_ai_settings.soft_quota_monthly,
+        excluded.soft_quota_monthly),
+      updated_at = now();
+```
+
+The `coalesce` leaves any deliberate existing value alone, so the statement stays safe to re-run.
+
+**3. Tighten later.** Clearing the override returns an organization to its tier default:
+
+```sql
+update organization_ai_settings
+set soft_quota_monthly = null, updated_at = now()
+where organization_id = '<org-uuid>';
+```
+
+From the release that adds the admin quota controls onward, do steps 2 and 3 from **AI Usage → Quota** in the admin console instead of by hand.
+
+The alternative to seeding is raising the `free` default in `netlify/functions/_shared/aiQuota.js` before the release. That is one line and needs no SQL, but it applies to every future signup too, so it is a pricing decision rather than a migration safeguard.
 
 #### Rollback procedure
 

--- a/Docs v1.1.0/FUNCTIONAL_SPEC.md
+++ b/Docs v1.1.0/FUNCTIONAL_SPEC.md
@@ -1,4 +1,4 @@
-<!-- Version: 1.1.0 — Last updated: 2026-05-09 -->
+<!-- Version: 1.1.0 — Last updated: 2026-09-05 -->
 
 # Functional Specification
 
@@ -337,8 +337,19 @@ Displays:
 - Feature / action type
 - Timestamp
 - Running total for the current billing period
+- Calls used against the organization's monthly ceiling, with warnings as it approaches and when it is reached
 
 Data sourced from `ai_usage_log` table, which is populated by `api.ts` on every Gemini call.
+
+### Monthly allowance
+
+Each organization has a monthly platform AI allowance determined by its tier, overridable per organization, and extendable by expiring grants. When it is spent, AI actions fail with a clear message rather than silently consuming platform budget; the allowance resets on the 1st.
+
+Two ways for an organization to continue immediately:
+1. **Bring Your Own Key** — configured in the same panel by an Owner or Admin. BYOK calls are not subject to platform quota.
+2. **Ask support to raise it** — a platform admin can grant additional calls for the current month or change the standing limit.
+
+The ceiling shown in the panel is resolved server-side, so it always matches what will actually be enforced. See [CONFIGURATION.md](./CONFIGURATION.md#monthly-ai-allowance) for the tier defaults and [ADMIN_MANUAL.md](./ADMIN_MANUAL.md#ai-quota) for the admin-side controls.
 
 ---
 

--- a/Docs v1.1.0/GLOSSARY.md
+++ b/Docs v1.1.0/GLOSSARY.md
@@ -1,4 +1,4 @@
-<!-- Version: 1.1.0 — Last updated: 2026-05-09 -->
+<!-- Version: 1.1.0 — Last updated: 2026-09-05 -->
 
 # Glossary
 
@@ -122,6 +122,21 @@ Serverless functions deployed alongside the frontend on Netlify. In this project
 
 **Magic link**
 A one-time sign-in URL sent by email. Clicking it authenticates the user without a password. Supabase Auth manages magic-link generation and delivery.
+
+**Tier**
+An organization's billing/access level: `free`, `starter`, `pro`, or `enterprise`. Stored in `organizations.tier` and set by a platform admin. Determines the monthly AI allowance and the evidence storage quota.
+
+**BYOK — Bring Your Own Key**
+An organization supplying its own Gemini API key instead of using the platform's. BYOK calls are billed by the provider directly to that organization, so they are exempt from the platform's monthly allowance. The key is stored in a service-role-only table and is never returned to the browser.
+
+**Monthly allowance / quota**
+The number of platform-funded AI calls an organization may make per calendar month. Exceeding it returns an error rather than consuming further platform budget. Resets on the 1st.
+
+**Quota grant**
+A temporary addition to an organization's monthly allowance, recorded in `ai_quota_grants` with a reason and an expiry at the next reset. Distinct from the standing `soft_quota_monthly` override, which does not expire.
+
+**Auto-burst**
+The one automatic quota grant an organization receives the first time it crosses its ceiling in a month, so service is not interrupted before a platform admin can decide what to do. Limited to once per organization per month.
 
 **Invite token**
 A UUID that serves as both the primary key of the `organization_invites` row and the secret in the invitation email link. It is single-use: the `accept-invite` function deletes it after the invitee joins.

--- a/Docs v1.1.0/TECH_STACK.md
+++ b/Docs v1.1.0/TECH_STACK.md
@@ -1,4 +1,4 @@
-<!-- Version: 1.1.0 - Last updated: 2026-08-18 -->
+<!-- Version: 1.1.0 - Last updated: 2026-09-05 -->
 
 # Tech Stack & Deployment
 
@@ -94,8 +94,9 @@ swot_analyses              ─┤
 organization_ai_settings   ─┘
 
 organization_ai_secrets    ─┐  Service-role-only credentials/state
-organization_integrations  ─┤
-organization_oauth_states  ─┘
+organization_integrations  ─┤  (RLS enabled, no policies; no browser grants)
+organization_oauth_states  ─┤
+ai_quota_grants            ─┘
 
 assessments                ─┐  Many per org
 kpis                       ─┤  (org-scoped via FK + RLS)
@@ -138,6 +139,8 @@ Security-relevant migrations:
 - `023_validate_evidence_external_urls.sql` - database defense for external evidence URLs
 - `024_rate_limit_invite_resends.sql` - atomic invite-resend rate limit and delivery cooldown
 - `025_secure_error_log_inserts.sql` - bind client logs to the authenticated user and tenant
+- `026_ai_quota_enforcement.sql` - complete the `quota_type` constraint for the starter tier
+- `027_ai_quota_grants.sql` - service-role-only expiring quota grants; one automatic burst per org per month enforced by a partial unique index
 
 **When to run what:**
 

--- a/Docs v1.1.0/USER_MANUAL.md
+++ b/Docs v1.1.0/USER_MANUAL.md
@@ -1,4 +1,4 @@
-<!-- Version: 1.1.0 — Last updated: 2026-05-09 -->
+<!-- Version: 1.1.0 — Last updated: 2026-09-05 -->
 # AeternumAlly - User Manual (v1.1.0)
 
 Welcome to AeternumAlly! This platform guides your organization through a structured sustainability reporting workflow, allowing you to generate a draft Sustainability Statement aligned with ESRS (European Sustainability Reporting Standards) and GRI standards, all without needing prior expertise.
@@ -257,7 +257,7 @@ To help you understand how AeternumAlly works in practice, here are two common s
 ## 9. Troubleshooting
 
 - **Login Link Expired:** Return to the login page and request a new link. Check your spam folder if it doesn't arrive.
-- **AI Features Unresponsive:** If using the live demo, the shared quota may be temporarily exhausted. If self-hosting, ensure your `GEMINI_API_KEY` is configured correctly in your environment variables.
+- **AI Features Unresponsive:** Check the **Monthly call quota** bar under Settings → AI. Each workspace has a monthly allowance, and AI features pause once it is spent until the allowance resets on the 1st. To continue immediately, an Owner or Admin can add your own Gemini API key (Settings → AI → Bring Your Own Key), which is not subject to the platform allowance — or contact support to have the limit raised. If you are using the live demo, the shared quota may also be temporarily exhausted. If self-hosting, ensure your `GEMINI_API_KEY` is configured correctly in your environment variables.
 - **Data Not Saving:** Look for the spinning save indicator in the top right. If an error persists, refresh the page.
 - **Empty Materiality Matrix:** Ensure you have completed at least one Double Materiality Assessment.
 - **Missing Sidebar Sections:** Some features are role-restricted. Consultants (Read-Only) will not see management or destructive actions. Contact your Workspace Owner if you need your role upgraded.


### PR DESCRIPTION
> Retargeted to `main` and rebased — it now contains **only** documentation, and can merge independently of #191. It documents what #191 ships, so ideally merge it alongside or just after.

**Version stays `1.1.0` in every file** — only the `Last updated` stamps move to 2026-09-05, and only on files this work actually changed. Say the word if you'd rather I leave the dates untouched too.

## The one that was actively wrong

`CONFIGURATION.md` described the quota column as:

> Optional monthly call allowance override; **the current quota is a soft warning, not a hard block**

The opposite of what the server now does. Replaced with the tier defaults, the standing-limit vs. grant distinction, and the auto-burst rule.

## The one that could cost you a bad morning

`DEPLOYMENT.md` gains migrations 026 and 027, and a one-off **"Enabling AI quota enforcement"** runbook — the answer to where to set generous limits before the switch flips:

1. Measure current per-org usage this month (query included). It also tells you whether the tier defaults are anywhere near reality.
2. Seed a generous standing limit — the insert handles organizations with no `organization_ai_settings` row at all, which is most of them, and the `coalesce` makes it safe to re-run.
3. Tighten later, from the admin console.

Plus the alternative — raising the `free` default in code — with the trade-off spelled out: it applies to every future signup, so it is a pricing decision rather than a migration safeguard.

## The rest

| File | What changed |
|---|---|
| `ARCHITECTURE.md` | The authorization step added to the AI request-flow diagram |
| `TECH_STACK.md` | `ai_quota_grants` under the service-role-only tables; both migrations listed |
| `FUNCTIONAL_SPEC.md` | What the AI Usage Panel reports, and the two ways a tenant continues when the allowance is spent |
| `USER_MANUAL.md` | "AI Features Unresponsive" now answers with the quota bar, BYOK and support — not just "the demo quota may be exhausted" |
| `GLOSSARY.md` | Tier, BYOK, monthly allowance, quota grant, auto-burst |
| `CLAUDE.md` | Shared modules, quota constants, and the entitlement rule — it instructs itself to stay consistent with `AGENTS.md`, and had drifted |
| `CHANGELOG.md` | The tier and quota work, added to the existing `Unreleased` section rather than opening a new version heading |

`ADMIN_MANUAL.md` content came with #186/#187; only its date stamp moves here.

## Verification

Every relative link and heading anchor in the touched documents was checked to resolve against a real file and a real heading. Trial-merged onto current `main` with #190 and #191: clean, 141 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)