### PR TITLE
fix(ai): stop SBMC suggestions completing the canvas from industry norms

### DIFF
--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -424,7 +424,7 @@ const SBMC_BLOCK_DEFINITIONS: Record<SBMCBlockLabel, string> = {
   "Channels": "The routes and touchpoints through which the company reaches customer segments for awareness, sales, delivery, service, or communication. Do not include relationship styles, customer types, or partner organizations unless they are explicitly a route to market.",
   "Customer Segments": "The distinct groups of customers, users, beneficiaries, or buyers the company serves or intends to serve. Do not include channels, relationships, partners, or generic stakeholder categories without support from the company context.",
   "Cost Structure": "The main economic cost drivers and operating expenses required to run the business model. Do not include environmental or social externalities here unless they are also explicit financial costs.",
-  "Revenue Streams": "The ways the company earns or could earn money from customers for delivered value, such as subscriptions, usage fees, licensing, services, or transactions. Do not invent monetization models unsupported by the company context.",
+  "Revenue Streams": "How the company earns money from customers for delivered value. Do not list costs, channels, or customer segments. Do not introduce a monetization model that the supplied context does not evidence.",
   "Eco-Social Costs": "Credible actual or potential negative environmental or social externalities arising from the company's technology, activities, operations, or business relationships. Do not confuse ordinary operating expenses with eco-social externalities.",
   "Eco-Social Benefits": "Positive environmental or social outcomes the company's products, services, or business model can support or enable. Do not guarantee outcomes, invent impacts, or imply unsupported causality.",
 };
@@ -487,19 +487,37 @@ function buildCanvasSuggestionPrompt(profile: any, fieldLabel: unknown, bmcData:
     Existing items in the requested block:
     ${currentBlockItems.length ? currentBlockItems.map(item => `- ${item}`).join("\n") : "- (empty)"}
 
-    Task:
-    Suggest concise content for the requested SBMC block only.
+    The definition above describes the boundary of the block — what belongs in it
+    rather than another block. It is not a checklist of categories to fill, and
+    naming a category there is not a reason to produce an item for it.
 
-    Grounding and classification rules:
+    Task:
+    Work from what is already known about this company. In order of preference:
+    1. Improve, clarify, or consolidate existing items in the requested block.
+    2. Identify elements that are missing but follow from the supplied company
+       context or from content already present elsewhere in the canvas.
+    Do not complete the block by adding what a company of this type would
+    typically have.
+
+    Grounding rules:
     - Treat only explicitly supplied company information and current canvas content as factual context.
+    - Plausibility is not evidence. That something is common among SaaS companies,
+      sustainability platforms, ESG consultancies, or technology companies is not a
+      reason to include it in this company's canvas.
     - Do not assume common industry practices, partnerships, channels, capabilities, customers, revenue models, teams, certifications, or operational practices already exist.
-    - Strategic possibilities may be suggested, but they must not be worded as established facts when unsupported.
+    - Before returning an item, ask whether it requires assuming a new capability,
+      team, partnership, customer relationship, channel, revenue model, asset,
+      proprietary technology, certification, intellectual property, data-usage
+      practice, or business activity. If that assumption is not supported by the
+      supplied company context or current canvas, do not return it.
     - Apply the requested SBMC block definition strictly.
     - Do not suggest an item if it primarily belongs to another SBMC block.
     - Avoid duplicate or semantically overlapping suggestions already present anywhere in the current canvas.
     - Avoid contradictions with existing canvas content.
-    - Prefer company-specific strategic suggestions over generic SaaS or sustainability-business statements.
-    - Prefer fewer high-quality suggestions rather than filling the block artificially.
+    - Prefer company-specific suggestions over generic SaaS or sustainability-business statements.
+    - Returning one or two well-grounded items, or none at all, is the correct
+      outcome when the supplied context supports no more. A short list is not a
+      failure; an unsupported list is.
 
     Sustainability claim guardrails:
     - For Eco-Social Benefits, describe outcomes the company can support or enable.
@@ -735,6 +753,9 @@ ${(qualityCheckContext.issues as any[]).map((i: any) =>
   };
 }
 
+/** Low, because canvas suggestions must stay tied to supplied evidence. */
+const CANVAS_SUGGESTION_TEMPERATURE = 0.2;
+
 async function generateCanvasSuggestion(
   ai: GoogleGenAI,
   model: string,
@@ -751,6 +772,10 @@ async function generateCanvasSuggestion(
         type: Type.ARRAY,
         items: { type: Type.STRING },
       },
+      // This task is grounded extraction, not ideation. The provider default
+      // (1.0) rewards fluent completion of a familiar business-model shape,
+      // which is what produced speculative items in dogfooding.
+      temperature: CANVAS_SUGGESTION_TEMPERATURE,
       ...noThinkingConfig(model),
     },
   });

