### PR TITLE
fix(carbon): stop Carbon Quest estimates double counting the year

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,7 @@
 # cannot be skipped by forgetting to run them locally.
 #
 #   npm run test:security   security regression suite
+#   npm run test:unit       calculation and aggregation rules
 #   npx tsc --noEmit        type check
 #   npm run build           production build
 #   npm audit --omit=dev    runtime dependency audit
@@ -47,6 +48,9 @@ jobs:
 
       - name: Security regression tests
         run: npm run test:security
+
+      - name: Unit tests
+        run: npm run test:unit
 
       - name: Type check
         run: npx tsc --noEmit

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,8 @@ Stack: React 19 + TypeScript + Vite (frontend), Netlify Functions (backend), Sup
 ```bash
 npm run dev:netlify     # start dev server (Vite + Netlify Functions on port 8888) — always use this, not npm run dev
 npm run build           # production build
+npm run test:security   # security regression suite
+npm run test:unit       # calculation and aggregation rules
 npx tsc --noEmit        # type-check without building
 ```
 
@@ -66,6 +68,8 @@ supabase/
 
 tests/security/       Security regression tests for auth, tenant isolation,
                       secrets, URLs, uploads, logging, and dependencies
+tests/unit/           Calculation rules that must stay correct — pure modules
+                      only, so keep the arithmetic out of components
 ```
 
 ---

--- a/components/CarbonDashboard.tsx
+++ b/components/CarbonDashboard.tsx
@@ -24,6 +24,13 @@ import {
 } from 'recharts';
 import { EmissionSource, EmissionEntry } from '../types';
 import {
+  buildMonthlyTrend,
+  countableForYear,
+  entriesForYear,
+  overlappingEntries,
+  sourcesOnEstimate,
+} from '../services/carbonAggregation';
+import {
   fetchEmissionSources,
   fetchEmissionEntries,
   upsertEmissionSource,
@@ -58,45 +65,6 @@ function periodLabel(start: string): string {
 
 function startOfYear(year: number) { return `${year}-01-01`; }
 function endOfYear(year: number)   { return `${year}-12-31`; }
-
-function entriesForYear(entries: EmissionEntry[], year: number): EmissionEntry[] {
-  return entries.filter(e => new Date(e.period_start).getFullYear() === year);
-}
-
-function ytdSummary(entries: EmissionEntry[], year: number) {
-  const filtered = entriesForYear(entries, year);
-  const total    = filtered.reduce((s, e) => s + e.calculated_emissions_kgco2e, 0);
-  const scope: Record<string, number> = { '1': 0, '2': 0, '3': 0 };
-  // We need source scope — we'll join by sourceId below
-  return { total, byScope: scope, entries: filtered };
-}
-
-function buildMonthlyTrend(
-  entries: EmissionEntry[],
-  sources: EmissionSource[],
-  year: number,
-): { month: string; scope1: number; scope2: number; scope3: number; total: number }[] {
-  const scopeOf = Object.fromEntries(sources.map(s => [s.id, s.scope]));
-  const months = MONTH_LABELS.map((label, mi) => {
-    const monthEntries = entries.filter(e => {
-      const d = new Date(e.period_start);
-      return d.getFullYear() === year && d.getMonth() === mi;
-    });
-    const s: Record<string, number> = { '1': 0, '2': 0, '3': 0 };
-    for (const e of monthEntries) {
-      const scope = scopeOf[e.source_id] ?? '1';
-      s[scope] = (s[scope] ?? 0) + e.calculated_emissions_kgco2e / 1000;
-    }
-    return {
-      month: label,
-      scope1: Math.round(s['1'] * 100) / 100,
-      scope2: Math.round(s['2'] * 100) / 100,
-      scope3: Math.round(s['3'] * 100) / 100,
-      total:  Math.round((s['1'] + s['2'] + s['3']) * 100) / 100,
-    };
-  });
-  return months;
-}
 
 function lastEntry(entries: EmissionEntry[], sourceId: string): EmissionEntry | null {
   const es = entries.filter(e => e.source_id === sourceId).sort(
@@ -167,9 +135,12 @@ const CarbonDashboard: React.FC<Props> = ({ orgId, currentUserId, onRunWizard })
   // ── Derived data ────────────────────────────────────────────────────────
   const scopeOf = Object.fromEntries(sources.map(s => [s.id, s.scope]));
   const yearEntries = entriesForYear(entries, year);
+  const countableEntries = countableForYear(entries, year);
+  // Sources still carrying an annualised estimate rather than measurements.
+  const estimatedSources = sourcesOnEstimate(entries, year);
 
   const scopeTotals = { '1': 0, '2': 0, '3': 0 };
-  for (const e of yearEntries) {
+  for (const e of countableEntries) {
     const sc = scopeOf[e.source_id] ?? '1';
     scopeTotals[sc as keyof typeof scopeTotals] += e.calculated_emissions_kgco2e;
   }
@@ -179,9 +150,9 @@ const CarbonDashboard: React.FC<Props> = ({ orgId, currentUserId, onRunWizard })
   const hasData = yearEntries.length > 0;
 
   // YoY
-  const prevYearEntries = entriesForYear(entries, year - 1);
+  const prevYearEntries = countableForYear(entries, year - 1);
   const prevTotal = prevYearEntries.reduce((s, e) => s + e.calculated_emissions_kgco2e, 0);
-  const showYoY = prevYearEntries.length > 0 && yearEntries.length > 0;
+  const showYoY = prevYearEntries.length > 0 && countableEntries.length > 0;
   const yoyChange = showYoY && prevTotal > 0 ? ((grandTotal - prevTotal) / prevTotal) * 100 : 0;
 
   // Available years
@@ -247,6 +218,16 @@ const CarbonDashboard: React.FC<Props> = ({ orgId, currentUserId, onRunWizard })
           {/* ── Summary cards ── */}
           <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
             <ScopeCard label="Total" value={grandTotal} color="text-slate-800 dark:text-white" bg="bg-slate-50 dark:bg-slate-800" border="border-slate-200 dark:border-slate-700" />
+            {estimatedSources.size > 0 && (
+              <div className="sm:col-span-3 flex items-start gap-2 px-4 py-3 rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 text-xs text-amber-800 dark:text-amber-300">
+                <Info className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
+                <span>
+                  {estimatedSources.size === 1 ? '1 source is' : `${estimatedSources.size} sources are`}{' '}
+                  still an annualised estimate from Carbon Quest. Record a month of actual
+                  usage and it replaces the estimate for that source — the total never counts both.
+                </span>
+              </div>
+            )}
             <ScopeCard label="Scope 1 – Direct" value={scopeTotals['1']} color="text-amber-700 dark:text-amber-300" bg="bg-amber-50 dark:bg-amber-900/20" border="border-amber-200 dark:border-amber-800" />
             <ScopeCard label="Scope 2 – Energy" value={scopeTotals['2']} color="text-indigo-700 dark:text-indigo-300" bg="bg-indigo-50 dark:bg-indigo-900/20" border="border-indigo-200 dark:border-indigo-800" />
             <ScopeCard label="Scope 3 – Other" value={scopeTotals['3']} color="text-emerald-700 dark:text-emerald-300" bg="bg-emerald-50 dark:bg-emerald-900/20" border="border-emerald-200 dark:border-emerald-800" />
@@ -385,6 +366,7 @@ const CarbonDashboard: React.FC<Props> = ({ orgId, currentUserId, onRunWizard })
       {addSource && createPortal(
         <QuickAddModal
           source={addSource}
+          existingEntries={entries}
           currentUserId={currentUserId}
           orgId={orgId}
           onClose={() => setAddSource(null)}
@@ -527,11 +509,12 @@ const EditSourceModal: React.FC<{
 
 const QuickAddModal: React.FC<{
   source: EmissionSource;
+  existingEntries: EmissionEntry[];
   orgId: string;
   currentUserId: string;
   onClose: () => void;
   onSaved: () => void;
-}> = ({ source, orgId, currentUserId, onClose, onSaved }) => {
+}> = ({ source, existingEntries, orgId, currentUserId, onClose, onSaved }) => {
   const now = new Date();
   const y = now.getFullYear(), m = now.getMonth();
   const defaultStart = `${y}-${String(m + 1).padStart(2, '0')}-01`;
@@ -542,14 +525,30 @@ const QuickAddModal: React.FC<{
   const [start, setStart] = useState(defaultStart);
   const [end, setEnd] = useState(defaultEnd);
   const [notes, setNotes] = useState('');
+  const [confirmedDuplicate, setConfirmedDuplicate] = useState(false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState('');
 
   const factor = source.emission_factor_value ?? 0;
   const kgco2e = amount ? calculateEmissions(Number(amount), factor) : 0;
 
+  // A second entry for a period is allowed — corrections and adjustments are
+  // real — but it has to be deliberate and it has to say why.
+  const overlaps = overlappingEntries(existingEntries, source.id, 'actual', start, end);
+  const isDuplicate = overlaps.length > 0;
+  const noteRequired = isDuplicate && notes.trim() === '';
+  const blocked = isDuplicate && (!confirmedDuplicate || noteRequired);
+
   const handleSave = async () => {
     if (!amount || Number(amount) <= 0) { setError('Please enter a positive amount.'); return; }
+    if (isDuplicate && !confirmedDuplicate) {
+      setError('Another entry already covers this period. Confirm below to add this one as well.');
+      return;
+    }
+    if (noteRequired) {
+      setError('A note is required when more than one entry covers the same period.');
+      return;
+    }
     setSaving(true); setError('');
     try {
       await upsertEmissionEntry(orgId, {
@@ -614,18 +613,80 @@ const QuickAddModal: React.FC<{
             </div>
           )}
 
+          {isDuplicate && (
+            <div className="rounded-xl border border-amber-200 dark:border-amber-800 bg-amber-50 dark:bg-amber-900/20 p-3 space-y-2">
+              <div className="flex items-start gap-2 text-xs text-amber-800 dark:text-amber-300">
+                <AlertCircle className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
+                <div>
+                  <p className="font-semibold">
+                    {overlaps.length === 1
+                      ? 'An entry already covers this period'
+                      : `${overlaps.length} entries already cover this period`}
+                  </p>
+                  <ul className="mt-1 space-y-0.5">
+                    {overlaps.slice(0, 3).map(o => (
+                      <li key={o.id} className="font-mono">
+                        {o.period_start} → {o.period_end}: {o.activity_data.toLocaleString()} {source.unit}
+                        {o.notes ? ` — ${o.notes}` : ''}
+                      </li>
+                    ))}
+                  </ul>
+                  <p className="mt-1">
+                    Adding another is fine for a correction or adjustment — it will be
+                    counted in addition to the entries above, so only continue if that
+                    is what you intend.
+                  </p>
+                </div>
+              </div>
+              <label className="flex items-start gap-2 text-xs text-amber-800 dark:text-amber-300 cursor-pointer">
+                <input
+                  type="checkbox"
+                  checked={confirmedDuplicate}
+                  onChange={e => { setConfirmedDuplicate(e.target.checked); setError(''); }}
+                  className="mt-0.5 accent-amber-600"
+                />
+                <span>Yes, add this as an additional entry for the period.</span>
+              </label>
+            </div>
+          )}
+
           <div>
-            <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">Notes (optional)</label>
-            <input type="text" value={notes} onChange={e => setNotes(e.target.value)} placeholder="e.g. Oct 2026 bill" className="w-full px-4 py-2 border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-900 text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500" />
+            <label className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1">
+              {isDuplicate
+                ? <>Notes <span className="text-amber-600 dark:text-amber-400">(required — explain why)</span></>
+                : 'Notes (optional)'}
+            </label>
+            <input
+              type="text"
+              value={notes}
+              onChange={e => { setNotes(e.target.value); setError(''); }}
+              placeholder={isDuplicate ? 'e.g. correction to Feb reading, second invoice' : 'e.g. Oct 2026 bill'}
+              className={`w-full px-4 py-2 border rounded-lg bg-white dark:bg-slate-900 text-slate-900 dark:text-white text-sm focus:outline-none focus:ring-2 ${
+                noteRequired
+                  ? 'border-amber-400 dark:border-amber-600 focus:ring-amber-500'
+                  : 'border-slate-300 dark:border-slate-600 focus:ring-indigo-500'
+              }`}
+            />
           </div>
 
           {error && <p className="text-red-500 text-sm">{error}</p>}
 
           <div className="flex gap-3 pt-1">
             <button onClick={onClose} className="flex-1 py-2 border border-slate-200 dark:border-slate-600 text-slate-600 dark:text-slate-300 rounded-lg text-sm font-medium hover:bg-slate-50 dark:hover:bg-slate-700 transition-colors">Cancel</button>
-            <button onClick={handleSave} disabled={saving || !amount} className="flex-1 flex items-center justify-center gap-1.5 py-2 bg-indigo-600 hover:bg-indigo-700 disabled:opacity-40 text-white rounded-lg text-sm font-bold transition-colors">
+            <button
+              onClick={handleSave}
+              disabled={saving || !amount || blocked}
+              title={blocked
+                ? (noteRequired
+                    ? 'Add a note explaining this additional entry'
+                    : 'Confirm that this is an additional entry for the period')
+                : undefined}
+              className={`flex-1 flex items-center justify-center gap-1.5 py-2 disabled:opacity-40 text-white rounded-lg text-sm font-bold transition-colors ${
+                isDuplicate ? 'bg-amber-600 hover:bg-amber-700' : 'bg-indigo-600 hover:bg-indigo-700'
+              }`}
+            >
               {saving ? <Loader2 className="w-4 h-4 animate-spin" /> : <Plus className="w-4 h-4" />}
-              {saving ? 'Saving…' : 'Save Entry'}
+              {saving ? 'Saving…' : isDuplicate ? 'Add Anyway' : 'Save Entry'}
             </button>
           </div>
         </div>

--- a/components/CarbonWizard.tsx
+++ b/components/CarbonWizard.tsx
@@ -351,6 +351,8 @@ const Mission1Phase: React.FC<{
         source_id: source.id,
         period_start: periodStart,
         period_end: periodEnd,
+        // Annualised from a typical period, not a measurement for this year.
+        basis: 'estimate',
         activity_data: annualKWh,
         calculated_emissions_kgco2e: kgco2e,
         notes: `Wizard entry: ${period === 'monthly' ? `${kWh} kWh/month × 12` : `${kWh} kWh/year`}`,
@@ -595,6 +597,8 @@ const Scope1SourceForm: React.FC<{
         source_id: dbSource.id,
         period_start: periodStart,
         period_end: periodEnd,
+        // Annualised from a typical period, not a measurement for this year.
+        basis: 'estimate',
         activity_data: annual,
         calculated_emissions_kgco2e: kgco2e,
         notes: `Wizard entry — ${source.label}`,
@@ -752,6 +756,8 @@ const Mission3Phase: React.FC<{
         source_id: source.id,
         period_start: periodStart,
         period_end: periodEnd,
+        // Annualised from a typical period, not a measurement for this year.
+        basis: 'estimate',
         activity_data: val,
         calculated_emissions_kgco2e: kgco2e,
         notes: 'Wizard entry — Scope 3',

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev:netlify": "netlify dev",
     "build": "vite build",
     "test:security": "node --experimental-strip-types --test tests/security/*.test.mjs",
+    "test:unit": "node --experimental-strip-types --test tests/unit/*.test.mjs",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/services/carbonAggregation.ts
+++ b/services/carbonAggregation.ts
@@ -1,0 +1,113 @@
+/**
+ * carbonAggregation.ts
+ *
+ * Pure aggregation rules for emission entries, kept out of the dashboard
+ * component so they can be tested directly.
+ *
+ * The rule that matters: Carbon Quest writes one annualised `estimate` per
+ * source covering the whole year, while measured months arrive later as
+ * `actual`. Summing both double counts the year, and plotting an estimate
+ * against its start month invents a January spike. So an estimate counts only
+ * for a source with no measurement yet, and never appears in the trend.
+ */
+
+// Type-only: erased at runtime, so the module loads under node --test.
+import type { EmissionEntry, EmissionSource } from '../types';
+
+export const MONTH_LABELS = [
+  'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun',
+  'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec',
+];
+
+export interface MonthlyTrendPoint {
+  month: string;
+  scope1: number;
+  scope2: number;
+  scope3: number;
+  total: number;
+}
+
+/** Every entry whose period starts in the given year, regardless of basis. */
+export function entriesForYear(entries: EmissionEntry[], year: number): EmissionEntry[] {
+  return entries.filter(e => new Date(e.period_start).getFullYear() === year);
+}
+
+/**
+ * The entries that should contribute to a year's total: all measurements,
+ * plus an estimate only for a source that has none.
+ */
+export function countableForYear(entries: EmissionEntry[], year: number): EmissionEntry[] {
+  const inYear = entriesForYear(entries, year);
+  const measured = new Set(
+    inYear.filter(e => e.basis === 'actual').map(e => e.source_id),
+  );
+  return inYear.filter(e => e.basis === 'actual' || !measured.has(e.source_id));
+}
+
+/** Sources in the year whose figure is still an annualised estimate. */
+export function sourcesOnEstimate(entries: EmissionEntry[], year: number): Set<string> {
+  return new Set(
+    countableForYear(entries, year)
+      .filter(e => e.basis === 'estimate')
+      .map(e => e.source_id),
+  );
+}
+
+/** Totals in tonnes CO2e per scope, per month. Measurements only. */
+export function buildMonthlyTrend(
+  entries: EmissionEntry[],
+  sources: EmissionSource[],
+  year: number,
+): MonthlyTrendPoint[] {
+  const scopeOf = Object.fromEntries(sources.map(s => [s.id, s.scope]));
+
+  return MONTH_LABELS.map((label, monthIndex) => {
+    const monthEntries = entries.filter(e => {
+      const d = new Date(e.period_start);
+      return e.basis === 'actual'
+        && d.getFullYear() === year
+        && d.getMonth() === monthIndex;
+    });
+
+    const s: Record<string, number> = { '1': 0, '2': 0, '3': 0 };
+    for (const e of monthEntries) {
+      const scope = scopeOf[e.source_id] ?? '1';
+      s[scope] = (s[scope] ?? 0) + e.calculated_emissions_kgco2e / 1000;
+    }
+
+    return {
+      month: label,
+      scope1: Math.round(s['1'] * 100) / 100,
+      scope2: Math.round(s['2'] * 100) / 100,
+      scope3: Math.round(s['3'] * 100) / 100,
+      total: Math.round((s['1'] + s['2'] + s['3']) * 100) / 100,
+    };
+  });
+}
+
+/**
+ * Entries for the same source and basis whose period overlaps the one given.
+ *
+ * A second entry for a period is legitimate — a correction, an adjustment, a
+ * second invoice for one meter — so this exists to warn and to require an
+ * explanation, not to block.
+ */
+export function overlappingEntries(
+  entries: EmissionEntry[],
+  sourceId: string,
+  basis: EmissionEntry['basis'],
+  periodStart: string,
+  periodEnd: string,
+  excludeEntryId?: string,
+): EmissionEntry[] {
+  if (!periodStart || !periodEnd || periodStart > periodEnd) return [];
+
+  return entries.filter(e =>
+    e.source_id === sourceId
+    && e.basis === basis
+    && e.id !== excludeEntryId
+    // Inclusive ranges overlap unless one ends before the other starts.
+    && e.period_start <= periodEnd
+    && e.period_end >= periodStart,
+  );
+}

--- a/services/emissionFactorService.ts
+++ b/services/emissionFactorService.ts
@@ -11,7 +11,7 @@
  */
 
 import { supabase } from '../lib/supabaseClient';
-import { EmissionFactor, EmissionSource, EmissionEntry, EmissionScope } from '../types';
+import { EmissionFactor, EmissionSource, EmissionEntry, EmissionScope, EmissionBasis } from '../types';
 import { deleteEvidenceByEntity } from './evidenceService';
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -195,6 +195,7 @@ const fromDbEntry = (row: any): EmissionEntry => ({
   source_id: row.source_id,
   period_start: row.period_start,
   period_end: row.period_end,
+  basis: (row.basis === 'estimate' ? 'estimate' : 'actual') as EmissionBasis,
   activity_data: Number(row.activity_data),
   calculated_emissions_kgco2e: Number(row.calculated_emissions_kgco2e),
   notes: row.notes ?? null,
@@ -223,6 +224,8 @@ export async function upsertEmissionEntry(
     source_id: entry.source_id,
     period_start: entry.period_start,
     period_end: entry.period_end,
+    // Default to a measurement; only Carbon Quest records estimates.
+    basis: entry.basis ?? 'actual',
     activity_data: entry.activity_data,
     calculated_emissions_kgco2e: entry.calculated_emissions_kgco2e,
     notes: entry.notes ?? null,

--- a/supabase/migrations/029_emission_entry_basis.sql
+++ b/supabase/migrations/029_emission_entry_basis.sql
@@ -1,0 +1,81 @@
+-- ============================================================
+-- Migration 029 — estimated vs actual emission entries
+-- ============================================================
+-- Carbon Quest asks for a monthly average, multiplies it by twelve, and stores
+-- the result as one entry spanning 1 Jan – 31 Dec. The dashboard buckets the
+-- monthly trend by period_start, so that annualised figure lands entirely in
+-- January, and it is then summed alongside any real monthly entries the
+-- organization records afterwards — double counting the year.
+--
+-- The two are different kinds of number, so the table now says which is which:
+--
+--   estimate = an annualised figure derived from a typical period
+--   actual   = measured consumption for the period stated
+--
+-- Aggregation counts every actual, and counts an estimate only for a source
+-- that has no actuals in that year.
+--
+-- A second entry for the same period is legitimate — a correction, an
+-- adjustment, a second invoice for one meter — so it is allowed rather than
+-- blocked. What it must carry is an explanation: when an entry overlaps
+-- another for the same source and basis, a note becomes mandatory. The UI
+-- warns before saving; this trigger is what makes the rule hold for the
+-- spreadsheet importer and any future path too.
+--
+-- Rollback:
+--   DROP TRIGGER IF EXISTS emission_entries_require_note_on_overlap ON public.emission_entries;
+--   DROP FUNCTION IF EXISTS public.require_note_on_overlapping_entry();
+--   ALTER TABLE public.emission_entries DROP COLUMN IF EXISTS basis;
+-- ============================================================
+
+ALTER TABLE public.emission_entries
+  ADD COLUMN IF NOT EXISTS basis text NOT NULL DEFAULT 'actual';
+
+ALTER TABLE public.emission_entries
+  DROP CONSTRAINT IF EXISTS emission_entries_basis_check;
+ALTER TABLE public.emission_entries
+  ADD CONSTRAINT emission_entries_basis_check
+  CHECK (basis IN ('estimate', 'actual'));
+
+-- Existing wizard rows span a full year; genuine measurements never do.
+UPDATE public.emission_entries
+SET basis = 'estimate'
+WHERE period_end - period_start >= 180;
+
+-- An overlapping entry is allowed, but it has to say why.
+CREATE OR REPLACE FUNCTION public.require_note_on_overlapping_entry()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF coalesce(btrim(NEW.notes), '') = '' AND EXISTS (
+    SELECT 1
+    FROM public.emission_entries existing
+    WHERE existing.source_id = NEW.source_id
+      AND existing.basis     = NEW.basis
+      AND existing.id       <> NEW.id
+      AND daterange(existing.period_start, existing.period_end, '[]')
+       && daterange(NEW.period_start, NEW.period_end, '[]')
+  ) THEN
+    RAISE EXCEPTION
+      'Another entry already covers this period for this source. Add a note explaining why this one exists (for example: correction, adjustment, second invoice).'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS emission_entries_require_note_on_overlap ON public.emission_entries;
+CREATE TRIGGER emission_entries_require_note_on_overlap
+  BEFORE INSERT OR UPDATE ON public.emission_entries
+  FOR EACH ROW
+  EXECUTE FUNCTION public.require_note_on_overlapping_entry();
+
+-- Existing overlapping rows are left as they are: this rule governs what is
+-- written from here on, and is not a reason to reject history.
+ALTER TABLE public.emission_entries
+  DROP CONSTRAINT IF EXISTS emission_entries_no_overlap;
+
+COMMENT ON COLUMN public.emission_entries.basis
+  IS 'estimate = annualised from a typical period (Carbon Quest); actual = measured for the stated period. An estimate counts only for a source with no actuals that year.';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -629,6 +629,51 @@ CREATE TABLE emission_entries (
   updated_at                  timestamptz NOT NULL DEFAULT now()
 );
 
+-- Migration 029: an estimate is an annualised figure from Carbon Quest; an
+-- actual is measured consumption for the stated period. Aggregation counts an
+-- estimate only for a source with no actuals that year.
+ALTER TABLE emission_entries
+  ADD COLUMN IF NOT EXISTS basis text NOT NULL DEFAULT 'actual';
+
+ALTER TABLE emission_entries
+  ADD CONSTRAINT emission_entries_basis_check
+  CHECK (basis IN ('estimate', 'actual'));
+
+-- A second entry for the same period is legitimate — a correction, an
+-- adjustment, a second invoice for one meter — so it is allowed. What it must
+-- carry is an explanation. The UI warns first; this trigger is what makes the
+-- rule hold for the spreadsheet importer and any future path.
+CREATE OR REPLACE FUNCTION public.require_note_on_overlapping_entry()
+RETURNS trigger
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF coalesce(btrim(NEW.notes), '') = '' AND EXISTS (
+    SELECT 1
+    FROM public.emission_entries existing
+    WHERE existing.source_id = NEW.source_id
+      AND existing.basis     = NEW.basis
+      AND existing.id       <> NEW.id
+      AND daterange(existing.period_start, existing.period_end, '[]')
+       && daterange(NEW.period_start, NEW.period_end, '[]')
+  ) THEN
+    RAISE EXCEPTION
+      'Another entry already covers this period for this source. Add a note explaining why this one exists (for example: correction, adjustment, second invoice).'
+      USING ERRCODE = 'check_violation';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+CREATE TRIGGER emission_entries_require_note_on_overlap
+  BEFORE INSERT OR UPDATE ON emission_entries
+  FOR EACH ROW
+  EXECUTE FUNCTION public.require_note_on_overlapping_entry();
+
+COMMENT ON COLUMN emission_entries.basis
+  IS 'estimate = annualised from a typical period (Carbon Quest); actual = measured for the stated period.';
+
 CREATE INDEX idx_emission_entries_org_period ON emission_entries (organization_id, period_start DESC);
 CREATE INDEX idx_emission_entries_source     ON emission_entries (source_id, period_start DESC);
 

--- a/tests/unit/carbon-aggregation.test.mjs
+++ b/tests/unit/carbon-aggregation.test.mjs
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildMonthlyTrend,
+  countableForYear,
+  sourcesOnEstimate,
+} from "../../services/carbonAggregation.ts";
+
+const SOURCES = [
+  { id: "elec", scope: "2" },
+  { id: "fleet", scope: "1" },
+];
+
+const entry = (source_id, basis, period_start, period_end, kg) => ({
+  id: `${source_id}-${period_start}-${basis}`,
+  organization_id: "org",
+  source_id,
+  basis,
+  period_start,
+  period_end,
+  activity_data: kg,
+  calculated_emissions_kgco2e: kg,
+  notes: null,
+  created_by: null,
+  created_at: period_start,
+  updated_at: period_start,
+});
+
+const total = (entries) =>
+  entries.reduce((sum, e) => sum + e.calculated_emissions_kgco2e, 0);
+
+test("a Carbon Quest estimate counts when nothing has been measured", () => {
+  const entries = [entry("elec", "estimate", "2026-01-01", "2026-12-31", 12_000)];
+
+  assert.equal(total(countableForYear(entries, 2026)), 12_000);
+  assert.deepEqual([...sourcesOnEstimate(entries, 2026)], ["elec"]);
+});
+
+test("measurements replace the estimate for that source instead of adding to it", () => {
+  // The regression: the wizard's annualised 12 000 plus twelve real months
+  // used to total 24 000 for a company that emitted 12 000.
+  const entries = [
+    entry("elec", "estimate", "2026-01-01", "2026-12-31", 12_000),
+    ...Array.from({ length: 12 }, (_, m) => {
+      const mm = String(m + 1).padStart(2, "0");
+      const last = new Date(2026, m + 1, 0).getDate();
+      return entry("elec", "actual", `2026-${mm}-01`, `2026-${mm}-${last}`, 1_000);
+    }),
+  ];
+
+  assert.equal(total(countableForYear(entries, 2026)), 12_000, "not 24 000");
+  assert.equal(sourcesOnEstimate(entries, 2026).size, 0);
+});
+
+test("a partly measured year keeps the estimate only for untouched sources", () => {
+  const entries = [
+    entry("elec", "estimate", "2026-01-01", "2026-12-31", 12_000),
+    entry("fleet", "estimate", "2026-01-01", "2026-12-31", 6_000),
+    entry("elec", "actual", "2026-01-01", "2026-01-31", 900),
+  ];
+
+  // Measured electricity (900) + still-estimated fleet (6 000).
+  assert.equal(total(countableForYear(entries, 2026)), 6_900);
+  assert.deepEqual([...sourcesOnEstimate(entries, 2026)], ["fleet"]);
+});
+
+test("the monthly trend never plots an estimate as a January spike", () => {
+  const entries = [
+    entry("elec", "estimate", "2026-01-01", "2026-12-31", 12_000),
+    entry("elec", "actual", "2026-03-01", "2026-03-31", 1_000),
+  ];
+
+  const trend = buildMonthlyTrend(entries, SOURCES, 2026);
+  const january = trend.find(p => p.month === "Jan");
+  const march = trend.find(p => p.month === "Mar");
+
+  assert.equal(january.total, 0, "the annualised figure must not land in January");
+  assert.equal(march.scope2, 1, "1 000 kg renders as 1 tonne in March");
+  assert.equal(trend.reduce((s, p) => s + p.total, 0), 1);
+});
+
+test("entries are scoped to their own year", () => {
+  const entries = [
+    entry("elec", "actual", "2025-12-01", "2025-12-31", 500),
+    entry("elec", "actual", "2026-01-01", "2026-01-31", 700),
+  ];
+
+  assert.equal(total(countableForYear(entries, 2026)), 700);
+  assert.equal(total(countableForYear(entries, 2025)), 500);
+});
+
+test("an overlapping entry is detected so the user can be warned, not blocked", async () => {
+  const { overlappingEntries } = await import("../../services/carbonAggregation.ts");
+
+  const feb = entry("elec", "actual", "2026-02-01", "2026-02-28", 900);
+  const mar = entry("elec", "actual", "2026-03-01", "2026-03-31", 800);
+  const febEstimate = entry("elec", "estimate", "2026-02-01", "2026-02-28", 950);
+  const otherSource = entry("fleet", "actual", "2026-02-01", "2026-02-28", 400);
+  const entries = [feb, mar, febEstimate, otherSource];
+
+  // Same source, same basis, overlapping period.
+  assert.deepEqual(
+    overlappingEntries(entries, "elec", "actual", "2026-02-10", "2026-02-20").map(e => e.id),
+    [feb.id],
+  );
+
+  // A different basis or a different source is not a duplicate.
+  assert.equal(overlappingEntries(entries, "elec", "actual", "2026-04-01", "2026-04-30").length, 0);
+  assert.equal(overlappingEntries(entries, "fleet", "actual", "2026-03-01", "2026-03-31").length, 0);
+
+  // A period spanning both months overlaps both of that source's actuals.
+  assert.equal(
+    overlappingEntries(entries, "elec", "actual", "2026-02-15", "2026-03-15").length,
+    2,
+  );
+
+  // Editing an entry must not flag it against itself.
+  assert.equal(
+    overlappingEntries(entries, "elec", "actual", "2026-02-01", "2026-02-28", feb.id).length,
+    0,
+  );
+
+  // Adjacent periods do not overlap.
+  assert.equal(overlappingEntries([feb], "elec", "actual", "2026-03-01", "2026-03-31").length, 0);
+});

--- a/types.ts
+++ b/types.ts
@@ -249,12 +249,20 @@ export interface EmissionSource {
   asset_number?: string | null;
 }
 
+/**
+ * How a figure was arrived at. An `estimate` is annualised from a typical
+ * period (what Carbon Quest produces); an `actual` is measured consumption for
+ * the period stated.
+ */
+export type EmissionBasis = 'estimate' | 'actual';
+
 export interface EmissionEntry {
   id: string;
   organization_id: string;
   source_id: string;
   period_start: string;
   period_end: string;
+  basis: EmissionBasis;
   activity_data: number;
   calculated_emissions_kgco2e: number;
   notes: string | null;


### PR DESCRIPTION
Second carbon-integrity fix. **Reshaped after your feedback:** a duplicate in a period is now warned about and explained, not blocked.

## The bug

`CarbonWizard.tsx:329,348` takes a monthly average, **multiplies it by twelve**, and writes one entry spanning `1 Jan – 31 Dec`. `CarbonDashboard.tsx` bucketed the monthly trend by `period_start`.

1. **A January spike that never happened** — every organisation onboarded through Carbon Quest saw one enormous January bar and eleven empty months.
2. **Silent double counting** — Quick Add writes real month ranges, and the annualised estimate was summed alongside them. A company emitting 12 t/year that logged every month reported **24 t**, and the more carefully they used the product the more wrong it got.

## The fix

Entries now say which kind of number they are:

| basis | meaning |
|---|---|
| `estimate` | annualised from a typical period — what Carbon Quest produces |
| `actual` | measured consumption for the period stated |

**The rule:** count every actual, and count an estimate only for a source with no measurement that year. Recording a month therefore *replaces* the estimate for that source instead of adding to it. The trend plots actuals only.

## Duplicates: warn and require a reason, don't block

My first version added an exclusion constraint that made a second entry per period impossible. That was wrong — corrections, adjustments and a second invoice for one meter are all legitimate. Your call, and it's the better design.

So now:

- **Quick Add detects an overlapping entry** for the same source and basis, and shows what already covers the period, with amounts and notes.
- **The user confirms explicitly** — a checkbox saying "add this as an additional entry", and the button changes to *Add Anyway*.
- **A note becomes mandatory** for that entry, with placeholder text prompting the reason (correction, second invoice).
- **A database trigger enforces the note requirement**, so the rule also holds for the spreadsheet importer and any path added later — not just the screen where it was implemented. Existing overlapping rows are left alone; this governs new writes.

The dashboard also states how many sources are still estimates, turning the caveat into the "replace estimates with measurements" progress signal Carbon Quest is reaching for.

## Applying migration 029

The earlier version failed on real data — two `actual` entries covering February 2026 for one source. **That is no longer a blocker:** existing overlaps are untouched and the migration applies cleanly. Whether those two February rows are a mis-click or two genuine invoices is now a data question you can settle in the UI, not something the migration decides for you.

## A note on scope

The aggregation and overlap rules live in `services/carbonAggregation.ts` so they can be tested at all — arithmetic buried in a `.tsx` can only be verified by grepping source, which is exactly the trap that let an earlier fix land in an unmounted file. That needed somewhere to put a non-security test, so this PR also adds `tests/unit/` with an npm script and a CI step: the first coverage of the calculations the product exists to produce.

## Verification

```
npm run test:unit       # 6 pass (new)
npm run test:security   # 142 pass
npx tsc --noEmit         # clean
npm run build            # clean
```

The unit tests encode the regressions directly: an estimate plus twelve measured months totals 12 000 rather than 24 000; the trend's January bucket is 0 when an annual estimate exists; and overlap detection ignores a different basis, a different source, an adjacent period, and the entry being edited itself.

Not visually verified — the carbon screens need data behind a login. Worth a deploy-preview pass: a wizard run, a quick-add, then a second quick-add for the same month to see the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)