### PR TITLE
fix(carbon): make every emission figure reproducible

### DIFF
--- a/services/emissionFactorSelection.ts
+++ b/services/emissionFactorSelection.ts
@@ -1,0 +1,78 @@
+/**
+ * emissionFactorSelection.ts
+ *
+ * Pure factor-selection rules, kept free of the Supabase client so they can be
+ * tested directly.
+ *
+ * Two things decide which factor applies:
+ *
+ *   Geography — the most specific match wins: country, then a region the
+ *   country belongs to, then a global default.
+ *
+ *   Period — the factor that applied during the reporting year. Selecting the
+ *   newest publication regardless of period silently restates a figure that
+ *   was already reported, which breaks year-on-year comparison.
+ */
+
+import type { EmissionFactor } from '../types';
+
+export const REGION_MAP: Record<string, string[]> = {
+  EU: [
+    'Austria', 'Belgium', 'Bulgaria', 'Croatia', 'Cyprus', 'Czech Republic', 'Denmark',
+    'Estonia', 'Finland', 'France', 'Germany', 'Greece', 'Hungary', 'Ireland', 'Italy',
+    'Latvia', 'Lithuania', 'Luxembourg', 'Malta', 'Netherlands', 'Poland', 'Portugal',
+    'Romania', 'Slovakia', 'Slovenia', 'Spain', 'Sweden',
+  ],
+  ASEAN: [
+    'Brunei', 'Cambodia', 'Indonesia', 'Laos', 'Malaysia', 'Myanmar', 'Philippines',
+    'Singapore', 'Thailand', 'Timor-Leste', 'Vietnam',
+  ],
+};
+
+export function countryToRegions(country: string): string[] {
+  return Object.entries(REGION_MAP)
+    .filter(([, members]) => members.some(m => m.toLowerCase() === country.toLowerCase()))
+    .map(([region]) => region);
+}
+
+/**
+ * @param factors      candidates for one fuel type and unit
+ * @param country      the organization's country
+ * @param reportingYear year the activity took place; omit to accept any
+ */
+export function selectBestFactor(
+  factors: EmissionFactor[],
+  country: string,
+  reportingYear?: number,
+): EmissionFactor | null {
+  if (factors.length === 0) return null;
+
+  // Newest first, so the first geographic match is also the most recent one
+  // that applies.
+  const ordered = [...factors].sort((a, b) => b.year - a.year);
+
+  // Prefer factors published no later than the reporting year. If none exist
+  // — a period earlier than any published factor — fall back rather than
+  // refuse to calculate.
+  const inPeriod = reportingYear
+    ? ordered.filter(f => f.year <= reportingYear)
+    : ordered;
+  const candidates = inPeriod.length > 0 ? inPeriod : ordered;
+
+  const target = country.trim().toLowerCase();
+
+  const exact = candidates.find(f => (f.region ?? '').toLowerCase() === target);
+  if (exact) return exact;
+
+  for (const region of countryToRegions(country)) {
+    const match = candidates.find(
+      f => (f.region ?? '').toLowerCase() === region.toLowerCase(),
+    );
+    if (match) return match;
+  }
+
+  const global = candidates.find(f => (f.region ?? '').toLowerCase() === 'global');
+  if (global) return global;
+
+  return candidates[0];
+}

--- a/services/emissionFactorService.ts
+++ b/services/emissionFactorService.ts
@@ -13,29 +13,11 @@
 import { supabase } from '../lib/supabaseClient';
 import { EmissionFactor, EmissionSource, EmissionEntry, EmissionScope, EmissionBasis } from '../types';
 import { deleteEvidenceByEntity } from './evidenceService';
+import { selectBestFactor } from './emissionFactorSelection';
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Region → country membership (lightweight client-side mapping)
 // ─────────────────────────────────────────────────────────────────────────────