--- a/tests/security/canvas-suggestion-prompt.test.mjs
+++ b/tests/security/canvas-suggestion-prompt.test.mjs
@@ -78,6 +78,56 @@ test("canvas suggestion prompt includes company context, block definition, canva
   assert.match(prompt, /Return ONLY a valid JSON array of strings/);
 });
 
+test("the prompt does not authorise speculative business-model elements", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const source = await readFile(
+    new URL("../../netlify/functions/api.ts", import.meta.url),
+    "utf8",
+  );
+
+  // Regression: this line permitted unsupported elements so long as they were
+  // hedged. A string[] rendered as a canvas bullet cannot carry a hedge, so the
+  // speculation reached the canvas as if it were fact.
+  assert.doesNotMatch(source, /Strategic possibilities may be suggested/);
+
+  // Regression: the Revenue Streams definition invited invented monetization
+  // ("or could earn") in the same sentence that forbade it.
+  assert.doesNotMatch(SBMC_BLOCK_DEFINITIONS["Revenue Streams"], /could earn/);
+});
+
+test("every block prompt states the evidence gate and refuses block completion", () => {
+  for (const label of SBMC_BLOCKS) {
+    const prompt = buildCanvasSuggestionPrompt(profile, label, bmcData);
+
+    assert.match(prompt, /Plausibility is not evidence/, label);
+    assert.match(prompt, /requires assuming a new capability/, label);
+    assert.match(
+      prompt,
+      /Do not complete the block by adding what a company of this type would\s+typically have/,
+      label,
+    );
+    // Improving what exists must outrank proposing something new.
+    assert.match(prompt, /Improve, clarify, or consolidate existing items/, label);
+    // The definition must not read as a list of categories to fill.
+    assert.match(prompt, /not a checklist of categories to fill/, label);
+    // Returning little must be an acceptable outcome, not a failure.
+    assert.match(prompt, /A short list is not a\s+failure/, label);
+  }
+});
+
+test("grounding is pinned to supplied context, not model creativity", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const source = await readFile(
+    new URL("../../netlify/functions/api.ts", import.meta.url),
+    "utf8",
+  );
+
+  // Provider default is 1.0, which rewards fluent completion of a familiar
+  // business-model shape over checking the supplied evidence.
+  assert.match(source, /const CANVAS_SUGGESTION_TEMPERATURE = 0\.2;/);
+  assert.match(source, /temperature: CANVAS_SUGGESTION_TEMPERATURE/);
+});
+
 test("canvas context normalization keeps the string array contract for valid values", () => {
   const normalized = normalizeCanvasContext({
     keyPartners: ["Partner A", 42, " Partner B "],


### PR DESCRIPTION
Follow-up to the SBMC dogfooding round. **Analysis first — the previous grounding work was not the weak point, and none of it is removed here.**

## Root cause: the prompt authorised the thing it forbade

```
- Strategic possibilities may be suggested, but they must not be worded as
  established facts when unsupported.
```

This permits unsupported elements and constrains only their **wording**. But the response contract is a bare `string[]` rendered as a canvas bullet — and a bullet in Revenue Streams *is* an assertion of fact. There is no wording that makes "Carbon credit monetization from client emissions reductions" read as a hypothesis once it lands in the block.

So the instruction was unsatisfiable. The model honoured the half it could (propose it) and dropped the half it couldn't (mark it speculative). **Your hypothesis was correct**: the two instructions were in tension, and the second reopened the door.

## Three causes reinforced it

**The task was block completion.** *"Suggest concise content for the requested SBMC block only"* — nothing ranked improving or deriving above proposing something new.

**The block definitions doubled as generation menus.** Key Resources enumerates *"…technology, **intellectual property**, financial resources…"* — and dogfooding returned "Intellectual property and patents". Worst case, Revenue Streams contradicted itself inside a single sentence:

> "The ways the company earns **or could earn** money… **Do not invent monetization models** unsupported by the company context."

That sentence invites invention and forbids it at once. It produced your strongest failure case.

**Generation config favoured fluency over grounding.** No `temperature` was set anywhere, so the provider default of 1.0 applied while `thinkingBudget: 0` removed deliberation — maximum creativity, minimum reasoning, which is the configuration most likely to complete a familiar SaaS shape.

## Ruled out by inspection

I verified rather than assumed, by rendering the **constructed** prompt:

- Profile field casing matches `CompanyProfile` exactly — no silent `undefined` weakening the context.
- Company profile **and all eleven canvas blocks** genuinely reach the model.
- Generation is per-block, with cross-block context supplied.
- No stale or legacy canvas prompt exists.
- `SBMC_BLOCK_DEFINITIONS` is used only by this prompt, so editing it affects nothing else.

## The change

Conservative for this iteration, no redesign:

- Removed the speculation permission.
- Ranked improve / clarify / consolidate above adding, and refused completion from industry norms outright.
- "Plausibility is not evidence", plus an explicit test for assumed capabilities, teams, partnerships, channels, revenue models, assets, IP and data practices.
- Stated the block definition is a **boundary, not a checklist to fill**.
- Rewrote **only** the Revenue Streams definition to drop "or could earn".
- Made a short or empty list an explicitly correct outcome — *"A short list is not a failure; an unsupported list is."*
- Pinned `temperature: 0.2` for this action alone.

**Preserved:** every sustainability claim guardrail (verified by rendering the Eco-Social Benefits prompt), anti-duplication, cross-block semantics, all other block definitions. **No API, type, schema, UI or persistence change** — the `string[]` contract stands.

## Verification

```
npm run test:security   # 147 pass (143 before, 4 new)
npx tsc --noEmit         # clean
npm run build            # clean
```

New tests assert the speculation line cannot return, "could earn" cannot return, the temperature stays pinned, and **all 11 blocks** carry the evidence gate, the anti-completion rule, the preference ordering and the checklist disclaimer. No phrase blacklist — the tests target the rules, not your example strings.

## ⚠️ What this PR does not prove

I cannot call the model, so I have **not** observed whether patents, community forums or carbon-credit monetization actually stop appearing. I verified prompt construction, not output. **This needs a real dogfooding run before it can be called fixed** — ideally the same six cases.

## The honest limitation

The `string[]` contract is *why* the root cause existed. A canvas bullet is an assertion, so the only safe move within this contract is to forbid hypotheses entirely — which is what this does. **"AI Suggest" can no longer suggest anything genuinely new.** That is the right trade while a wrong fact costs more than a missing idea, but the feature no longer does what its name implies.

A future structured shape — roughly `{ text, kind: "derived" | "hypothesis", basis, confidence }`, where `basis` names the profile field or canvas item a suggestion traces to, and hypotheses render distinctly and require an accept action — would restore strategic value without laundering speculation into fact. **Not implemented here**, as agreed.

## Found elsewhere, deliberately not touched

`generateSwotInternal`, `generateKPISuggestions` and `generateAssessmentSuggestions` have **zero grounding instructions** and all run at the default temperature. The assessment one is the most consequential: it drafts IRO descriptions that feed the materiality scores and then the published statement, so speculation there propagates furthest. Worth its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)