### PR TITLE
feat(ai): enforce the monthly AI quota, with tier controls and ad-hoc grants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ netlify/functions/
   google-callback.ts  OAuth callback with hashed, expiring state
   evidence.ts         Tenant-aware evidence operations
   _shared/organizationTier.js  Canonical organizations.tier resolver; fails closed to free
-  _shared/aiQuota.js           Monthly platform AI ceiling per tier
+  _shared/aiQuota.js           Monthly platform AI ceiling, grants, auto-burst
   invite.ts           Invitation CRUD + rate-limited public resend
   accept-invite.ts    Authenticated invite validation + member join
   ally-support.ts     Authenticated, tenant-bound support AI
@@ -153,6 +153,7 @@ Singleton tables (profile, canvas, SWOT) use `useOrgData` which auto-saves on st
 | `DEFAULT_MODEL` | `netlify/functions/api.ts` | `"gemini-2.5-flash"` | Used when org has no AI settings row |
 | Invite expiry | `supabase/schema.sql` | `now() + interval '7 days'` | Hardcoded in DB default |
 | `MONTHLY_AI_CALL_LIMITS` | `netlify/functions/_shared/aiQuota.js` | free 100 / starter 500 / pro 2 000 / enterprise 10 000 | Enforced monthly platform AI ceiling; `organization_ai_settings.soft_quota_monthly` overrides it per org |
+| `AUTO_BURST_RATIO` | `netlify/functions/_shared/aiQuota.js` | `0.25` | One automatic top-up per org per month on first breach, so worst-case spend is 125% of plan rather than open-ended |
 
 ---
 
@@ -168,6 +169,7 @@ Singleton tables (profile, canvas, SWOT) use `useOrgData` which auto-saves on st
 - Ally support authenticates the user and verifies organization membership before side effects.
 - Client error logs bind user and tenant identity in RLS; AI handlers do not log tenant output content.
 - Platform AI calls are capped per organization per month. Both AI entry points (`api.ts` and `ally-support.ts`) return 429 before any provider call once the ceiling is spent; BYOK tenants bypass the cap because they pay the provider directly.
+- Quota headroom can be added ad-hoc through `ai_quota_grants`, a service-role-only table of expiring, attributed top-ups. Effective ceiling is `standing limit + active grants`. One automatic burst per organization per month is allowed on first breach; a partial unique index, not application logic, is what enforces "once".
 
 ## Known gaps (track; do not introduce workarounds)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,8 @@ netlify/functions/
   google-drive.ts     Authenticated Drive proxy; never returns OAuth tokens
   google-callback.ts  OAuth callback with hashed, expiring state
   evidence.ts         Tenant-aware evidence operations
+  _shared/organizationTier.js  Canonical organizations.tier resolver; fails closed to free
+  _shared/aiQuota.js           Monthly platform AI ceiling per tier
   invite.ts           Invitation CRUD + rate-limited public resend
   accept-invite.ts    Authenticated invite validation + member join
   ally-support.ts     Authenticated, tenant-bound support AI
@@ -150,6 +152,7 @@ Singleton tables (profile, canvas, SWOT) use `useOrgData` which auto-saves on st
 | `MATERIALITY_THRESHOLD` | `constants.ts` | `40` | Topics above this on either axis are material |
 | `DEFAULT_MODEL` | `netlify/functions/api.ts` | `"gemini-2.5-flash"` | Used when org has no AI settings row |
 | Invite expiry | `supabase/schema.sql` | `now() + interval '7 days'` | Hardcoded in DB default |
+| `MONTHLY_AI_CALL_LIMITS` | `netlify/functions/_shared/aiQuota.js` | free 100 / starter 500 / pro 2 000 / enterprise 10 000 | Enforced monthly platform AI ceiling; `organization_ai_settings.soft_quota_monthly` overrides it per org |
 
 ---
 
@@ -164,6 +167,7 @@ Singleton tables (profile, canvas, SWOT) use `useOrgData` which auto-saves on st
 - Public invite resend is generic, centrally rate-limited, and has a delivery cooldown.
 - Ally support authenticates the user and verifies organization membership before side effects.
 - Client error logs bind user and tenant identity in RLS; AI handlers do not log tenant output content.
+- Platform AI calls are capped per organization per month. Both AI entry points (`api.ts` and `ally-support.ts`) return 429 before any provider call once the ceiling is spent; BYOK tenants bypass the cap because they pay the provider directly.
 
 ## Known gaps (track; do not introduce workarounds)
 

--- a/Docs v1.1.0/ADMIN_MANUAL.md
+++ b/Docs v1.1.0/ADMIN_MANUAL.md
@@ -44,6 +44,20 @@ The Dashboard provides a real-time, high-level summary of the entire platform's 
 
 *Use the year dropdown in the top right of each chart card to view historical data.*
 
+### AI Quota
+
+Each organization has a monthly platform AI allowance set by its tier. When it is spent, AI features return an error until the allowance resets on the 1st — so this is the screen to reach for when a customer reports that AI has stopped working.
+
+Click **Quota** on any row of *Top Companies — this month* to see where that organization stands and to adjust it:
+
+- **Grant extra calls** — a one-off top-up for the current month, with a reason that is recorded against your admin email. It expires automatically when the allowance resets, so it cannot quietly become the customer's permanent plan. This is the fastest way to unblock someone.
+- **Standing monthly limit** — replaces the tier default every month, for a customer whose normal usage genuinely exceeds their plan. Leave it blank to return to the tier default. `0` suspends platform AI for that organization.
+- **Change the tier** instead (Company Management → Tier) when the customer has actually moved plans. That changes storage entitlements too.
+
+**Automatic top-ups.** The first time an organization crosses its ceiling in a month, the platform grants a one-off 25% top-up by itself and keeps serving, so nobody is cut off before a human has looked. It appears in the grant list with an `auto` badge and a note. Treat one as a prompt to decide: raise the standing limit, move the tier, or let it lapse. An organization only ever receives one automatic top-up per month; after that it is refused until you grant more.
+
+**Organizations using their own API key (BYOK)** are not subject to platform quota, and the panel says so.
+
 ---
 
 ## 3. Company Management

--- a/Docs v1.1.0/ADMIN_MANUAL.md
+++ b/Docs v1.1.0/ADMIN_MANUAL.md
@@ -59,6 +59,7 @@ This module allows you to oversee all tenant organizations registered on the pla
 ### Managing Existing Companies
 - **Search & Sort:** Use the search bar to find specific companies, and click column headers to sort by Tier, Member Count, Creation Date, or Status.
 - **Detail View:** Click on any company name to view a detailed breakdown of their activity and specific platform statistics.
+- **Tier:** The tier shown in the Tier column is a dropdown. Changing it takes effect immediately and moves both the organization's monthly AI call allowance and its evidence storage quota, so you are asked to confirm. The change is recorded in the function log against your admin email.
 - **Status Toggle:** Use the **Deactivate / Reactivate** button to freeze or unfreeze an organization's access. Deactivating a company immediately revokes access for all its members.
 - **Data Export:** Click **Export** to download a comprehensive archive of the company's sustainability data (useful for manual backups or support requests).
 

--- a/components/AIUsagePanel.tsx
+++ b/components/AIUsagePanel.tsx
@@ -65,8 +65,9 @@ const ACTION_COLORS: Record<string, string> = {
   generateTasks:                 "#fb923c",
 };
 
-// Platform soft limit shown in the quota bar (same default as api.ts)
-const PLATFORM_SOFT_LIMIT_DEFAULT = 100;
+// Fallback only for the moment before settings load; the real ceiling is
+// resolved server-side and returned as `monthly_call_limit`.
+const MONTHLY_LIMIT_FALLBACK = 100;
 
 const AIUsagePanel: React.FC<Props> = ({ organizationId, currentUserRole }) => {
   const canManage = currentUserRole === "Owner" || currentUserRole === "Admin";
@@ -92,7 +93,7 @@ const AIUsagePanel: React.FC<Props> = ({ organizationId, currentUserRole }) => {
   // ── Usage data ───────────────────────────────────────────────────
   const [usage, setUsage] = useState<AiUsageRow[]>([]);
   const [monthlyCallCount, setMonthlyCallCount] = useState<number>(0);
-  const [softQuotaMonthly, setSoftQuotaMonthly] = useState<number | null>(null);
+  const [monthlyCallLimit, setMonthlyCallLimit] = useState<number | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   // Fetch settings + recent usage + this month's count on mount
@@ -113,7 +114,7 @@ const AIUsagePanel: React.FC<Props> = ({ organizationId, currentUserRole }) => {
         setSavedUseBYOK(settings.use_byok);
         setByokProvider(settings.byok_provider ?? "gemini");
         setHasStoredKey(settings.has_byok_key);
-        setSoftQuotaMonthly(settings.soft_quota_monthly);
+        setMonthlyCallLimit(settings.monthly_call_limit);
       }
       setUsage(log);
       setMonthlyCallCount(monthCount);
@@ -324,13 +325,14 @@ const AIUsagePanel: React.FC<Props> = ({ organizationId, currentUserRole }) => {
               <Hash className="w-4 h-4 text-esg-600" /> Monthly call quota
             </h3>
             <p className="text-sm text-slate-500 dark:text-slate-400">
-              Platform quota resets on the 1st of each month. Enable BYOK below to bypass it.
+              AI features pause when this is spent, and the allowance resets on the 1st.
+              Enable BYOK below to bypass it entirely.
             </p>
           </header>
 
           <QuotaBar
             used={monthlyCallCount}
-            limit={softQuotaMonthly ?? PLATFORM_SOFT_LIMIT_DEFAULT}
+            limit={monthlyCallLimit ?? MONTHLY_LIMIT_FALLBACK}
           />
         </section>
       )}
@@ -612,13 +614,13 @@ const QuotaBar: React.FC<{ used: number; limit: number }> = ({ used, limit }) =>
         }`}>
           <AlertCircle className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
           {isOver
-            ? "Soft quota exceeded. AI calls are still allowed but you may want to enable BYOK or contact support."
-            : "Approaching monthly quota. Consider enabling BYOK to avoid interruptions."}
+            ? "Monthly quota reached. AI features are paused until the allowance resets on the 1st. Enable BYOK below to continue now, or contact support to raise the limit."
+            : "Approaching the monthly quota. Enable BYOK, or contact support to raise the limit, before AI features pause."}
         </div>
       )}
       <div className="flex justify-between items-center text-xs text-slate-600 dark:text-slate-400">
         <span>{used.toLocaleString()} calls used</span>
-        <span>{limit.toLocaleString()} soft limit</span>
+        <span>{limit.toLocaleString()} monthly limit</span>
       </div>
       <div className="h-2 bg-slate-100 dark:bg-slate-700 rounded-full overflow-hidden">
         <div
@@ -626,7 +628,7 @@ const QuotaBar: React.FC<{ used: number; limit: number }> = ({ used, limit }) =>
           style={{ width: `${pct}%` }}
         />
       </div>
-      <p className="text-xs text-slate-400">{pct}% of monthly soft limit used</p>
+      <p className="text-xs text-slate-400">{pct}% of the monthly limit used</p>
     </div>
   );
 };

--- a/components/admin/AdminAIUsagePanel.tsx
+++ b/components/admin/AdminAIUsagePanel.tsx
@@ -5,7 +5,7 @@ import {
 } from 'recharts';
 import {
   Zap, RefreshCw, Loader2, AlertCircle, TrendingUp,
-  DollarSign, AlertTriangle, Activity,
+  DollarSign, AlertTriangle, Activity, Gauge, Plus, X,
 } from 'lucide-react';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
@@ -22,12 +22,22 @@ interface TopOrg { org_id: string; name: string; tier: string; calls: number; }
 
 interface Props { adminToken: string; }
 
+interface QuotaGrant {
+  id: string; additional_calls: number; source: 'admin' | 'auto_burst';
+  reason: string | null; granted_by: string | null; expires_at: string; created_at: string;
+}
+interface OrgQuota {
+  organization_id: string; tier: string; use_byok: boolean;
+  soft_quota_monthly: number | null; base_limit: number; granted_calls: number;
+  effective_limit: number; used: number; resets_at: string; grants: QuotaGrant[];
+}
+
 // ── API helper ────────────────────────────────────────────────────────────────
-async function callAdmin(action: string, token: string) {
+async function callAdmin(action: string, token: string, body?: object) {
   const res = await fetch('/.netlify/functions/admin', {
     method:  'POST',
     headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${token}` },
-    body:    JSON.stringify({ action }),
+    body:    JSON.stringify({ action, ...body }),
   });
   const json = await res.json();
   if (!res.ok) throw new Error(json.error ?? `Request failed (${res.status})`);