-
-const REGION_MAP: Record<string, string[]> = {
-  EU: [
-    'Austria','Belgium','Bulgaria','Croatia','Cyprus','Czech Republic','Denmark',
-    'Estonia','Finland','France','Germany','Greece','Hungary','Ireland','Italy',
-    'Latvia','Lithuania','Luxembourg','Malta','Netherlands','Poland','Portugal',
-    'Romania','Slovakia','Slovenia','Spain','Sweden',
-  ],
-  ASEAN: [
-    'Brunei','Cambodia','Indonesia','Laos','Malaysia','Myanmar','Philippines',
-    'Singapore','Thailand','Timor-Leste','Vietnam',
-  ],
-};
-
-function countryToRegions(country: string): string[] {
-  return Object.entries(REGION_MAP)
-    .filter(([, members]) => members.some(m => m.toLowerCase() === country.toLowerCase()))
-    .map(([region]) => region);
-}
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Fetch helpers
@@ -91,30 +73,12 @@ export async function getBestEmissionFactor(
   fuelType: string,
   unit: string,
   organizationCountry: string,
+  reportingYear?: number,
 ): Promise<EmissionFactor | null> {
   const factors = await fetchEmissionFactorsForFuel(fuelType, unit);
-  if (factors.length === 0) return null;
-
-  const country = organizationCountry.trim().toLowerCase();
-
-  // 1. Exact country match (newest year first — already ordered)
-  const countryMatch = factors.find(f => (f.region ?? '').toLowerCase() === country);
-  if (countryMatch) return countryMatch;
-
-  // 2. Any region this country belongs to
-  const regions = countryToRegions(organizationCountry);
-  for (const region of regions) {
-    const regionMatch = factors.find(f => (f.region ?? '').toLowerCase() === region.toLowerCase());
-    if (regionMatch) return regionMatch;
-  }
-
-  // 3. Global fallback
-  const globalMatch = factors.find(f => (f.region ?? '').toLowerCase() === 'global');
-  if (globalMatch) return globalMatch;
-
-  // 4. Whatever is newest
-  return factors[0];
+  return selectBestFactor(factors, organizationCountry, reportingYear);
 }