@@ -81,6 +91,7 @@ const AdminAIUsagePanel: React.FC<Props> = ({ adminToken }) => {
   const [topOrgs,  setTopOrgs]  = useState<TopOrg[]>([]);
   const [loading,  setLoading]  = useState(true);
   const [error,    setError]    = useState('');
+  const [quotaOrg, setQuotaOrg] = useState<{ id: string; name: string } | null>(null);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -269,12 +280,220 @@ const AdminAIUsagePanel: React.FC<Props> = ({ adminToken }) => {
                     <p className="text-sm font-bold text-slate-800 dark:text-white tabular-nums">{fmt(org.calls)}</p>
                     <p className="text-xs text-slate-400">calls</p>
                   </div>
+                  <button
+                    onClick={() => setQuotaOrg({ id: org.org_id, name: org.name })}
+                    title="View and adjust this organization's AI quota"
+                    className="flex-shrink-0 inline-flex items-center gap-1.5 px-2.5 py-1.5 text-xs font-medium text-slate-500 dark:text-slate-400 hover:text-white hover:bg-esg-700 border border-slate-300 dark:border-slate-600 hover:border-esg-600 rounded-lg transition-all"
+                  >
+                    <Gauge className="w-3 h-3" /> Quota
+                  </button>
                 </div>
               ))}
             </div>
           )}
         </div>
 
+      </div>
+
+      {quotaOrg && (
+        <QuotaModal
+          adminToken={adminToken}
+          orgId={quotaOrg.id}
+          orgName={quotaOrg.name}
+          onClose={() => setQuotaOrg(null)}
+        />
+      )}
+    </div>
+  );
+};
+
+// ── Quota modal ───────────────────────────────────────────────────────────────
+// Raising a ceiling is the release valve for an interrupted customer, so this
+// deliberately shows where the org actually stands before offering the controls.
+const QuotaModal: React.FC<{
+  adminToken: string; orgId: string; orgName: string; onClose: () => void;
+}> = ({ adminToken, orgId, orgName, onClose }) => {
+  const [quota,   setQuota]   = useState<OrgQuota | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [busy,    setBusy]    = useState(false);
+  const [error,   setError]   = useState('');
+  const [notice,  setNotice]  = useState('');
+  const [grantCalls,  setGrantCalls]  = useState('');
+  const [grantReason, setGrantReason] = useState('');
+  const [override,    setOverride]    = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const data: OrgQuota = await callAdmin('org_ai_quota', adminToken, { organization_id: orgId });
+      setQuota(data);
+      setOverride(data.soft_quota_monthly === null ? '' : String(data.soft_quota_monthly));
+    } catch (err: any) {
+      setError(err?.message ?? 'Failed to load quota');
+    } finally {
+      setLoading(false);
+    }
+  }, [adminToken, orgId]);
+
+  useEffect(() => { load(); }, [load]);
+
+  const run = async (fn: () => Promise<void>, successText: string) => {
+    setBusy(true);
+    setError('');
+    setNotice('');
+    try {
+      await fn();
+      setNotice(successText);
+      await load();
+    } catch (err: any) {
+      setError(err?.message ?? 'Request failed');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleGrant = () => run(async () => {
+    await callAdmin('grant_ai_quota', adminToken, {
+      organization_id: orgId,
+      additional_calls: Number(grantCalls),
+      reason: grantReason,
+    });
+    setGrantCalls('');
+    setGrantReason('');
+  }, 'Grant added. It expires when the allowance resets.');
+
+  const handleOverride = () => run(async () => {
+    await callAdmin('set_ai_quota_override', adminToken, {
+      organization_id: orgId,
+      soft_quota_monthly: override.trim() === '' ? null : Number(override),
+    });
+  }, override.trim() === '' ? 'Override cleared — back to the tier default.' : 'Standing limit updated.');
+
+  const pct = quota && quota.effective_limit > 0
+    ? Math.min(100, Math.round((quota.used / quota.effective_limit) * 100))
+    : 0;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4" role="dialog" aria-modal="true">
+      <div className="w-full max-w-lg max-h-[90vh] overflow-y-auto bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-2xl shadow-xl">
+        <div className="flex items-center justify-between px-5 py-4 border-b border-slate-200 dark:border-slate-700">
+          <div>
+            <h3 className="font-bold text-slate-800 dark:text-white">AI quota</h3>
+            <p className="text-xs text-slate-500 dark:text-slate-400 truncate max-w-[300px]">{orgName}</p>
+          </div>
+          <button onClick={onClose} aria-label="Close" className="p-1.5 rounded-lg text-slate-400 hover:text-slate-700 dark:hover:text-white hover:bg-slate-100 dark:hover:bg-slate-700">
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        <div className="p-5 space-y-5">
+          {loading ? (
+            <div className="flex items-center gap-2 text-slate-500 dark:text-slate-400 text-sm py-6 justify-center">
+              <Loader2 className="w-4 h-4 animate-spin" /> Loading…
+            </div>
+          ) : quota && (
+            <>
+              {quota.use_byok && (
+                <p className="text-xs p-2.5 rounded-lg bg-blue-50 dark:bg-blue-900/20 text-blue-700 dark:text-blue-300 border border-blue-200 dark:border-blue-800">
+                  This organization uses its own API key. Platform quota does not apply to it.
+                </p>
+              )}
+
+              <div>
+                <div className="flex justify-between text-xs text-slate-600 dark:text-slate-400 mb-1.5">
+                  <span>{quota.used.toLocaleString()} used</span>
+                  <span>{quota.effective_limit.toLocaleString()} available</span>
+                </div>
+                <div className="h-2 bg-slate-100 dark:bg-slate-700 rounded-full overflow-hidden">
+                  <div className={`h-full rounded-full ${pct >= 100 ? 'bg-red-500' : pct >= 80 ? 'bg-amber-500' : 'bg-esg-500'}`} style={{ width: `${pct}%` }} />
+                </div>
+                <p className="text-xs text-slate-400 mt-1.5">
+                  {quota.base_limit.toLocaleString()} from the <span className="capitalize">{quota.tier}</span> plan
+                  {quota.granted_calls > 0 && ` + ${quota.granted_calls.toLocaleString()} granted`}
+                  {' · resets '}{new Date(quota.resets_at).toLocaleDateString()}
+                </p>
+              </div>
+
+              {quota.grants.length > 0 && (
+                <div className="space-y-1.5">
+                  <p className="text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wide">Active grants</p>
+                  {quota.grants.map(g => (
+                    <div key={g.id} className="flex items-start gap-2 text-xs p-2 rounded-lg bg-slate-50 dark:bg-slate-700/40">
+                      <span className={`px-1.5 py-0.5 rounded font-semibold flex-shrink-0 ${
+                        g.source === 'auto_burst'
+                          ? 'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300'
+                          : 'bg-esg-100 dark:bg-esg-900/40 text-esg-700 dark:text-esg-300'
+                      }`}>
+                        {g.source === 'auto_burst' ? 'auto' : 'admin'}
+                      </span>
+                      <span className="flex-1 text-slate-600 dark:text-slate-300">
+                        +{g.additional_calls.toLocaleString()} calls
+                        {g.reason && <span className="text-slate-400"> — {g.reason}</span>}
+                        {g.granted_by && <span className="text-slate-400"> ({g.granted_by})</span>}
+                      </span>
+                    </div>
+                  ))}
+                  {quota.grants.some(g => g.source === 'auto_burst') && (
+                    <p className="text-xs text-amber-600 dark:text-amber-400">
+                      An automatic top-up fired this month — this organization hit its ceiling. Consider a tier change or a standing limit.
+                    </p>
+                  )}
+                </div>
+              )}
+
+              <div className="pt-1 border-t border-slate-200 dark:border-slate-700 space-y-2">
+                <p className="text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wide pt-3">Grant extra calls</p>
+                <p className="text-xs text-slate-400">One-off top-up for this month only. Expires when the allowance resets.</p>
+                <div className="flex gap-2">
+                  <input
+                    type="number" min={1} value={grantCalls} placeholder="500"
+                    onChange={e => setGrantCalls(e.target.value)}
+                    className="w-28 px-3 py-2 text-sm rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-800 dark:text-white"
+                  />
+                  <input
+                    type="text" value={grantReason} placeholder="Reason (recorded)" maxLength={200}
+                    onChange={e => setGrantReason(e.target.value)}
+                    className="flex-1 px-3 py-2 text-sm rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-800 dark:text-white"
+                  />
+                  <button
+                    onClick={handleGrant}
+                    disabled={busy || !grantCalls || Number(grantCalls) < 1}
+                    className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg bg-esg-600 hover:bg-esg-700 text-white disabled:opacity-50 disabled:cursor-not-allowed"
+                  >
+                    <Plus className="w-3.5 h-3.5" /> Grant
+                  </button>
+                </div>
+              </div>
+
+              <div className="pt-1 border-t border-slate-200 dark:border-slate-700 space-y-2">
+                <p className="text-xs font-semibold text-slate-600 dark:text-slate-300 uppercase tracking-wide pt-3">Standing monthly limit</p>
+                <p className="text-xs text-slate-400">Replaces the tier default every month. Leave blank to use the plan default; 0 suspends platform AI.</p>
+                <div className="flex gap-2">
+                  <input
+                    type="number" min={0} value={override} placeholder={`${quota.base_limit} (tier default)`}
+                    onChange={e => setOverride(e.target.value)}
+                    className="flex-1 px-3 py-2 text-sm rounded-lg border border-slate-300 dark:border-slate-600 bg-white dark:bg-slate-900 text-slate-800 dark:text-white"
+                  />
+                  <button
+                    onClick={handleOverride}
+                    disabled={busy}
+                    className="px-3 py-2 text-sm font-medium rounded-lg border border-slate-300 dark:border-slate-600 text-slate-700 dark:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-700 disabled:opacity-50"
+                  >
+                    Save
+                  </button>
+                </div>
+              </div>
+            </>
+          )}
+
+          {error && (
+            <p className="text-xs p-2.5 rounded-lg bg-red-50 dark:bg-red-900/20 text-red-700 dark:text-red-300 border border-red-200 dark:border-red-800">{error}</p>
+          )}
+          {notice && (
+            <p className="text-xs p-2.5 rounded-lg bg-esg-50 dark:bg-esg-900/20 text-esg-700 dark:text-esg-300 border border-esg-200 dark:border-esg-800">{notice}</p>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/components/admin/CompanyListPanel.tsx
+++ b/components/admin/CompanyListPanel.tsx
@@ -46,12 +46,6 @@ const TIER_STYLES: Record<string, string> = {
   pro:        'bg-violet-900/60 text-violet-300 border border-violet-700/50',
   enterprise: 'bg-amber-900/60 text-amber-300 border border-amber-700/50',
 };
-const TierBadge: React.FC<{ tier: string }> = ({ tier }) => (
-  <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-semibold capitalize ${TIER_STYLES[tier] ?? TIER_STYLES.free}`}>
-    {tier}
-  </span>
-);
-
 // ── Sort header cell ──────────────────────────────────────────────────────────
 const SortTh: React.FC<{
   label: string; col: SortKey; sort: SortKey; dir: SortDir;
@@ -207,6 +201,7 @@ const CompanyListPanel: React.FC<Props> = ({ adminToken }) => {
   const [sort,         setSort]         = useState<SortKey>('created_at');
   const [dir,          setDir]          = useState<SortDir>('desc');
   const [toggling,     setToggling]     = useState<string | null>(null);
+  const [tierSaving,   setTierSaving]   = useState<string | null>(null);
   const [actionMsg,    setActionMsg]    = useState<{ type: 'success' | 'error'; text: string } | null>(null);
   const [createModal,  setCreateModal]  = useState<{ open: boolean; prefillEmail: string }>({ open: false, prefillEmail: '' });
   const [exportModal,  setExportModal]  = useState<{ open: boolean; id: string; name: string }>({ open: false, id: '', name: '' });
@@ -240,6 +235,26 @@ const CompanyListPanel: React.FC<Props> = ({ adminToken }) => {
       setActionMsg({ type: 'error', text: err?.message ?? 'Failed to update status' });
     } finally {
       setToggling(null);
+    }
+  };
+
+  const handleTierChange = async (company: Company, tier: string) => {
+    if (tier === company.tier) return;
+    if (!window.confirm(
+      `Move "${company.name}" from ${company.tier} to ${tier}?\n\n`
+      + `This changes the organization's monthly AI allowance and evidence storage quota immediately.`
+    )) return;
+
+    setTierSaving(company.id);
+    setActionMsg(null);
+    try {
+      await callAdmin('set_company_tier', adminToken, { id: company.id, tier });
+      setActionMsg({ type: 'success', text: `"${company.name}" moved to ${tier}.` });
+      await load();
+    } catch (err: any) {
+      setActionMsg({ type: 'error', text: err?.message ?? 'Failed to update tier' });
+    } finally {
+      setTierSaving(null);
     }
   };
 
@@ -442,7 +457,20 @@ const CompanyListPanel: React.FC<Props> = ({ adminToken }) => {
                               </span>
                             </button>
                           </td>
-                          <td className="px-4 py-3.5 hidden md:table-cell"><TierBadge tier={company.tier} /></td>
+                          <td className="px-4 py-3.5 hidden md:table-cell">
+                            <select
+                              value={company.tier}
+                              disabled={tierSaving === company.id}
+                              onChange={e => handleTierChange(company, e.target.value)}
+                              aria-label={`Tier for ${company.name}`}
+                              title="Change tier — adjusts AI and storage entitlements"
+                              className={`px-2 py-0.5 rounded-full text-xs font-semibold capitalize border-0 cursor-pointer disabled:opacity-50 disabled:cursor-wait focus:ring-2 focus:ring-esg-500 ${TIER_STYLES[company.tier] ?? TIER_STYLES.free}`}
+                            >
+                              {TIERS.map(t => (
+                                <option key={t} value={t} className="capitalize bg-white dark:bg-slate-800 text-slate-800 dark:text-white">{t}</option>
+                              ))}
+                            </select>
+                          </td>
                           <td className="px-4 py-3.5 text-slate-500 dark:text-slate-400 hidden sm:table-cell">{company.member_count}</td>
                           <td className="px-4 py-3.5 text-slate-500 dark:text-slate-400 hidden lg:table-cell whitespace-nowrap">{formatDate(company.created_at)}</td>
                           <td className="px-4 py-3.5 text-center">

--- a/netlify/functions/_shared/aiQuota.js
+++ b/netlify/functions/_shared/aiQuota.js
@@ -44,6 +44,14 @@ export function resolveMonthlyCallLimit(tier, softQuotaMonthly) {
 }
 
 /**
+ * Share of the base allowance granted automatically the first time an
+ * organization crosses its ceiling in a month, so nobody is hard-stopped
+ * before a human has had a chance to look. Bounds worst-case spend at
+ * 125% of plan rather than leaving it open-ended.
+ */
+export const AUTO_BURST_RATIO = 0.25;
+
+/**
  * First instant of the current calendar month, in UTC.
  *
  * @param {Date} [now]
@@ -51,6 +59,96 @@ export function resolveMonthlyCallLimit(tier, softQuotaMonthly) {
  */
 export function monthStartIso(now = new Date()) {
   return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString();
+}
+
+/**
+ * First instant of the next calendar month, in UTC — when the allowance
+ * resets, and therefore when a grant for this month stops counting.
+ *
+ * @param {Date} [now]
+ * @returns {string}
+ */
+export function monthEndIso(now = new Date()) {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() + 1, 1)).toISOString();
+}
+
+/**
+ * `period_month` value for the current UTC month (YYYY-MM-DD).
+ *
+ * @param {Date} [now]
+ * @returns {string}
+ */
+export function periodMonth(now = new Date()) {
+  return monthStartIso(now).slice(0, 10);
+}
+
+/**
+ * Total calls added by grants that have not expired.
+ *
+ * Returns 0 on error: a grant is extra capacity, so failing to read one costs
+ * a customer headroom rather than handing out spend that was never authorized.
+ *
+ * @param {any} admin Supabase service-role client
+ * @param {string} organizationId
+ * @param {Date} [now]
+ * @returns {Promise<number>}
+ */
+export async function loadActiveGrantTotal(admin, organizationId, now = new Date()) {
+  const { data, error } = await admin
+    .from("ai_quota_grants")
+    .select("additional_calls")
+    .eq("organization_id", organizationId)
+    .gt("expires_at", now.toISOString());
+
+  if (error) {
+    console.warn(`[quota] grant lookup failed org=${organizationId} — ignoring grants`);
+    return 0;
+  }
+
+  return (data ?? []).reduce(
+    (total, row) => total + (Number(row?.additional_calls) || 0),
+    0,
+  );
+}
+
+/**
+ * Grant the one automatic burst this organization is allowed this month.
+ *
+ * Uniqueness is enforced by the partial index in migration 027, not here: a
+ * duplicate insert loses the race and returns null, which is the correct
+ * answer for a second concurrent request.
+ *
+ * @param {any} admin Supabase service-role client
+ * @param {string} organizationId
+ * @param {number} baseLimit
+ * @param {Date} [now]
+ * @returns {Promise<number>} calls granted, or 0 when none was
+ */
+export async function grantAutoBurst(admin, organizationId, baseLimit, now = new Date()) {
+  const additionalCalls = Math.max(1, Math.ceil(baseLimit * AUTO_BURST_RATIO));
+
+  const { error } = await admin.from("ai_quota_grants").insert({
+    organization_id: organizationId,
+    additional_calls: additionalCalls,
+    source: "auto_burst",
+    reason: "Automatic one-off top-up on first monthly ceiling breach",
+    period_month: periodMonth(now),
+    expires_at: monthEndIso(now),
+  });
+
+  if (error) {
+    // 23505 = the org already used this month's burst. Anything else is a real
+    // failure; either way the caller falls through to the refusal path.
+    if (error.code !== "23505") {
+      console.error(`[quota] auto-burst insert failed org=${organizationId}`);
+    }
+    return 0;
+  }
+
+  console.warn(
+    `[quota] auto-burst granted org=${organizationId} calls=${additionalCalls} base=${baseLimit}`,
+  );
+  return additionalCalls;
 }
 
 /**
@@ -72,26 +170,71 @@ export async function checkMonthlyAiQuota(
   organizationId,
   tier,
   softQuotaMonthly,
-  now,
+  now = new Date(),
 ) {
-  const limit = resolveMonthlyCallLimit(tier, softQuotaMonthly);
+  const baseLimit = resolveMonthlyCallLimit(tier, softQuotaMonthly);
 
-  const { count, error } = await admin
-    .from("ai_usage_log")
-    .select("id", { count: "exact", head: true })
-    .eq("organization_id", organizationId)
-    .eq("success", true)
-    .gte("created_at", monthStartIso(now));
+  const [{ count, error }, grantedCalls] = await Promise.all([
+    admin
+      .from("ai_usage_log")
+      .select("id", { count: "exact", head: true })
+      .eq("organization_id", organizationId)
+      .eq("success", true)
+      .gte("created_at", monthStartIso(now)),
+    loadActiveGrantTotal(admin, organizationId, now),
+  ]);
+
+  const limit = baseLimit + grantedCalls;
 
   if (error) {
     console.warn(
       `[quota] usage lookup failed org=${organizationId} — allowing call`,
     );
-    return { allowed: true, used: null, limit, degraded: true };
+    return { allowed: true, used: null, limit, baseLimit, grantedCalls, degraded: true };
   }
 
   const used = count ?? 0;
-  return { allowed: used < limit, used, limit, degraded: false };
+  return {
+    allowed: used < limit,
+    used,
+    limit,
+    baseLimit,
+    grantedCalls,
+    degraded: false,
+  };
+}
+
+/**
+ * Full gate for one platform AI call: check the ceiling, and if it is spent,
+ * try this month's automatic burst before refusing.
+ *
+ * @param {any} admin Supabase service-role client
+ * @param {string} organizationId
+ * @param {unknown} tier
+ * @param {unknown} softQuotaMonthly
+ * @param {Date} [now]
+ */
+export async function authorizeAiCall(
+  admin,
+  organizationId,
+  tier,
+  softQuotaMonthly,
+  now = new Date(),
+) {
+  const quota = await checkMonthlyAiQuota(admin, organizationId, tier, softQuotaMonthly, now);
+  if (quota.allowed) return quota;
+
+  const burst = await grantAutoBurst(admin, organizationId, quota.baseLimit, now);
+  if (burst === 0) return quota;
+
+  const limit = quota.limit + burst;
+  return {
+    ...quota,
+    allowed: quota.used === null || quota.used < limit,
+    limit,
+    grantedCalls: quota.grantedCalls + burst,
+    autoBurstGranted: burst,
+  };
 }
 
 /**

--- a/netlify/functions/_shared/aiQuota.js
+++ b/netlify/functions/_shared/aiQuota.js
@@ -1,0 +1,110 @@
+// @ts-check
+
+import { normalizeOrganizationTier } from "./organizationTier.js";
+
+/**
+ * Monthly platform AI call ceilings, by organization tier.
+ *
+ * These are the allowances the platform pays for. A tenant using its own key
+ * (BYOK) is billed by the provider directly and is never counted here.
+ * A per-organization override lives in
+ * `organization_ai_settings.soft_quota_monthly`.
+ */
+export const MONTHLY_AI_CALL_LIMITS = {
+  free: 100,
+  starter: 500,
+  pro: 2_000,
+  enterprise: 10_000,
+};
+
+/**
+ * `ai_usage_log.quota_type` value for a platform-funded call.
+ *
+ * @param {unknown} tier
+ * @returns {string}
+ */
+export function platformQuotaType(tier) {
+  return `platform_${normalizeOrganizationTier(tier)}`;
+}
+
+/**
+ * The enforced ceiling for an organization. An explicit non-negative override
+ * always wins, including 0, which suspends platform AI for that tenant.
+ *
+ * @param {unknown} tier
+ * @param {unknown} softQuotaMonthly
+ * @returns {number}
+ */
+export function resolveMonthlyCallLimit(tier, softQuotaMonthly) {
+  if (Number.isInteger(softQuotaMonthly) && Number(softQuotaMonthly) >= 0) {
+    return Number(softQuotaMonthly);
+  }
+  return MONTHLY_AI_CALL_LIMITS[normalizeOrganizationTier(tier)]
+    ?? MONTHLY_AI_CALL_LIMITS.free;
+}
+
+/**
+ * First instant of the current calendar month, in UTC.
+ *
+ * @param {Date} [now]
+ * @returns {string}
+ */
+export function monthStartIso(now = new Date()) {
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1)).toISOString();
+}
+
+/**
+ * Decide whether an organization may make another platform AI call this month.
+ *
+ * If the usage lookup itself fails the call is allowed: that path is a
+ * service-role read of our own telemetry, a tenant cannot induce it, and
+ * taking every AI feature offline during a database incident is worse than
+ * briefly over-serving. The `degraded` flag records that it happened.
+ *
+ * @param {any} admin Supabase service-role client
+ * @param {string} organizationId
+ * @param {unknown} tier
+ * @param {unknown} softQuotaMonthly
+ * @param {Date} [now]
+ */
+export async function checkMonthlyAiQuota(
+  admin,
+  organizationId,
+  tier,
+  softQuotaMonthly,
+  now,
+) {
+  const limit = resolveMonthlyCallLimit(tier, softQuotaMonthly);
+
+  const { count, error } = await admin
+    .from("ai_usage_log")
+    .select("id", { count: "exact", head: true })
+    .eq("organization_id", organizationId)
+    .eq("success", true)
+    .gte("created_at", monthStartIso(now));
+
+  if (error) {
+    console.warn(
+      `[quota] usage lookup failed org=${organizationId} — allowing call`,
+    );
+    return { allowed: true, used: null, limit, degraded: true };
+  }
+
+  const used = count ?? 0;
+  return { allowed: used < limit, used, limit, degraded: false };
+}
+
+/**
+ * User-facing 429 body. Deliberately free of tenant data.
+ *
+ * @param {{ used: number | null, limit: number }} quota
+ */
+export function quotaExceededResponse(quota) {
+  return {
+    error:
+      `This organization has used its ${quota.limit} AI requests for this month. `
+      + `The allowance resets on the 1st. An Owner or Admin can add the organization's `
+      + `own API key under Settings to continue immediately.`,
+    quota: { used: quota.used, limit: quota.limit },
+  };
+}

--- a/netlify/functions/_shared/byokSecurity.js
+++ b/netlify/functions/_shared/byokSecurity.js
@@ -11,13 +11,23 @@ export function canManageByok(role) {
   return role === "Owner" || role === "Admin";
 }
 
-export function toSafeByokMetadata(settings, hasSecret) {
+/**
+ * @param {any} settings
+ * @param {boolean} hasSecret
+ * @param {{ tier?: string, monthlyCallLimit?: number | null }} [quota]
+ *   Effective ceiling resolved server-side. The browser must not recompute it:
+ *   the limit depends on the org tier and any active grants, neither of which
+ *   the client can be trusted to combine correctly.
+ */
+export function toSafeByokMetadata(settings, hasSecret, quota) {
   return {
     model: settings?.model ?? "gemini-2.5-flash",
     use_byok: settings?.use_byok === true,
     byok_provider: settings?.byok_provider ?? null,
     has_byok_key: Boolean(hasSecret),
     soft_quota_monthly: settings?.soft_quota_monthly ?? null,
+    tier: quota?.tier ?? "free",
+    monthly_call_limit: quota?.monthlyCallLimit ?? null,
   };
 }
 

--- a/netlify/functions/_shared/organizationTier.js
+++ b/netlify/functions/_shared/organizationTier.js
@@ -1,0 +1,54 @@
+// @ts-check
+
+/**
+ * Organization billing/access tier resolution.
+ *
+ * The canonical column is `organizations.tier` (migration 015). It is the only
+ * place a tier is stored — there is no `subscription_tier` column — so every
+ * server-side entitlement check must read it through this helper.
+ */
+
+/** Tier identifiers accepted by the `organizations.tier` CHECK constraint. */
+export const ORGANIZATION_TIERS = /** @type {const} */ ([
+  "free",
+  "starter",
+  "pro",
+  "enterprise",
+]);
+
+export const DEFAULT_ORGANIZATION_TIER = "free";
+
+/**
+ * Resolve an organization's tier. Fails closed to `free` when the row is
+ * missing, the value is unrecognized, or the lookup errors, so a database
+ * problem can never hand out paid capacity.
+ *
+ * @param {any} admin Supabase service-role client
+ * @param {string} organizationId
+ * @returns {Promise<string>}
+ */
+export async function loadOrganizationTier(admin, organizationId) {
+  const { data, error } = await admin
+    .from("organizations")
+    .select("tier")
+    .eq("id", organizationId)
+    .maybeSingle();
+
+  if (error) {
+    console.error(`[tier] lookup failed org=${organizationId}`);
+    return DEFAULT_ORGANIZATION_TIER;
+  }
+
+  return normalizeOrganizationTier(data?.tier);
+}
+
+/**
+ * @param {unknown} tier
+ * @returns {string}
+ */
+export function normalizeOrganizationTier(tier) {
+  return typeof tier === "string" &&
+    /** @type {readonly string[]} */ (ORGANIZATION_TIERS).includes(tier)
+    ? tier
+    : DEFAULT_ORGANIZATION_TIER;
+}

--- a/netlify/functions/admin.ts
+++ b/netlify/functions/admin.ts
@@ -24,7 +24,14 @@
 import type { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
 import crypto from 'crypto';
-import { ORGANIZATION_TIERS } from './_shared/organizationTier.js';
+import { ORGANIZATION_TIERS, loadOrganizationTier } from './_shared/organizationTier.js';
+import {
+  loadActiveGrantTotal,
+  monthEndIso,
+  monthStartIso,
+  periodMonth,
+  resolveMonthlyCallLimit,
+} from './_shared/aiQuota.js';
 
 // ---------------------------------------------------------------------------
 // Config
@@ -773,7 +780,7 @@ async function handleListCompanies(): Promise<object> {
 }
 
 // ---------------------------------------------------------------------------
-// Post-auth: set_company_status
+// Post-auth: set_company_tier
 // ---------------------------------------------------------------------------
 async function handleSetCompanyTier(body: any, actorEmail: string): Promise<object> {
   const id   = (body.id   ?? '').trim();
@@ -790,6 +797,107 @@ async function handleSetCompanyTier(body: any, actorEmail: string): Promise<obje
   // Tier changes move AI and storage entitlements, so record who made the call.
   console.info('[admin] set_company_tier:', id, '->', tier, 'by', actorEmail);
   return { updated: true, id, tier };
+}
+
+// ---------------------------------------------------------------------------
+// Post-auth: org_ai_quota — where an organization stands this month
+// ---------------------------------------------------------------------------
+async function handleOrgAiQuota(body: any): Promise<object> {
+  const orgId = (body.organization_id ?? '').trim();
+  if (!orgId) throw Object.assign(new Error('organization_id is required'), { status: 400 });
+
+  const sb  = getAdminClient();
+  const now = new Date();
+
+  const [tier, settingsRes, usageRes, grantsRes] = await Promise.all([
+    loadOrganizationTier(sb, orgId),
+    sb.from('organization_ai_settings')
+      .select('soft_quota_monthly, use_byok')
+      .eq('organization_id', orgId).maybeSingle(),
+    sb.from('ai_usage_log')
+      .select('id', { count: 'exact', head: true })
+      .eq('organization_id', orgId).eq('success', true)
+      .gte('created_at', monthStartIso(now)),
+    sb.from('ai_quota_grants')
+      .select('id, additional_calls, source, reason, granted_by, expires_at, created_at')
+      .eq('organization_id', orgId)
+      .gt('expires_at', now.toISOString())
+      .order('created_at', { ascending: false }),
+  ]);
+
+  const softQuotaMonthly = settingsRes.data?.soft_quota_monthly ?? null;
+  const baseLimit        = resolveMonthlyCallLimit(tier, softQuotaMonthly);
+  const grantedCalls     = await loadActiveGrantTotal(sb, orgId, now);
+
+  return {
+    organization_id:    orgId,
+    tier,
+    use_byok:           settingsRes.data?.use_byok === true,
+    soft_quota_monthly: softQuotaMonthly,
+    base_limit:         baseLimit,
+    granted_calls:      grantedCalls,
+    effective_limit:    baseLimit + grantedCalls,
+    used:               usageRes.count ?? 0,
+    resets_at:          monthEndIso(now),
+    grants:             grantsRes.data ?? [],
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Post-auth: grant_ai_quota — ad-hoc top-up, expires at month end
+// ---------------------------------------------------------------------------
+async function handleGrantAiQuota(body: any, actorEmail: string): Promise<object> {
+  const orgId  = (body.organization_id ?? '').trim();
+  const calls  = Number(body.additional_calls);
+  const reason = typeof body.reason === 'string' ? body.reason.trim().slice(0, 500) : null;
+
+  if (!orgId) throw Object.assign(new Error('organization_id is required'), { status: 400 });
+  if (!Number.isInteger(calls) || calls < 1 || calls > 1_000_000) {
+    throw Object.assign(new Error('additional_calls must be a whole number between 1 and 1,000,000'), { status: 400 });
+  }
+
+  const sb  = getAdminClient();
+  const now = new Date();
+
+  const { data, error } = await sb.from('ai_quota_grants').insert({
+    organization_id:  orgId,
+    additional_calls: calls,
+    source:           'admin',
+    reason:           reason || null,
+    granted_by:       actorEmail,
+    period_month:     periodMonth(now),
+    expires_at:       monthEndIso(now),
+  }).select('id, additional_calls, expires_at').single();
+
+  if (error) throw Object.assign(new Error(error.message), { status: 500 });
+
+  console.info('[admin] grant_ai_quota:', orgId, '+', calls, 'by', actorEmail);
+  return { granted: true, ...data };
+}
+
+// ---------------------------------------------------------------------------
+// Post-auth: set_ai_quota_override — standing per-org ceiling
+// ---------------------------------------------------------------------------
+async function handleSetAiQuotaOverride(body: any, actorEmail: string): Promise<object> {
+  const orgId = (body.organization_id ?? '').trim();
+  if (!orgId) throw Object.assign(new Error('organization_id is required'), { status: 400 });
+
+  const raw = body.soft_quota_monthly;
+  // null clears the override and returns the org to its tier default.
+  const override = raw === null || raw === '' ? null : Number(raw);
+  if (override !== null && (!Number.isInteger(override) || override < 0 || override > 1_000_000)) {
+    throw Object.assign(new Error('soft_quota_monthly must be null or a whole number between 0 and 1,000,000'), { status: 400 });
+  }
+
+  const sb = getAdminClient();
+  const { error } = await sb.from('organization_ai_settings').upsert(
+    { organization_id: orgId, soft_quota_monthly: override },
+    { onConflict: 'organization_id' },
+  );
+  if (error) throw Object.assign(new Error(error.message), { status: 500 });
+
+  console.info('[admin] set_ai_quota_override:', orgId, '->', override, 'by', actorEmail);
+  return { updated: true, organization_id: orgId, soft_quota_monthly: override };
 }
 
 // ---------------------------------------------------------------------------
@@ -1141,6 +1249,9 @@ export const handler: Handler = async (event) => {
         case 'list_companies':          result = await handleListCompanies();                   break;
         case 'set_company_status':      result = await handleSetCompanyStatus(body);            break;
         case 'set_company_tier':        result = await handleSetCompanyTier(body, actorEmail);  break;
+        case 'org_ai_quota':            result = await handleOrgAiQuota(body);                  break;
+        case 'grant_ai_quota':          result = await handleGrantAiQuota(body, actorEmail);    break;
+        case 'set_ai_quota_override':   result = await handleSetAiQuotaOverride(body, actorEmail); break;
         case 'list_pending_users':      result = await handleListPendingUsers();                break;
         case 'assign_user_to_company':  result = await handleAssignUserToCompany(body);         break;
         case 'list_admins':        result = await handleListAdmins();                            break;

--- a/netlify/functions/admin.ts
+++ b/netlify/functions/admin.ts
@@ -24,6 +24,7 @@
 import type { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
 import crypto from 'crypto';
+import { ORGANIZATION_TIERS } from './_shared/organizationTier.js';
 
 // ---------------------------------------------------------------------------
 // Config
@@ -774,6 +775,26 @@ async function handleListCompanies(): Promise<object> {
 // ---------------------------------------------------------------------------
 // Post-auth: set_company_status
 // ---------------------------------------------------------------------------
+async function handleSetCompanyTier(body: any, actorEmail: string): Promise<object> {
+  const id   = (body.id   ?? '').trim();
+  const tier = (body.tier ?? '').trim();
+  if (!id)   throw Object.assign(new Error('id is required'), { status: 400 });
+  if (!(ORGANIZATION_TIERS as readonly string[]).includes(tier)) {
+    throw Object.assign(new Error('Invalid tier'), { status: 400 });
+  }
+
+  const sb = getAdminClient();
+  const { error } = await sb.from('organizations').update({ tier }).eq('id', id);
+  if (error) throw Object.assign(new Error(error.message), { status: 500 });
+
+  // Tier changes move AI and storage entitlements, so record who made the call.
+  console.info('[admin] set_company_tier:', id, '->', tier, 'by', actorEmail);
+  return { updated: true, id, tier };
+}
+
+// ---------------------------------------------------------------------------
+// Post-auth: set_company_status
+// ---------------------------------------------------------------------------
 async function handleSetCompanyStatus(body: any): Promise<object> {
   const id        = (body.id        ?? '').trim();
   const is_active = body.is_active;
@@ -1119,6 +1140,7 @@ export const handler: Handler = async (event) => {
         case 'create_company':          result = await handleCreateCompany(body);              break;
         case 'list_companies':          result = await handleListCompanies();                   break;
         case 'set_company_status':      result = await handleSetCompanyStatus(body);            break;
+        case 'set_company_tier':        result = await handleSetCompanyTier(body, actorEmail);  break;
         case 'list_pending_users':      result = await handleListPendingUsers();                break;
         case 'assign_user_to_company':  result = await handleAssignUserToCompany(body);         break;
         case 'list_admins':        result = await handleListAdmins();                            break;

--- a/netlify/functions/ally-support.ts
+++ b/netlify/functions/ally-support.ts
@@ -9,6 +9,12 @@ import {
 } from "./_shared/allySupportSecurity.js";
 import { withAIRequestFence } from "./_shared/aiRequestFence.js";
 import { loadOrganizationAiConfig } from "./_shared/organizationAiConfig.js";
+import { loadOrganizationTier } from "./_shared/organizationTier.js";
+import {
+  checkMonthlyAiQuota,
+  platformQuotaType,
+  quotaExceededResponse,
+} from "./_shared/aiQuota.js";
 
 const DEFAULT_MODEL = "gemini-2.5-flash";
 
@@ -164,6 +170,28 @@ export function createAllySupportHandler(
       return json(503, { error: "Ally's AI settings are temporarily unavailable." });
     }
 
+    // Ally draws on the same monthly platform allowance as the rest of the app,
+    // so a long support conversation cannot bypass the tenant's ceiling.
+    let quotaType = aiConfig.quotaType;
+    if (!aiConfig.useBYOK) {
+      const tier = await loadOrganizationTier(admin, organization_id);
+      quotaType = platformQuotaType(tier);
+
+      const quota = await checkMonthlyAiQuota(
+        admin,
+        organization_id,
+        tier,
+        aiConfig.softQuotaMonthly,
+      );
+
+      if (!quota.allowed) {
+        console.warn(
+          `[quota] ally org=${organization_id} tier=${tier} used=${quota.used}/${quota.limit} — request blocked`,
+        );
+        return json(429, quotaExceededResponse(quota));
+      }
+    }
+
     const company = await getCompanyName(admin, organization_id);
     const userInfo = {
       email: user.email ?? null,
@@ -274,7 +302,7 @@ export function createAllySupportHandler(
         output_tokens: outputTokens,
         duration_ms: Date.now() - start,
         success: true,
-        quota_type: aiConfig.quotaType,
+        quota_type: quotaType,
       });
     } catch {
       console.error("[ally-support] Failed to log usage.");

--- a/netlify/functions/ally-support.ts
+++ b/netlify/functions/ally-support.ts
@@ -11,7 +11,7 @@ import { withAIRequestFence } from "./_shared/aiRequestFence.js";
 import { loadOrganizationAiConfig } from "./_shared/organizationAiConfig.js";
 import { loadOrganizationTier } from "./_shared/organizationTier.js";
 import {
-  checkMonthlyAiQuota,
+  authorizeAiCall,
   platformQuotaType,
   quotaExceededResponse,
 } from "./_shared/aiQuota.js";
@@ -177,7 +177,7 @@ export function createAllySupportHandler(
       const tier = await loadOrganizationTier(admin, organization_id);
       quotaType = platformQuotaType(tier);
 
-      const quota = await checkMonthlyAiQuota(
+      const quota = await authorizeAiCall(
         admin,
         organization_id,
         tier,

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -6,6 +6,12 @@ import {
 } from "./_shared/internalJobAuth.js";
 import { withAIRequestFence } from "./_shared/aiRequestFence.js";
 import { loadOrganizationAiConfig } from "./_shared/organizationAiConfig.js";
+import { loadOrganizationTier } from "./_shared/organizationTier.js";
+import {
+  checkMonthlyAiQuota,
+  platformQuotaType,
+  quotaExceededResponse,
+} from "./_shared/aiQuota.js";
 
 const apiKey = process.env.GEMINI_API_KEY;
 const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
@@ -129,28 +135,28 @@ const handler = async (event: any) => {
   } = aiConfig;
 
   // ------------------------------------------------------------------
-  // 4a. Soft quota check (platform calls only, BYOK bypasses)
+  // 4a. Monthly AI quota (platform calls only; BYOK bills the tenant)
   // ------------------------------------------------------------------
+  // The ceiling is the org's `soft_quota_monthly` override when set, otherwise
+  // the tier default. Exceeding it returns 429 before any provider call, so
+  // platform AI spend has an upper bound per tenant per month.
+  let effectiveQuotaType = quotaType;
   if (!useBYOK) {
-    const PLATFORM_SOFT_LIMIT = softQuotaMonthly ?? 100;
-    const monthStart = new Date();
-    monthStart.setDate(1);
-    monthStart.setHours(0, 0, 0, 0);
+    const tier = await loadOrganizationTier(admin, organization_id);
+    effectiveQuotaType = platformQuotaType(tier);
 
-    const { count: monthlyCount } = await admin
-      .from("ai_usage_log")
-      .select("id", { count: "exact", head: true })
-      .eq("organization_id", organization_id)
-      .eq("success", true)
-      .gte("created_at", monthStart.toISOString());
+    const quota = await checkMonthlyAiQuota(
+      admin,
+      organization_id,
+      tier,
+      softQuotaMonthly,
+    );
 
-    const callsUsed = monthlyCount ?? 0;
-
-    // Soft limit: log a warning but do NOT block. Admins can raise via soft_quota_monthly.
-    if (callsUsed >= PLATFORM_SOFT_LIMIT) {
+    if (!quota.allowed) {
       console.warn(
-        `[quota] org=${organization_id} used=${callsUsed}/${PLATFORM_SOFT_LIMIT} — soft limit reached (proceeding anyway)`
+        `[quota] org=${organization_id} tier=${tier} used=${quota.used}/${quota.limit} — request blocked`,
       );
+      return json(429, quotaExceededResponse(quota));
     }
   }
 
@@ -225,7 +231,7 @@ const handler = async (event: any) => {
         error_message: success ? null : errorMessage,
         http_status: success ? null : upstreamStatus,
         estimated_cost_usd: success ? Number(estimateCost(model, inputTokens, outputTokens).toFixed(6)) : 0,
-        quota_type: quotaType,
+        quota_type: effectiveQuotaType,
       });
     }
   } catch (logErr) {

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -8,7 +8,7 @@ import { withAIRequestFence } from "./_shared/aiRequestFence.js";
 import { loadOrganizationAiConfig } from "./_shared/organizationAiConfig.js";
 import { loadOrganizationTier } from "./_shared/organizationTier.js";
 import {
-  checkMonthlyAiQuota,
+  authorizeAiCall,
   platformQuotaType,
   quotaExceededResponse,
 } from "./_shared/aiQuota.js";
@@ -145,7 +145,9 @@ const handler = async (event: any) => {
     const tier = await loadOrganizationTier(admin, organization_id);
     effectiveQuotaType = platformQuotaType(tier);
 
-    const quota = await checkMonthlyAiQuota(
+    // Refusing is the last resort: this also spends the org's one automatic
+    // burst for the month before giving up.
+    const quota = await authorizeAiCall(
       admin,
       organization_id,
       tier,

--- a/netlify/functions/byok-settings.ts
+++ b/netlify/functions/byok-settings.ts
@@ -5,6 +5,8 @@ import {
   normalizeByokUpdate,
   toSafeByokMetadata,
 } from "./_shared/byokSecurity.js";
+import { loadOrganizationTier } from "./_shared/organizationTier.js";
+import { resolveMonthlyCallLimit } from "./_shared/aiQuota.js";
 
 const json = (status: number, body: object) =>
   new Response(JSON.stringify(body), {
@@ -29,6 +31,8 @@ function getAdminClient() {
 }
 
 async function loadSafeMetadata(admin: any, organizationId: string) {
+  const tier = await loadOrganizationTier(admin, organizationId);
+
   const [{ data: settings, error: settingsError }, { data: secret, error: secretError }] =
     await Promise.all([
       admin
@@ -46,7 +50,11 @@ async function loadSafeMetadata(admin: any, organizationId: string) {
   if (settingsError || secretError) {
     throw new Error("Could not load BYOK metadata.");
   }
-  return toSafeByokMetadata(settings, Boolean(secret));
+
+  return toSafeByokMetadata(settings, Boolean(secret), {
+    tier,
+    monthlyCallLimit: resolveMonthlyCallLimit(tier, settings?.soft_quota_monthly),
+  });
 }
 
 async function handleByokSettings(

--- a/netlify/functions/evidence.ts
+++ b/netlify/functions/evidence.ts
@@ -12,21 +12,26 @@
  * Storage bucket: 'evidence-files'
  * Create it in Supabase dashboard → Storage → New bucket → evidence-files (private).
  *
- * Quota limits (MB):
+ * Quota limits (MB), keyed by `organizations.tier`:
  *   free       → 0 (link-only, no direct upload)
+ *   starter    → 1 024 (1 GB)
  *   pro        → 10 240 (10 GB)
  *   enterprise → 102 400 (100 GB)
  */
 
 import { createClient } from '@supabase/supabase-js';
+import { loadOrganizationTier } from './_shared/organizationTier.js';
 
 const SUPABASE_URL   = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL || '';
 const SERVICE_KEY    = process.env.SUPABASE_SERVICE_ROLE_KEY || '';
 const BUCKET         = 'evidence-files';
 const MAX_MB         = 25;
 
+// One entry per tier in the `organizations.tier` CHECK constraint. An unknown
+// tier resolves to 0 MB, which blocks upload rather than granting free storage.
 const QUOTA_MAP: Record<string, number> = {
   free:       0,
+  starter:    1_024,
   pro:        10_240,
   enterprise: 102_400,
 };
@@ -248,14 +253,9 @@ async function isMember(admin: any, orgId: string, userId: string): Promise<bool
 }
 
 async function getOrgTier(admin: any, orgId: string): Promise<string> {
-  // Placeholder — when subscription management is added, query it here.
-  // For now: all orgs are 'free' (link-only). Set to 'pro' to unlock uploads.
-  const { data } = await admin
-    .from('organizations')
-    .select('subscription_tier')
-    .eq('id', orgId)
-    .maybeSingle();
-  return (data?.subscription_tier as string | null) ?? 'free';
+  // Reads the canonical `organizations.tier` column (migration 015), which
+  // platform admins set from the admin console. Fails closed to 'free'.
+  return loadOrganizationTier(admin, orgId);
 }
 
 async function getStorageQuota(

--- a/services/dbService.ts
+++ b/services/dbService.ts
@@ -158,7 +158,12 @@ export interface AiSettings {
   byok_provider: string | null;
   /** API key is NEVER returned from the server for security. Only a boolean `has_byok_key` is exposed. */
   has_byok_key: boolean;
+  /** Standing per-org override, or null when the tier default applies. */
   soft_quota_monthly: number | null;
+  /** Billing/access tier this organization is on. */
+  tier: string;
+  /** Effective monthly platform AI call ceiling, resolved server-side. */
+  monthly_call_limit: number | null;
 }
 
 const BYOK_SETTINGS_ENDPOINT = "/.netlify/functions/byok-settings";

--- a/supabase/migrations/026_ai_quota_enforcement.sql
+++ b/supabase/migrations/026_ai_quota_enforcement.sql
@@ -1,0 +1,36 @@
+-- ============================================================
+-- Migration 026 — AI quota enforcement
+-- ============================================================
+-- The monthly platform AI allowance is now enforced (HTTP 429) rather than
+-- logged and ignored. Two supporting changes:
+--
+--   1. quota_type gains 'platform_starter'. Migration 015 introduced four
+--      tiers but the quota_type CHECK from 007 only covered three, so usage
+--      rows for a starter organization would have been rejected.
+--   2. soft_quota_monthly is documented as the enforced ceiling it now is.
+--      NULL still means "use the tier default".
+--
+-- Rollback:
+--   ALTER TABLE public.ai_usage_log DROP CONSTRAINT ai_usage_log_quota_type_check;
+--   ALTER TABLE public.ai_usage_log ADD CONSTRAINT ai_usage_log_quota_type_check
+--     CHECK (quota_type IN ('platform_free','platform_pro','platform_enterprise','byok'));
+-- ============================================================
+
+ALTER TABLE public.ai_usage_log
+  DROP CONSTRAINT IF EXISTS ai_usage_log_quota_type_check;
+
+ALTER TABLE public.ai_usage_log
+  ADD CONSTRAINT ai_usage_log_quota_type_check
+  CHECK (quota_type IN (
+    'platform_free',
+    'platform_starter',
+    'platform_pro',
+    'platform_enterprise',
+    'byok'
+  ));
+
+COMMENT ON COLUMN public.ai_usage_log.quota_type
+  IS 'Allowance the call drew from: platform_<organizations.tier> or byok';
+
+COMMENT ON COLUMN public.organization_ai_settings.soft_quota_monthly
+  IS 'Enforced monthly platform AI call ceiling for this organization. NULL = tier default from netlify/functions/_shared/aiQuota.js. 0 suspends platform AI.';

--- a/supabase/migrations/027_ai_quota_grants.sql
+++ b/supabase/migrations/027_ai_quota_grants.sql
@@ -1,0 +1,63 @@
+-- ============================================================
+-- Migration 027 — Ad-hoc AI quota grants
+-- ============================================================
+-- Migration 026 made the monthly allowance enforceable. This adds the release
+-- valve: a temporary top-up that expires, so raising a ceiling to unblock a
+-- customer today does not silently become their permanent plan.
+--
+--   organization_ai_settings.soft_quota_monthly  standing override (deliberate)
+--   ai_quota_grants                              temporary top-up (expires)
+--
+-- Effective ceiling = standing limit + sum(active grants).
+--
+-- `source = 'auto_burst'` marks the automatic one-off top-up granted the first
+-- time an organization crosses its ceiling in a month, so a customer is never
+-- hard-stopped before a human has had a chance to look. The partial unique
+-- index is what makes that "once per organization per month" — it is the
+-- concurrency guard, not application logic.
+--
+-- Service-role only: the browser never reads or writes grants. The effective
+-- ceiling reaches the tenant through byok-settings, already computed.
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS public.ai_quota_grants;
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS public.ai_quota_grants (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id   uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  additional_calls  int  NOT NULL CHECK (additional_calls > 0 AND additional_calls <= 1000000),
+  source            text NOT NULL DEFAULT 'admin' CHECK (source IN ('admin', 'auto_burst')),
+  reason            text CHECK (reason IS NULL OR length(reason) <= 500),
+  granted_by        text CHECK (granted_by IS NULL OR length(granted_by) <= 320),
+  -- First day of the UTC month the grant belongs to; drives the auto-burst
+  -- uniqueness guard below.
+  period_month      date NOT NULL,
+  expires_at        timestamptz NOT NULL,
+  created_at        timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_quota_grants_active
+  ON public.ai_quota_grants (organization_id, expires_at);
+
+-- At most one automatic burst per organization per month. A second concurrent
+-- request loses this race with a unique violation and is refused, which is the
+-- intended outcome.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_quota_grants_one_auto_burst
+  ON public.ai_quota_grants (organization_id, period_month)
+  WHERE source = 'auto_burst';
+
+ALTER TABLE public.ai_quota_grants ENABLE ROW LEVEL SECURITY;
+
+-- No policies: RLS with zero policies denies every browser role. Grants are
+-- written and read only by service-role functions.
+REVOKE ALL ON public.ai_quota_grants FROM PUBLIC;
+REVOKE ALL ON public.ai_quota_grants FROM anon;
+REVOKE ALL ON public.ai_quota_grants FROM authenticated;
+
+COMMENT ON TABLE public.ai_quota_grants
+  IS 'Temporary additions to an organization monthly AI allowance. Expiring, audited, service-role only.';
+COMMENT ON COLUMN public.ai_quota_grants.source
+  IS 'admin = granted by a platform admin; auto_burst = automatic one-off top-up on first breach in a month';
+COMMENT ON COLUMN public.ai_quota_grants.period_month
+  IS 'First day of the UTC month this grant belongs to; enforces one auto_burst per org per month';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -1191,3 +1191,44 @@ COMMENT ON TABLE organization_oauth_states
   IS 'Server-only hashes for short-lived, single-use OAuth state parameters.';
 
 COMMIT;
+
+-- Migration 027: ad-hoc AI quota grants (expiring, service-role only)
+
+CREATE TABLE IF NOT EXISTS public.ai_quota_grants (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  organization_id   uuid NOT NULL REFERENCES public.organizations(id) ON DELETE CASCADE,
+  additional_calls  int  NOT NULL CHECK (additional_calls > 0 AND additional_calls <= 1000000),
+  source            text NOT NULL DEFAULT 'admin' CHECK (source IN ('admin', 'auto_burst')),
+  reason            text CHECK (reason IS NULL OR length(reason) <= 500),
+  granted_by        text CHECK (granted_by IS NULL OR length(granted_by) <= 320),
+  -- First day of the UTC month the grant belongs to; drives the auto-burst
+  -- uniqueness guard below.
+  period_month      date NOT NULL,
+  expires_at        timestamptz NOT NULL,
+  created_at        timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ai_quota_grants_active
+  ON public.ai_quota_grants (organization_id, expires_at);
+
+-- At most one automatic burst per organization per month. A second concurrent
+-- request loses this race with a unique violation and is refused, which is the
+-- intended outcome.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ai_quota_grants_one_auto_burst
+  ON public.ai_quota_grants (organization_id, period_month)
+  WHERE source = 'auto_burst';
+
+ALTER TABLE public.ai_quota_grants ENABLE ROW LEVEL SECURITY;
+
+-- No policies: RLS with zero policies denies every browser role. Grants are
+-- written and read only by service-role functions.
+REVOKE ALL ON public.ai_quota_grants FROM PUBLIC;
+REVOKE ALL ON public.ai_quota_grants FROM anon;
+REVOKE ALL ON public.ai_quota_grants FROM authenticated;
+
+COMMENT ON TABLE public.ai_quota_grants
+  IS 'Temporary additions to an organization monthly AI allowance. Expiring, audited, service-role only.';
+COMMENT ON COLUMN public.ai_quota_grants.source
+  IS 'admin = granted by a platform admin; auto_burst = automatic one-off top-up on first breach in a month';
+COMMENT ON COLUMN public.ai_quota_grants.period_month
+  IS 'First day of the UTC month this grant belongs to; enforces one auto_burst per org per month';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -775,13 +775,13 @@ COMMENT ON TABLE notification_delivery_log IS 'Audit trail for all notification 
 
 ALTER TABLE ai_usage_log
   ADD COLUMN IF NOT EXISTS quota_type text
-    CHECK (quota_type IN ('platform_free', 'platform_pro', 'platform_enterprise', 'byok')),
+    CHECK (quota_type IN ('platform_free', 'platform_starter', 'platform_pro', 'platform_enterprise', 'byok')),
   ADD COLUMN IF NOT EXISTS metadata jsonb;
 
 CREATE INDEX IF NOT EXISTS idx_ai_usage_quota
   ON ai_usage_log (organization_id, quota_type, created_at);
 
-COMMENT ON COLUMN ai_usage_log.quota_type IS 'Track whether call used platform quota or user BYOK key';
+COMMENT ON COLUMN ai_usage_log.quota_type IS 'Allowance the call drew from: platform_<organizations.tier> or byok';
 COMMENT ON COLUMN ai_usage_log.metadata   IS 'Optional context: { linked_to_type, linked_to_id, prompt_version }';
 -- Migration 008: Persist DMA quality checks, strategic insights, and suggested tasks
 --
@@ -932,7 +932,7 @@ COMMENT ON COLUMN organization_ai_settings.byok_provider
 COMMENT ON COLUMN organization_ai_settings.byok_api_key
   IS 'User-supplied API key; stored encrypted. Never returned to the browser.';
 COMMENT ON COLUMN organization_ai_settings.soft_quota_monthly
-  IS 'Per-org monthly call soft limit override. NULL = server default (100 for free orgs).';
+  IS 'Enforced monthly platform AI call ceiling for this organization. NULL = tier default from netlify/functions/_shared/aiQuota.js. 0 suspends platform AI.';
 -- Migration 013: user_profiles table
 -- Stores per-user profile information (display name, phone, mobile, notes).
 -- Separate from auth.users so it can be extended without touching Supabase Auth.

--- a/tests/security/admin-tier-management.test.mjs
+++ b/tests/security/admin-tier-management.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { toSafeByokMetadata } from "../../netlify/functions/_shared/byokSecurity.js";
+import { ORGANIZATION_TIERS } from "../../netlify/functions/_shared/organizationTier.js";
+
+const read = (path) => readFile(new URL(path, import.meta.url), "utf8");
+
+test("changing a tier requires platform-admin authentication", async () => {
+  const source = await read("../../netlify/functions/admin.ts");
+
+  const requireAdmin = source.indexOf("await requireAdmin(authHeader)");
+  const tierCase = source.indexOf("case 'set_company_tier'");
+  assert.ok(requireAdmin > 0 && tierCase > 0, "both must exist");
+  assert.ok(
+    tierCase > requireAdmin,
+    "set_company_tier must sit in the post-auth switch, not the pre-auth branch",
+  );
+});
+
+test("tier updates are validated and attributed", async () => {
+  const source = await read("../../netlify/functions/admin.ts");
+  const handler = source.match(
+    /async function handleSetCompanyTier[\s\S]*?\n}\n/,
+  )?.[0];
+  assert.ok(handler, "handleSetCompanyTier must exist");
+
+  // Caller-supplied tiers reach a CHECK-constrained column: reject anything
+  // that is not one of the four known tiers rather than relying on the DB.
+  assert.match(handler, /ORGANIZATION_TIERS[\s\S]*\.includes\(tier\)/);
+  assert.match(handler, /status: 400/);
+
+  // Only the tier column may move — not is_active, and not another tenant.
+  assert.match(handler, /\.update\(\{ tier \}\)\.eq\('id', id\)/);
+  assert.doesNotMatch(handler, /is_active/);
+
+  // Entitlement changes cost money; record who made them.
+  assert.match(handler, /set_company_tier[\s\S]*actorEmail/);
+});
+
+test("the tenant sees the ceiling the server will actually enforce", async () => {
+  const metadata = toSafeByokMetadata(
+    { model: "gemini-2.5-flash", use_byok: false, byok_api_key: "secret-key-value-abcdefgh" },
+    false,
+    { tier: "pro", monthlyCallLimit: 2_000 },
+  );
+
+  assert.equal(metadata.tier, "pro");
+  assert.equal(metadata.monthly_call_limit, 2_000);
+  assert.equal("byok_api_key" in metadata, false);
+  assert.doesNotMatch(JSON.stringify(metadata), /secret-key-value/);
+
+  // Absent quota info must not imply a paid allowance.
+  const unknown = toSafeByokMetadata(null, false);
+  assert.equal(unknown.tier, "free");
+  assert.equal(unknown.monthly_call_limit, null);
+});
+
+test("the limit is resolved server-side, not recomputed in the browser", async () => {
+  const [settingsFn, panel] = await Promise.all([
+    read("../../netlify/functions/byok-settings.ts"),
+    read("../../components/AIUsagePanel.tsx"),
+  ]);
+
+  assert.match(settingsFn, /loadOrganizationTier\(admin, organizationId\)/);
+  assert.match(settingsFn, /resolveMonthlyCallLimit\(tier, settings\?\.soft_quota_monthly\)/);
+
+  assert.match(panel, /settings\.monthly_call_limit/);
+  // Regression: the panel used to show a hardcoded 100 to every organization,
+  // which is wrong for every tier above free.
+  assert.doesNotMatch(panel, /PLATFORM_SOFT_LIMIT_DEFAULT/);
+  assert.doesNotMatch(panel, /softQuotaMonthly \?\?/);
+});
+
+test("the quota warning no longer promises calls that will be refused", async () => {
+  const panel = await read("../../components/AIUsagePanel.tsx");
+
+  assert.doesNotMatch(panel, /AI calls are still allowed/);
+  assert.doesNotMatch(panel, /soft limit|soft quota/i);
+  assert.match(panel, /AI features are paused/);
+});
+
+test("the admin console can select every tier the database accepts", async () => {
+  const panel = await read("../../components/admin/CompanyListPanel.tsx");
+
+  const declared = panel.match(/const TIERS = \[([^\]]*)\]/)?.[1];
+  assert.ok(declared, "TIERS must exist");
+  assert.deepEqual(
+    declared.split(",").map((t) => t.trim().replace(/'/g, "")).filter(Boolean),
+    [...ORGANIZATION_TIERS],
+  );
+
+  assert.match(panel, /callAdmin\('set_company_tier'/);
+  assert.match(panel, /window\.confirm\(/, "an entitlement change should be confirmed");
+});

--- a/tests/security/ai-quota-enforcement.test.mjs
+++ b/tests/security/ai-quota-enforcement.test.mjs
@@ -1,0 +1,144 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  MONTHLY_AI_CALL_LIMITS,
+  checkMonthlyAiQuota,
+  monthStartIso,
+  platformQuotaType,
+  quotaExceededResponse,
+  resolveMonthlyCallLimit,
+} from "../../netlify/functions/_shared/aiQuota.js";
+import { ORGANIZATION_TIERS } from "../../netlify/functions/_shared/organizationTier.js";
+
+/** Stub for admin.from("ai_usage_log").select(...).eq().eq().gte() */
+function stubUsage(result) {
+  const filters = [];
+  return {
+    filters,
+    from() {
+      const chain = {
+        select: (columns, options) => {
+          filters.push({ columns, options });
+          return chain;
+        },
+        eq: (column, value) => {
+          filters.push({ column, value });
+          return chain;
+        },
+        gte: async (column, value) => {
+          filters.push({ column, value });
+          return result;
+        },
+      };
+      return chain;
+    },
+  };
+}
+
+test("every tier has a monthly ceiling", () => {
+  assert.deepEqual(
+    Object.keys(MONTHLY_AI_CALL_LIMITS).sort(),
+    [...ORGANIZATION_TIERS].sort(),
+  );
+  for (const tier of ORGANIZATION_TIERS) {
+    assert.ok(MONTHLY_AI_CALL_LIMITS[tier] > 0, `${tier} needs an allowance`);
+  }
+});
+
+test("an explicit per-org override wins over the tier default", () => {
+  assert.equal(resolveMonthlyCallLimit("pro", 25), 25);
+  assert.equal(resolveMonthlyCallLimit("pro", 0), 0, "0 suspends platform AI");
+  assert.equal(resolveMonthlyCallLimit("pro", null), MONTHLY_AI_CALL_LIMITS.pro);
+  assert.equal(resolveMonthlyCallLimit("pro", undefined), MONTHLY_AI_CALL_LIMITS.pro);
+  assert.equal(resolveMonthlyCallLimit("pro", -5), MONTHLY_AI_CALL_LIMITS.pro);
+  assert.equal(resolveMonthlyCallLimit("pro", "500"), MONTHLY_AI_CALL_LIMITS.pro);
+  // An unknown tier must not inherit an enterprise-sized allowance.
+  assert.equal(resolveMonthlyCallLimit("platinum", null), MONTHLY_AI_CALL_LIMITS.free);
+});
+
+test("quota_type is derived from the tier and stays within the CHECK constraint", async () => {
+  const [migration, schema] = await Promise.all([
+    readFile(new URL("../../supabase/migrations/026_ai_quota_enforcement.sql", import.meta.url), "utf8"),
+    readFile(new URL("../../supabase/schema.sql", import.meta.url), "utf8"),
+  ]);
+
+  assert.equal(platformQuotaType("starter"), "platform_starter");
+  assert.equal(platformQuotaType("platinum"), "platform_free");
+
+  for (const source of [migration, schema]) {
+    // Ignore SQL comments so a documented rollback statement is not mistaken
+    // for the live constraint.
+    const executable = source.replace(/^\s*--.*$/gm, "");
+    const allowed = executable.match(/CHECK \(quota_type IN \(([\s\S]*?)\)\)/)?.[1];
+    assert.ok(allowed, "quota_type CHECK constraint must exist");
+    for (const tier of ORGANIZATION_TIERS) {
+      assert.ok(
+        allowed.includes(`'${platformQuotaType(tier)}'`),
+        `${platformQuotaType(tier)} must be an accepted quota_type`,
+      );
+    }
+    assert.ok(allowed.includes("'byok'"));
+  }
+});
+
+test("calls are blocked once the month's allowance is spent", async () => {
+  const under = stubUsage({ count: 99, error: null });
+  const atLimit = stubUsage({ count: 100, error: null });
+  const over = stubUsage({ count: 5_000, error: null });
+
+  assert.equal((await checkMonthlyAiQuota(under, "org-1", "free", null)).allowed, true);
+  assert.equal((await checkMonthlyAiQuota(atLimit, "org-1", "free", null)).allowed, false);
+  assert.equal((await checkMonthlyAiQuota(over, "org-1", "free", null)).allowed, false);
+
+  // The count is scoped to this org, successful calls only, this month only.
+  assert.deepEqual(under.filters, [
+    { columns: "id", options: { count: "exact", head: true } },
+    { column: "organization_id", value: "org-1" },
+    { column: "success", value: true },
+    { column: "created_at", value: monthStartIso() },
+  ]);
+
+  const now = new Date("2026-09-17T12:34:56.000Z");
+  assert.equal(monthStartIso(now), "2026-09-01T00:00:00.000Z");
+});
+
+test("a telemetry outage degrades to allow rather than taking AI offline", async () => {
+  const broken = stubUsage({ count: null, error: { message: "timeout" } });
+  const result = await checkMonthlyAiQuota(broken, "org-1", "free", null);
+
+  assert.equal(result.allowed, true);
+  assert.equal(result.degraded, true);
+  assert.equal(result.used, null);
+});
+
+test("the quota response carries no tenant data", () => {
+  const body = quotaExceededResponse({ used: 120, limit: 100 });
+  assert.match(body.error, /100 AI requests/);
+  assert.deepEqual(body.quota, { used: 120, limit: 100 });
+  assert.doesNotMatch(JSON.stringify(body), /organization_id|user_id|@/);
+});
+
+test("both AI entry points enforce the ceiling before calling the provider", async () => {
+  const [api, ally] = await Promise.all([
+    readFile(new URL("../../netlify/functions/api.ts", import.meta.url), "utf8"),
+    readFile(new URL("../../netlify/functions/ally-support.ts", import.meta.url), "utf8"),
+  ]);
+
+  for (const [name, source] of [["api.ts", api], ["ally-support.ts", ally]]) {
+    assert.match(source, /checkMonthlyAiQuota\(/, `${name} must check the quota`);
+    assert.match(source, /json\(429, quotaExceededResponse\(quota\)\)/, `${name} must return 429`);
+    assert.match(source, /platformQuotaType\(tier\)/, `${name} must log the tier-aware quota type`);
+
+    // The gate must precede the provider call in source order.
+    assert.ok(
+      source.indexOf("checkMonthlyAiQuota(") < source.indexOf("generateContent"),
+      `${name} must check the quota before calling Gemini`,
+    );
+  }
+
+  // Regression: the old handler logged the breach and continued anyway.
+  assert.doesNotMatch(api, /proceeding anyway/);
+  assert.doesNotMatch(api, /PLATFORM_SOFT_LIMIT/);
+});

--- a/tests/security/ai-quota-enforcement.test.mjs
+++ b/tests/security/ai-quota-enforcement.test.mjs
@@ -12,25 +12,30 @@ import {
 } from "../../netlify/functions/_shared/aiQuota.js";
 import { ORGANIZATION_TIERS } from "../../netlify/functions/_shared/organizationTier.js";
 
-/** Stub for admin.from("ai_usage_log").select(...).eq().eq().gte() */
-function stubUsage(result) {
+/**
+ * Stub for the two reads the quota check makes:
+ *   ai_usage_log   .select(...).eq().eq().gte()   → this month's calls
+ *   ai_quota_grants.select(...).eq().gt()         → active top-ups
+ */
+function stubUsage(result, grants = []) {
   const filters = [];
   return {
     filters,
-    from() {
+    from(table) {
       const chain = {
         select: (columns, options) => {
-          filters.push({ columns, options });
+          if (table === "ai_usage_log") filters.push({ columns, options });
           return chain;
         },
         eq: (column, value) => {
-          filters.push({ column, value });
+          if (table === "ai_usage_log") filters.push({ column, value });
           return chain;
         },
         gte: async (column, value) => {
           filters.push({ column, value });
           return result;
         },
+        gt: async () => ({ data: grants, error: null }),
       };
       return chain;
     },
@@ -127,14 +132,18 @@ test("both AI entry points enforce the ceiling before calling the provider", asy
   ]);
 
   for (const [name, source] of [["api.ts", api], ["ally-support.ts", ally]]) {
-    assert.match(source, /checkMonthlyAiQuota\(/, `${name} must check the quota`);
+    // authorizeAiCall checks the ceiling and spends the monthly auto-burst
+    // before refusing, so entry points must go through it rather than the
+    // bare check.
+    assert.match(source, /authorizeAiCall\(/, `${name} must authorize the call`);
+    assert.doesNotMatch(source, /checkMonthlyAiQuota\(/, `${name} must not skip the auto-burst`);
     assert.match(source, /json\(429, quotaExceededResponse\(quota\)\)/, `${name} must return 429`);
     assert.match(source, /platformQuotaType\(tier\)/, `${name} must log the tier-aware quota type`);
 
     // The gate must precede the provider call in source order.
     assert.ok(
-      source.indexOf("checkMonthlyAiQuota(") < source.indexOf("generateContent"),
-      `${name} must check the quota before calling Gemini`,
+      source.indexOf("authorizeAiCall(") < source.indexOf("generateContent"),
+      `${name} must authorize before calling Gemini`,
     );
   }
 

--- a/tests/security/ai-quota-grants.test.mjs
+++ b/tests/security/ai-quota-grants.test.mjs
@@ -1,0 +1,187 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  AUTO_BURST_RATIO,
+  authorizeAiCall,
+  grantAutoBurst,
+  loadActiveGrantTotal,
+  monthEndIso,
+  periodMonth,
+} from "../../netlify/functions/_shared/aiQuota.js";
+
+const NOW = new Date("2026-09-17T12:00:00.000Z");
+const read = (path) => readFile(new URL(path, import.meta.url), "utf8");
+
+/**
+ * @param {{ used?: number, usageError?: object, grants?: object[],
+ *           grantsError?: object, insertError?: object }} options
+ */
+function stubAdmin({ used = 0, usageError = null, grants = [], grantsError = null, insertError = null } = {}) {
+  const state = { inserts: [], grantFilters: [] };
+  return {
+    state,
+    from(table) {
+      if (table === "ai_usage_log") {
+        const chain = {
+          select: () => chain,
+          eq: () => chain,
+          gte: async () => ({ count: usageError ? null : used, error: usageError }),
+        };
+        return chain;
+      }
+      if (table === "ai_quota_grants") {
+        const chain = {
+          select: () => chain,
+          eq: (column, value) => {
+            state.grantFilters.push({ column, value });
+            return chain;
+          },
+          gt: async (column, value) => {
+            state.grantFilters.push({ column, value });
+            return { data: grantsError ? null : grants, error: grantsError };
+          },
+          insert: async (row) => {
+            state.inserts.push(row);
+            return { error: insertError };
+          },
+        };
+        return chain;
+      }
+      throw new Error(`Unexpected table ${table}`);
+    },
+  };
+}
+
+test("active grants are summed for the organization and the moment asked", async () => {
+  const admin = stubAdmin({ grants: [{ additional_calls: 300 }, { additional_calls: 200 }] });
+
+  assert.equal(await loadActiveGrantTotal(admin, "org-1", NOW), 500);
+  assert.deepEqual(admin.state.grantFilters, [
+    { column: "organization_id", value: "org-1" },
+    { column: "expires_at", value: NOW.toISOString() },
+  ]);
+});
+
+test("an unreadable grant costs headroom, never unauthorized spend", async () => {
+  const admin = stubAdmin({ grantsError: { message: "timeout" } });
+  assert.equal(await loadActiveGrantTotal(admin, "org-1", NOW), 0);
+});
+
+test("the automatic burst is a bounded share of the plan, expiring at the reset", async () => {
+  const admin = stubAdmin();
+  const granted = await grantAutoBurst(admin, "org-1", 100, NOW);
+
+  assert.equal(granted, Math.ceil(100 * AUTO_BURST_RATIO));
+  assert.equal(AUTO_BURST_RATIO, 0.25, "worst case stays at 125% of plan");
+
+  const [row] = admin.state.inserts;
+  assert.equal(row.organization_id, "org-1");
+  assert.equal(row.source, "auto_burst");
+  assert.equal(row.period_month, periodMonth(NOW));
+  assert.equal(row.expires_at, monthEndIso(NOW));
+  assert.equal(row.expires_at, "2026-10-01T00:00:00.000Z");
+});
+
+test("a second burst in the same month is refused by the database, not by chance", async () => {
+  const already = stubAdmin({ insertError: { code: "23505" } });
+  assert.equal(await grantAutoBurst(already, "org-1", 100, NOW), 0);
+
+  const broken = stubAdmin({ insertError: { code: "42501" } });
+  assert.equal(await grantAutoBurst(broken, "org-1", 100, NOW), 0);
+});
+
+test("a call under the ceiling is authorized without spending the burst", async () => {
+  const admin = stubAdmin({ used: 40 });
+  const quota = await authorizeAiCall(admin, "org-1", "free", null, NOW);
+
+  assert.equal(quota.allowed, true);
+  assert.equal(quota.limit, 100);
+  assert.deepEqual(admin.state.inserts, [], "no burst until the ceiling is actually hit");
+});
+
+test("grants raise the ceiling that authorization uses", async () => {
+  const admin = stubAdmin({ used: 120, grants: [{ additional_calls: 500 }] });
+  const quota = await authorizeAiCall(admin, "org-1", "free", null, NOW);
+
+  assert.equal(quota.baseLimit, 100);
+  assert.equal(quota.grantedCalls, 500);
+  assert.equal(quota.limit, 600);
+  assert.equal(quota.allowed, true);
+});
+
+test("first breach of the month is absorbed by the burst instead of interrupting", async () => {
+  const admin = stubAdmin({ used: 100 });
+  const quota = await authorizeAiCall(admin, "org-1", "free", null, NOW);
+
+  assert.equal(quota.allowed, true, "the customer is not hard-stopped");
+  assert.equal(quota.autoBurstGranted, 25);
+  assert.equal(quota.limit, 125);
+  assert.equal(admin.state.inserts.length, 1);
+});
+
+test("once the burst is spent the call is refused", async () => {
+  // 125 used against a 100 plan whose burst already exists: the top-up is in
+  // grants, and a second insert loses the unique index.
+  const admin = stubAdmin({
+    used: 125,
+    grants: [{ additional_calls: 25 }],
+    insertError: { code: "23505" },
+  });
+  const quota = await authorizeAiCall(admin, "org-1", "free", null, NOW);
+
+  assert.equal(quota.allowed, false);
+  assert.equal(quota.limit, 125);
+});
+
+test("grants are service-role only and one auto-burst per org per month", async () => {
+  const [migration, schema] = await Promise.all([
+    read("../../supabase/migrations/027_ai_quota_grants.sql"),
+    read("../../supabase/schema.sql"),
+  ]);
+
+  for (const source of [migration, schema]) {
+    const executable = source.replace(/^\s*--.*$/gm, "");
+
+    assert.match(executable, /ALTER TABLE public\.ai_quota_grants ENABLE ROW LEVEL SECURITY/);
+    assert.doesNotMatch(executable, /CREATE POLICY[^;]*ai_quota_grants/,
+      "RLS with no policy is what denies every browser role");
+    for (const role of ["PUBLIC", "anon", "authenticated"]) {
+      assert.match(
+        executable,
+        new RegExp(`REVOKE ALL ON public\\.ai_quota_grants FROM ${role}`),
+      );
+    }
+
+    assert.match(
+      executable,
+      /CREATE UNIQUE INDEX[\s\S]*ai_quota_grants \(organization_id, period_month\)\s*WHERE source = 'auto_burst'/,
+    );
+    assert.match(executable, /CHECK \(source IN \('admin', 'auto_burst'\)\)/);
+    assert.match(executable, /additional_calls > 0/);
+  }
+});
+
+test("admin quota actions are authenticated, validated and attributed", async () => {
+  const source = await read("../../netlify/functions/admin.ts");
+
+  const requireAdmin = source.indexOf("await requireAdmin(authHeader)");
+  for (const action of ["org_ai_quota", "grant_ai_quota", "set_ai_quota_override"]) {
+    const index = source.indexOf(`case '${action}'`);
+    assert.ok(index > requireAdmin, `${action} must sit in the post-auth switch`);
+  }
+
+  const grant = source.match(/async function handleGrantAiQuota[\s\S]*?\n}\n/)?.[0];
+  assert.ok(grant);
+  assert.match(grant, /Number\.isInteger\(calls\)/);
+  assert.match(grant, /calls < 1 \|\| calls > 1_000_000/);
+  assert.match(grant, /granted_by:\s*actorEmail/);
+  assert.match(grant, /expires_at:\s*monthEndIso\(now\)/, "an ad-hoc grant must expire");
+  assert.match(grant, /source:\s*'admin'/);
+
+  const override = source.match(/async function handleSetAiQuotaOverride[\s\S]*?\n}\n/)?.[0];
+  assert.ok(override);
+  assert.match(override, /raw === null \|\| raw === ''/, "blank must clear the override");
+  assert.match(override, /override < 0 \|\| override > 1_000_000/);
+});

--- a/tests/security/ally-support-auth.test.mjs
+++ b/tests/security/ally-support-auth.test.mjs
@@ -69,6 +69,13 @@ function createHarness({
       if (table === "organizations") {
         return createQuery({ data: { tier }, error: null });
       }
+      if (table === "ai_quota_grants") {
+        return {
+          select: () => ({ eq: () => ({ gt: async () => ({ data: [], error: null }) }) }),
+          // The auto-burst attempt on a breach; "already used this month".
+          insert: async () => ({ error: { code: "23505" } }),
+        };
+      }
       if (table === "ai_usage_log") {
         const countQuery = {
           select: () => countQuery,

--- a/tests/security/ally-support-auth.test.mjs
+++ b/tests/security/ally-support-auth.test.mjs
@@ -29,7 +29,12 @@ function createQuery(result) {
   return query;
 }
 
-function createHarness({ authenticated = true, member = true } = {}) {
+function createHarness({
+  authenticated = true,
+  member = true,
+  tier = "free",
+  monthlyAiCalls = 0,
+} = {}) {
   const state = {
     aiCalls: 0,
     blobWrites: [],
@@ -61,13 +66,20 @@ function createHarness({ authenticated = true, member = true } = {}) {
       if (table === "company_profiles") {
         return createQuery({ data: { name: "Verified Company" }, error: null });
       }
+      if (table === "organizations") {
+        return createQuery({ data: { tier }, error: null });
+      }
       if (table === "ai_usage_log") {
-        return {
+        const countQuery = {
+          select: () => countQuery,
+          eq: () => countQuery,
+          gte: async () => ({ count: monthlyAiCalls, error: null }),
           insert: async (value) => {
             state.inserts.push(value);
             return { error: null };
           },
         };
+        return countQuery;
       }
       throw new Error(`Unexpected table: ${table}`);
     },
@@ -195,6 +207,41 @@ test("Ally derives tenant identity from the verified session and membership", as
   assert.equal(state.inserts[0].organization_id, ORGANIZATION_ID);
   assert.equal(state.inserts[0].user_id, USER_ID);
   assert.equal(state.inserts[0].user_email, "verified@example.com");
+});
+
+test("Ally refuses to spend AI budget past the organization's monthly ceiling", async () => {
+  // soft_quota_monthly is 100 in the harness; 100 calls already logged.
+  const exhausted = createHarness({ monthlyAiCalls: 100 });
+  const blocked = await exhausted.handler({
+    httpMethod: "POST",
+    headers: { Authorization: "Bearer valid" },
+    body: VALID_BODY,
+  });
+
+  assert.equal(blocked.statusCode, 429);
+  assert.equal(exhausted.state.aiCalls, 0, "no provider call once the quota is spent");
+  assert.deepEqual(exhausted.state.blobWrites, [], "no conversation is stored");
+
+  const withinQuota = createHarness({ monthlyAiCalls: 99 });
+  const allowed = await withinQuota.handler({
+    httpMethod: "POST",
+    headers: { Authorization: "Bearer valid" },
+    body: VALID_BODY,
+  });
+
+  assert.equal(allowed.statusCode, 200);
+  assert.equal(withinQuota.state.aiCalls, 1);
+});
+
+test("Ally records the usage row against the organization's tier", async () => {
+  const { handler, state } = createHarness({ tier: "pro" });
+  await handler({
+    httpMethod: "POST",
+    headers: { Authorization: "Bearer valid" },
+    body: VALID_BODY,
+  });
+
+  assert.equal(state.inserts[0].quota_type, "platform_pro");
 });
 
 test("support email HTML escaping neutralizes caller markup", () => {

--- a/tests/security/byok-secret-isolation.test.mjs
+++ b/tests/security/byok-secret-isolation.test.mjs
@@ -40,7 +40,7 @@ function createAdminMock(rows) {
   };
 }
 
-function createEndpointAdminMock({ role = "Owner", hasSecret = true } = {}) {
+function createEndpointAdminMock({ role = "Owner", hasSecret = true, tier = "free" } = {}) {
   const calls = [];
   let storedSecret = hasSecret;
   let useByok = hasSecret;
@@ -105,6 +105,11 @@ function createEndpointAdminMock({ role = "Owner", hasSecret = true } = {}) {
               data: storedSecret ? { organization_id: ORG_ID } : null,
               error: null,
             };
+          }
+          // The endpoint resolves the tier so it can report the ceiling the
+          // server will enforce; the browser is never asked to compute it.
+          if (table === "organizations") {
+            return { data: { tier }, error: null };
           }
           throw new Error(`Unexpected table ${table}`);
         },
@@ -307,6 +312,23 @@ test("authenticated members receive safe metadata for their organization", async
     admin.calls.some((call) => call.table === "organization_ai_secrets"),
     true,
   );
+});
+
+test("metadata reports the ceiling the server will enforce for that tier", async () => {
+  const handlerFor = (tier) =>
+    createByokSettingsHandler(() => createEndpointAdminMock({ tier }));
+  const get = (handler) => handler(new Request(
+    `https://app.example.com/.netlify/functions/byok-settings?organization_id=${ORG_ID}`,
+    { headers: { Authorization: "Bearer member-token" } },
+  ));
+
+  // soft_quota_monthly is 100 in the mock, so the override wins on every tier.
+  const overridden = await (await get(handlerFor("pro"))).json();
+  assert.equal(overridden.tier, "pro");
+  assert.equal(overridden.monthly_call_limit, 100);
+
+  // The client must never be handed the raw column to interpret for itself.
+  assert.equal(typeof overridden.monthly_call_limit, "number");
 });
 
 test("non-members are rejected before the endpoint reads secret metadata", async () => {

--- a/tests/security/evidence-tier-entitlement.test.mjs
+++ b/tests/security/evidence-tier-entitlement.test.mjs
@@ -1,0 +1,102 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import {
+  DEFAULT_ORGANIZATION_TIER,
+  ORGANIZATION_TIERS,
+  loadOrganizationTier,
+  normalizeOrganizationTier,
+} from "../../netlify/functions/_shared/organizationTier.js";
+
+/** Minimal service-role client stub: organizations.select().eq().maybeSingle() */
+function stubAdmin(response) {
+  const calls = [];
+  return {
+    calls,
+    from(table) {
+      calls.push({ table });
+      return {
+        select(columns) {
+          calls[calls.length - 1].columns = columns;
+          return {
+            eq(column, value) {
+              calls[calls.length - 1].filter = { column, value };
+              return { maybeSingle: async () => response };
+            },
+          };
+        },
+      };
+    },
+  };
+}
+
+test("the tier helper reads the canonical organizations.tier column", async () => {
+  const admin = stubAdmin({ data: { tier: "pro" }, error: null });
+
+  assert.equal(await loadOrganizationTier(admin, "org-1"), "pro");
+  assert.deepEqual(admin.calls, [
+    { table: "organizations", columns: "tier", filter: { column: "id", value: "org-1" } },
+  ]);
+});
+
+test("tier resolution fails closed instead of granting paid capacity", async () => {
+  const missingRow = stubAdmin({ data: null, error: null });
+  assert.equal(await loadOrganizationTier(missingRow, "org-1"), "free");
+
+  const lookupError = stubAdmin({ data: null, error: { message: "boom" } });
+  assert.equal(await loadOrganizationTier(lookupError, "org-1"), "free");
+
+  const unknownTier = stubAdmin({ data: { tier: "platinum" }, error: null });
+  assert.equal(await loadOrganizationTier(unknownTier, "org-1"), "free");
+
+  assert.equal(DEFAULT_ORGANIZATION_TIER, "free");
+  for (const value of [undefined, null, "", "PRO", 3, {}]) {
+    assert.equal(normalizeOrganizationTier(value), "free");
+  }
+});
+
+test("the tier list matches the organizations.tier CHECK constraint", async () => {
+  const [migration, schema] = await Promise.all([
+    readFile(new URL("../../supabase/migrations/015_org_tier_status.sql", import.meta.url), "utf8"),
+    readFile(new URL("../../supabase/schema.sql", import.meta.url), "utf8"),
+  ]);
+
+  for (const source of [migration, schema]) {
+    const constraint = source.match(/CHECK \(tier IN \(([^)]*)\)\)/)?.[1];
+    assert.ok(constraint, "organizations.tier CHECK constraint must exist");
+    const declared = constraint.split(",").map((value) => value.trim().replace(/'/g, ""));
+    assert.deepEqual(declared, [...ORGANIZATION_TIERS]);
+  }
+});
+
+test("evidence uploads resolve entitlements from tier, with a quota for every tier", async () => {
+  const source = await readFile(
+    new URL("../../netlify/functions/evidence.ts", import.meta.url),
+    "utf8",
+  );
+
+  // Regression: the handler previously queried a column that does not exist,
+  // which silently downgraded every organization to the link-only free tier.
+  assert.doesNotMatch(source, /subscription_tier/);
+  assert.match(source, /loadOrganizationTier\(admin, orgId\)/);
+
+  const quotaMap = source.match(/const QUOTA_MAP: Record<string, number> = \{([\s\S]*?)\};/)?.[1];
+  assert.ok(quotaMap, "QUOTA_MAP must exist");
+
+  const quotas = Object.fromEntries(
+    [...quotaMap.matchAll(/^\s*(\w+):\s*([\d_]+),/gm)].map(([, tier, mb]) => [
+      tier,
+      Number(mb.replace(/_/g, "")),
+    ]),
+  );
+
+  assert.deepEqual(Object.keys(quotas).sort(), [...ORGANIZATION_TIERS].sort());
+  assert.equal(quotas.free, 0, "the free tier stays link-only");
+  for (const tier of ORGANIZATION_TIERS.filter((t) => t !== "free")) {
+    assert.ok(quotas[tier] > 0, `${tier} must receive upload capacity`);
+  }
+
+  // An unrecognized tier must map to 0 MB rather than an open-ended default.
+  assert.match(source, /QUOTA_MAP\[tier\] \?\? 0/);
+});


### PR DESCRIPTION
> **This is #181 + #186 + #187 combined, re-opened against `main`.** Those three were merged into their parent branches rather than into `main`, so none of this work is on `main` yet. All of it has already been reviewed there; this PR only changes where it lands.

## What lands

**Enforced monthly AI quota** (was #181)
`api.ts` counted the month's calls, logged `soft limit reached (proceeding anyway)`, and ran the request regardless — so platform AI spend had no upper bound per tenant and `soft_quota_monthly` did nothing. Both AI entry points now return **429 before any provider call** once the ceiling is spent. BYOK tenants are exempt. `quota_type` becomes `platform_<tier>`.

| Tier | Monthly platform AI calls |
|---|---|
| free | 100 |
| starter | 500 |
| pro | 2 000 |
| enterprise | 10 000 |

**Tier is changeable, and the tenant sees the real number** (was #186)
`organizations.tier` could be set at company creation and never again. `set_company_tier` fixes that, and the Tier column becomes a dropdown. The tenant AI panel showed a hardcoded 100 to every org and told anyone over it "AI calls are still allowed" — it now shows the server-resolved ceiling and says AI features pause.

**Ad-hoc grants and the automatic first-breach burst** (was #187)
`ai_quota_grants` holds expiring, attributed top-ups, so unblocking a customer today does not silently become their permanent plan. Effective ceiling = standing limit + active grants. The first time an org crosses its ceiling in a month it gets one automatic 25% burst and keeps working — worst case 125% of plan, with "once per month" enforced by a partial unique index rather than application logic. Admin controls live under **AI Usage → Quota**.

## ⚠️ Before merging

**Migrations 026 and 027 must be applied first** — the quota check reads `ai_quota_grants` on every AI call.

**Enforcement starts the moment this deploys.** Any org already over its tier default this month starts getting 429s — the demo org almost certainly qualifies. `Docs v1.1.0/DEPLOYMENT.md` gains an "Enabling AI quota enforcement" runbook in #189 (measure usage, seed a generous standing limit, tighten later). If you merge this before #189, the runbook is in that PR's diff.

The tier numbers above are still placeholders for a commercial decision.

## Verification

Trial-merged onto current `main` alongside #190 and #189: **clean, 141 tests pass**, `tsc --noEmit` and `build` clean.

The diff re-includes `organizationTier.js` and the evidence tier fix because #180 was squash-merged; the content is identical, and the trial merge confirms no conflict.

Not visually verified: the admin quota modal needs a platform-admin session. Worth a deploy-preview click-through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)