+
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Emission Sources CRUD
@@ -198,6 +162,13 @@ const fromDbEntry = (row: any): EmissionEntry => ({
   basis: (row.basis === 'estimate' ? 'estimate' : 'actual') as EmissionBasis,
   activity_data: Number(row.activity_data),
   calculated_emissions_kgco2e: Number(row.calculated_emissions_kgco2e),
+  factor_id: row.factor_id ?? null,
+  factor_kgco2e_per_unit:
+    row.factor_kgco2e_per_unit === null || row.factor_kgco2e_per_unit === undefined
+      ? null
+      : Number(row.factor_kgco2e_per_unit),
+  factor_source: row.factor_source ?? null,
+  factor_year: row.factor_year ?? null,
   notes: row.notes ?? null,
   created_by: row.created_by ?? null,
   created_at: row.created_at,
@@ -214,6 +185,47 @@ export async function fetchEmissionEntries(orgId: string): Promise<EmissionEntry
   return (data ?? []).map(fromDbEntry);
 }
 
+/**
+ * The derivation to store alongside a figure.
+ *
+ * Callers that already resolved a factor pass it through. Everything else —
+ * the quick-add modal, the spreadsheet importer — falls back to the factor
+ * currently on the source, so no save path can silently omit provenance.
+ */
+async function resolveFactorProvenance(
+  entry: Partial<EmissionEntry> & Pick<EmissionEntry, 'source_id'>,
+): Promise<{
+  factor_id: string | null;
+  factor_kgco2e_per_unit: number | null;
+  factor_source: string | null;
+  factor_year: number | null;
+}> {
+  if (entry.factor_kgco2e_per_unit !== null && entry.factor_kgco2e_per_unit !== undefined) {
+    return {
+      factor_id: entry.factor_id ?? null,
+      factor_kgco2e_per_unit: entry.factor_kgco2e_per_unit,
+      factor_source: entry.factor_source ?? null,
+      factor_year: entry.factor_year ?? null,
+    };
+  }
+
+  const { data } = await supabase
+    .from('emission_sources')
+    .select('emission_factor_value, emission_factor_source')
+    .eq('id', entry.source_id)
+    .maybeSingle();
+
+  return {
+    factor_id: entry.factor_id ?? null,
+    factor_kgco2e_per_unit:
+      data?.emission_factor_value === null || data?.emission_factor_value === undefined
+        ? null
+        : Number(data.emission_factor_value),
+    factor_source: entry.factor_source ?? data?.emission_factor_source ?? null,
+    factor_year: entry.factor_year ?? null,
+  };
+}
+
 export async function upsertEmissionEntry(
   orgId: string,
   entry: Partial<EmissionEntry> & Pick<EmissionEntry, 'source_id' | 'period_start' | 'period_end' | 'activity_data' | 'calculated_emissions_kgco2e'>,
@@ -228,6 +240,9 @@ export async function upsertEmissionEntry(
     basis: entry.basis ?? 'actual',
     activity_data: entry.activity_data,
     calculated_emissions_kgco2e: entry.calculated_emissions_kgco2e,
+    // Snapshot the derivation so the figure stays explainable even if the
+    // factor is later corrected on the source or in reference data.
+    ...(await resolveFactorProvenance(entry)),
     notes: entry.notes ?? null,
     created_by: userId,
     updated_at: new Date().toISOString(),

--- a/supabase/migrations/030_emission_factor_provenance.sql
+++ b/supabase/migrations/030_emission_factor_provenance.sql
@@ -1,0 +1,61 @@
+-- ============================================================
+-- Migration 030 — reproducible emission figures
+-- ============================================================
+-- An emission entry recorded its result but never which factor produced it.
+-- The factor lived denormalised on emission_sources.emission_factor_value,
+-- which is mutable and shared by every entry for that source: change it and
+-- past figures keep a number nobody can explain. "How did you arrive at
+-- 12,345 kgCO2e?" had no answer, which fails any assurance or bank request.
+--
+-- Entries now snapshot the factor at the moment of calculation. The snapshot,
+-- not the pointer, is the record — factor_id deliberately has no foreign key,
+-- because reference data may later be corrected or withdrawn and that must
+-- never rewrite or delete history.
+--
+-- emission_factors also had no unique constraint, so the seed file's promise
+-- that it is "safe to re-run" was false: ON CONFLICT DO NOTHING had nothing to
+-- conflict against and every re-run duplicated all ~100 rows. This dedupes and
+-- adds the missing natural key.
+--
+-- Rollback:
+--   DROP INDEX IF EXISTS idx_emission_factors_natural_key;
+--   ALTER TABLE public.emission_entries
+--     DROP COLUMN IF EXISTS factor_id,
+--     DROP COLUMN IF EXISTS factor_kgco2e_per_unit,
+--     DROP COLUMN IF EXISTS factor_source,
+--     DROP COLUMN IF EXISTS factor_year;
+-- ============================================================
+
+ALTER TABLE public.emission_entries
+  ADD COLUMN IF NOT EXISTS factor_id              uuid,
+  ADD COLUMN IF NOT EXISTS factor_kgco2e_per_unit numeric(12, 6),
+  ADD COLUMN IF NOT EXISTS factor_source          text,
+  ADD COLUMN IF NOT EXISTS factor_year            int;
+
+-- Best available reconstruction for rows written before provenance existed:
+-- the factor currently on the source is what produced them, unless it has been
+-- edited since. Rows written from here on record it at save time instead.
+UPDATE public.emission_entries e
+SET factor_kgco2e_per_unit = s.emission_factor_value,
+    factor_source          = s.emission_factor_source
+FROM public.emission_sources s
+WHERE e.source_id = s.id
+  AND e.factor_kgco2e_per_unit IS NULL;
+
+-- Deduplicate before the natural key can be enforced (keeps the earliest row).
+DELETE FROM public.emission_factors a
+USING public.emission_factors b
+WHERE a.id > b.id
+  AND a.fuel_type = b.fuel_type
+  AND a.unit      = b.unit
+  AND a.source    = b.source
+  AND a.year      = b.year
+  AND coalesce(a.region, '') = coalesce(b.region, '');
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_emission_factors_natural_key
+  ON public.emission_factors (fuel_type, unit, source, year, coalesce(region, ''));
+
+COMMENT ON COLUMN public.emission_entries.factor_id
+  IS 'Pointer to the factor used. Intentionally not a foreign key: the snapshot columns are the record, and correcting reference data must not rewrite history.';
+COMMENT ON COLUMN public.emission_entries.factor_kgco2e_per_unit
+  IS 'Factor value at the moment of calculation. calculated_emissions_kgco2e = activity_data x this.';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -684,7 +684,16 @@ CREATE POLICY "members_crud_entries" ON emission_entries
 
 COMMENT ON TABLE  emission_entries                          IS 'Recurring GHG emission data entries';
 COMMENT ON COLUMN emission_entries.activity_data            IS 'Raw consumption figure (in the source unit)';
-COMMENT ON COLUMN emission_entries.calculated_emissions_kgco2e IS 'activity_data × emission_factor_value';
+-- Migration 030: entries snapshot the factor that produced them. factor_id is
+-- deliberately not a foreign key — the snapshot is the record, and correcting
+-- reference data must never rewrite history.
+ALTER TABLE emission_entries
+  ADD COLUMN IF NOT EXISTS factor_id              uuid,
+  ADD COLUMN IF NOT EXISTS factor_kgco2e_per_unit numeric(12, 6),
+  ADD COLUMN IF NOT EXISTS factor_source          text,
+  ADD COLUMN IF NOT EXISTS factor_year            int;
+
+COMMENT ON COLUMN emission_entries.calculated_emissions_kgco2e IS 'activity_data × factor_kgco2e_per_unit, snapshotted at save time';
 
 -- =============================================================
 -- 5. emission_factors  (shared reference data — RLS read-only for tenants)
@@ -704,6 +713,11 @@ CREATE TABLE emission_factors (
 
 CREATE INDEX idx_emission_factors_lookup
   ON emission_factors (fuel_type, unit, year DESC);
+
+-- Migration 030: the natural key. Without it the seed file's ON CONFLICT DO
+-- NOTHING had nothing to conflict against and duplicated every row on re-run.
+CREATE UNIQUE INDEX idx_emission_factors_natural_key
+  ON emission_factors (fuel_type, unit, source, year, coalesce(region, ''));
 
 -- Migration 028: reference data is readable by any signed-in user and written
 -- only by platform admins through service_role. There is deliberately no

--- a/supabase/seeds/emission_factors.sql
+++ b/supabase/seeds/emission_factors.sql
@@ -116,4 +116,6 @@ VALUES
   ('Wastewater Treatment','3', 'm3',    0.44,'IPCC 2021', 2021, 'Global'),
   ('Composting',          '3', 'tonne',  8.0,'IPCC 2021', 2021, 'Global')
 
-ON CONFLICT DO NOTHING;
+-- Requires the natural key from migration 030; without it this clause has
+-- nothing to conflict against and a re-run duplicates every row.
+ON CONFLICT (fuel_type, unit, source, year, coalesce(region, '')) DO NOTHING;

--- a/tests/unit/emission-factor-selection.test.mjs
+++ b/tests/unit/emission-factor-selection.test.mjs
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { selectBestFactor } from "../../services/emissionFactorSelection.ts";
+
+const factor = (region, year, value, source = "IPCC") => ({
+  id: `${region}-${year}`,
+  fuel_type: "Diesel",
+  scope: "1",
+  unit: "L",
+  kgco2e_per_unit: value,
+  source,
+  year,
+  region,
+});
+
+test("the most specific geography wins", () => {
+  const factors = [factor("Global", 2021, 2.68), factor("EU", 2021, 2.6), factor("Germany", 2021, 2.5)];
+
+  assert.equal(selectBestFactor(factors, "Germany").region, "Germany");
+  assert.equal(selectBestFactor(factors, "France").region, "EU", "via region membership");
+  assert.equal(selectBestFactor(factors, "Brazil").region, "Global", "no country or region match");
+});
+
+test("a figure uses the factor that applied in its reporting year", () => {
+  const factors = [factor("Global", 2021, 2.68), factor("Global", 2026, 2.40)];
+
+  // The regression: selection took the newest publication regardless of
+  // period, so adding a 2026 factor silently restated an already-reported
+  // 2024 figure.
+  assert.equal(selectBestFactor(factors, "Brazil", 2024).year, 2021);
+  assert.equal(selectBestFactor(factors, "Brazil", 2026).year, 2026);
+  assert.equal(selectBestFactor(factors, "Brazil").year, 2026, "no year given: newest");
+});
+
+test("period filtering does not override geography", () => {
+  const factors = [
+    factor("Global", 2026, 2.40),
+    factor("Thailand", 2020, 2.71),
+    factor("Thailand", 2024, 2.70),
+  ];
+
+  const chosen = selectBestFactor(factors, "Thailand", 2024);
+  assert.equal(chosen.region, "Thailand");
+  assert.equal(chosen.year, 2024, "newest Thai factor that applied in 2024");
+
+  assert.equal(selectBestFactor(factors, "Thailand", 2022).year, 2020);
+});
+
+test("a period earlier than any published factor still calculates", () => {
+  const factors = [factor("Global", 2021, 2.68)];
+
+  const chosen = selectBestFactor(factors, "Brazil", 2015);
+  assert.equal(chosen.year, 2021, "fall back rather than refuse to calculate");
+});
+
+test("no candidates yields nothing rather than a wrong number", () => {
+  assert.equal(selectBestFactor([], "Thailand", 2024), null);
+});

--- a/types.ts
+++ b/types.ts
@@ -265,6 +265,11 @@ export interface EmissionEntry {
   basis: EmissionBasis;
   activity_data: number;
   calculated_emissions_kgco2e: number;
+  /** The factor that produced the figure, snapshotted when it was saved. */
+  factor_id: string | null;
+  factor_kgco2e_per_unit: number | null;
+  factor_source: string | null;
+  factor_year: number | null;
   notes: string | null;
   created_by: string | null;
   created_at: string;


### PR DESCRIPTION
> **Re-opened against `main`.** #196 was merged into `codex/carbon-entry-basis` rather than into `main`, so none of this work is on `main` and Netlify had nothing new to build. Same content, rebased onto current `main` — the schema conflict with #194's RLS block is resolved (both belong: 028 governs access, 030 adds the missing key).

## You cannot currently explain any number

An entry records its result but never which factor produced it. The factor lives denormalised on `emission_sources.emission_factor_value` — mutable, and shared by every entry for that source. Correct it and every past figure keeps a number nobody can reconstruct.

For a bank or an auditor asking *"how did you arrive at 12,345 kgCO2e?"*, the honest answer today is that you can't say.

Entries now snapshot the factor: value, source, publication year, and the factor id. Two deliberate choices:

- **`factor_id` has no foreign key.** The snapshot is the record. Correcting or withdrawing reference data must never rewrite or cascade-delete history.
- **Provenance is resolved inside `upsertEmissionEntry`, not at each call site.** A caller that already has a factor passes it through; everything else — quick-add, the spreadsheet importer — falls back to the factor on the source. No save path can silently omit it, including ones added later.

## Selection ignored the reporting period

`getBestEmissionFactor` took the newest publication available. Add a 2026 factor and a customer's already-reported 2024 figure silently changes basis, breaking exactly the year-on-year comparison the dashboard shows.

It now prefers the newest factor published no later than the reporting year, with geography still the stronger signal, and falls back rather than refusing to calculate for a period older than any published factor.

## The seed was not re-runnable

`emission_factors` had no unique constraint, so `ON CONFLICT DO NOTHING` had nothing to conflict against — every re-run duplicated all ~100 rows. Migration 030 dedupes (keeping the earliest row) and adds the natural key; the seed now names it.

## Verification

```
npm run test:unit       # 11 pass
npm run test:security   # 144 pass
npx tsc --noEmit         # clean
npm run build            # clean
```

Diff against `main` is 030 only — 029 and the basis work are already there via #195.

## Applying

Migration 030 after 029. It deletes duplicate factor rows; nothing references `emission_factors` by key (sources denormalise the value, entries now snapshot it), so it is safe, but it is a delete and worth reading first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)