### PR TITLE
feat(profile): structured company context as the shared AI grounding layer

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -47,6 +47,7 @@ const DEFAULT_PROFILE: CompanyProfile = {
   contactEmail: '', contactPhone: '',
   employeeCount: '', revenueRange: '',
   description: '', mission: '', vision: '', productsServices: '',
+  structuredContext: [],
 };
 
 const DEFAULT_CANVAS: SustainabilityBusinessModel = {

--- a/components/CompanyProfileForm.tsx
+++ b/components/CompanyProfileForm.tsx
@@ -1,10 +1,15 @@
 
 import React, { useState } from 'react';
-import { CompanyProfile } from '../types';
+import {
+  CompanyProfile,
+  CompanyContextCategory,
+  CompanyContextItem,
+  CompanyContextStatus,
+} from '../types';
 import { INDUSTRY_SECTORS, ISIC_CODES_GROUPED, COUNTRIES } from '../constants';
 import {
   Building2, MapPin, Globe, Hash, Users, Wallet, Target, Layers, BookOpen,
-  Settings, Mail, Phone, AlertCircle, ArrowRight,
+  Settings, Mail, Phone, AlertCircle, ArrowRight, Workflow, Plus, X,
 } from 'lucide-react';
 import SaveIndicator from './SaveIndicator';
 import type { SaveStatus } from '../hooks/useOrgData';
@@ -23,7 +28,7 @@ interface Props {
 const CompanyProfileForm: React.FC<Props> = ({
   data, onChange, onSave, saveStatus, isDirty, saveError, onOpenSettings,
 }) => {
-  const [activeTab, setActiveTab] = useState<'general' | 'details' | 'strategy'>('general');
+  const [activeTab, setActiveTab] = useState<'general' | 'details' | 'strategy' | 'context'>('general');
   const [emailError, setEmailError] = useState<string | null>(null);
 
   const handleChange = (field: keyof CompanyProfile, value: string) => {
@@ -66,6 +71,9 @@ const CompanyProfileForm: React.FC<Props> = ({
           <TabButton
             active={activeTab === 'strategy'} onClick={() => setActiveTab('strategy')}
             icon={<Target className="w-4 h-4 flex-shrink-0" />} label="Strategy & Mission" />
+          <TabButton
+            active={activeTab === 'context'} onClick={() => setActiveTab('context')}
+            icon={<Workflow className="w-4 h-4 flex-shrink-0" />} label="How We Work" />
           {/* Team & AI moved to Settings */}
           <button
             type="button"
@@ -201,6 +209,29 @@ const CompanyProfileForm: React.FC<Props> = ({
             </div>
           )}
 
+          {activeTab === 'context' && (
+            <div>
+              <div className="mb-2">
+                <h3 className="text-lg font-bold text-slate-800 dark:text-white">How your business works</h3>
+                <p className="text-sm text-slate-500 dark:text-slate-400 mt-1">
+                  Answer whatever you can — all of this is optional, and you can come back later.
+                  AeternumAlly only uses what you state here as fact, so leaving something out is
+                  better than guessing. Mark anything you are only considering as Planned or Exploring
+                  and it will not be treated as something you already do.
+                </p>
+              </div>
+
+              {CONTEXT_GROUPS.map(group => (
+                <ContextGroup
+                  key={group.category}
+                  group={group}
+                  items={data.structuredContext ?? []}
+                  onChange={items => onChange({ ...data, structuredContext: items })}
+                />
+              ))}
+            </div>
+          )}
+
           {activeTab === 'strategy' && (
             <div className="space-y-6">
               <div className="space-y-2">
@@ -223,6 +254,165 @@ const CompanyProfileForm: React.FC<Props> = ({
         </div>
       </div>
     </div>
+  );
+};
+
+/**
+ * The questions a user actually sees. The internal category never appears —
+ * "commercial model" and "ecosystem relationships" are our words, not theirs.
+ */
+const CONTEXT_GROUPS: {
+  category: CompanyContextCategory;
+  question: string;
+  helper: string;
+  namePlaceholder: string;
+  rolePlaceholder: string;
+}[] = [
+  {
+    category: 'business',
+    question: 'What kind of business is this, and who are your main customers?',
+    helper: 'For example: a subscription software product, sold to small manufacturers.',
+    namePlaceholder: 'e.g. Small manufacturers',
+    rolePlaceholder: 'e.g. Main customer group',
+  },
+  {
+    category: 'operating',
+    question: 'What work does your company need to do well to deliver what it sells?',
+    helper: 'Only what you actually do today. If you do not have something yet, mark it "Not established".',
+    namePlaceholder: 'e.g. Software development',
+    rolePlaceholder: 'e.g. Done in-house',
+  },
+  {
+    category: 'technology',
+    question: 'Which tools, platforms, or services does your business run on?',
+    helper: 'Say what each one is used for — running the product, building it, or internal work.',
+    namePlaceholder: 'e.g. Netlify',
+    rolePlaceholder: 'e.g. Application hosting',
+  },
+  {
+    category: 'commercial',
+    question: 'How do customers pay you, and how do you reach them?',
+    helper: 'For example: monthly subscription; introductions from existing customers.',
+    namePlaceholder: 'e.g. Monthly subscription',
+    rolePlaceholder: 'e.g. How customers pay',
+  },
+  {
+    category: 'ecosystem',
+    question: 'Which outside organizations does your business depend on or work with?',
+    helper: 'Suppliers, resellers, consultants, or anyone you rely on. Not standards you follow — those go below.',
+    namePlaceholder: 'e.g. Sustainability consultants',
+    rolePlaceholder: 'e.g. Refer clients to us',
+  },
+  {
+    category: 'standards',
+    question: 'Which sustainability standards or frameworks do you use or follow?',
+    helper: 'Using a standard does not make its organization a partner — this is kept separate on purpose.',
+    namePlaceholder: 'e.g. GHG Protocol',
+    rolePlaceholder: 'e.g. Methodology we follow',
+  },
+];
+
+const STATUS_CHOICES: { value: CompanyContextStatus; label: string }[] = [
+  { value: 'current', label: 'Now' },
+  { value: 'planned', label: 'Planned' },
+  { value: 'exploring', label: 'Exploring' },
+  { value: 'not_established', label: 'Not yet' },
+];
+
+const ContextGroup: React.FC<{
+  group: typeof CONTEXT_GROUPS[number];
+  items: CompanyContextItem[];
+  onChange: (items: CompanyContextItem[]) => void;
+}> = ({ group, items, onChange }) => {
+  const [name, setName] = useState('');
+  const [role, setRole] = useState('');
+
+  const mine = items.filter(i => i.category === group.category);
+  const others = items.filter(i => i.category !== group.category);
+
+  const add = () => {
+    if (!name.trim()) return;
+    onChange([...others, ...mine, {
+      id: crypto.randomUUID(),
+      category: group.category,
+      name: name.trim(),
+      role: role.trim(),
+      status: 'current',
+      source: 'user',
+      updatedAt: new Date().toISOString(),
+    }]);
+    setName('');
+    setRole('');
+  };
+
+  const update = (id: string, patch: Partial<CompanyContextItem>) =>
+    onChange([...others, ...mine.map(i =>
+      i.id === id ? { ...i, ...patch, updatedAt: new Date().toISOString() } : i)]);
+
+  const remove = (id: string) => onChange([...others, ...mine.filter(i => i.id !== id)]);
+
+  return (
+    <section className="py-5 border-b border-slate-100 dark:border-slate-700 last:border-0">
+      <h3 className="text-sm font-semibold text-slate-800 dark:text-white">{group.question}</h3>
+      <p className="text-xs text-slate-500 dark:text-slate-400 mt-1 mb-3">{group.helper}</p>
+
+      {mine.length > 0 && (
+        <ul className="space-y-2 mb-3">
+          {mine.map(item => (
+            <li key={item.id} className="flex flex-wrap items-center gap-2 p-2.5 rounded-lg bg-slate-50 dark:bg-slate-900/50 border border-slate-200 dark:border-slate-700">
+              <span className="font-medium text-sm text-slate-800 dark:text-white">{item.name}</span>
+              {item.role && <span className="text-xs text-slate-500 dark:text-slate-400">— {item.role}</span>}
+              <div className="flex gap-1 ml-auto">
+                {STATUS_CHOICES.map(choice => (
+                  <button
+                    key={choice.value}
+                    onClick={() => update(item.id, { status: choice.value })}
+                    className={`px-2 py-0.5 rounded-full text-xs font-medium transition-colors ${
+                      item.status === choice.value
+                        ? 'bg-esg-600 text-white'
+                        : 'bg-white dark:bg-slate-800 text-slate-500 dark:text-slate-400 border border-slate-200 dark:border-slate-600 hover:border-esg-400'
+                    }`}
+                  >
+                    {choice.label}
+                  </button>
+                ))}
+                <button
+                  onClick={() => remove(item.id)}
+                  aria-label={`Remove ${item.name}`}
+                  className="p-1 text-slate-400 hover:text-red-500"
+                >
+                  <X className="w-3.5 h-3.5" />
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      <div className="flex flex-wrap gap-2">
+        <input
+          value={name}
+          onChange={e => setName(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); add(); } }}
+          placeholder={group.namePlaceholder}
+          className="flex-1 min-w-[160px] px-3 py-2 text-sm border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-950 text-slate-900 dark:text-white"
+        />
+        <input
+          value={role}
+          onChange={e => setRole(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); add(); } }}
+          placeholder={group.rolePlaceholder}
+          className="flex-1 min-w-[160px] px-3 py-2 text-sm border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-950 text-slate-900 dark:text-white"
+        />
+        <button
+          onClick={add}
+          disabled={!name.trim()}
+          className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg bg-esg-600 hover:bg-esg-700 disabled:opacity-40 text-white"
+        >
+          <Plus className="w-4 h-4" /> Add
+        </button>
+      </div>
+    </section>
   );
 };
 

--- a/netlify/functions/_shared/companyContext.js
+++ b/netlify/functions/_shared/companyContext.js
@@ -1,0 +1,153 @@
+// @ts-check
+
+/**
+ * Company factual context shared by every AI feature.
+ *
+ * Dogfooding showed the Business Description was acting as the de facto
+ * grounding layer: naming an infrastructure provider there was the difference
+ * between SBMC returning Key Partners and returning nothing. Free prose is a
+ * poor place for facts — nothing distinguishes what a company *does* from what
+ * it is *considering*, and nothing survives into a later feature intact.
+ *
+ * `structured_context` holds those facts as items instead. One shape covers all
+ * six categories, because they differ only in what `name` and `role` mean:
+ * "Netlify / Application hosting" and "GHG Protocol / Methodology used" are the
+ * same record with different meanings.
+ *
+ * The status field is what keeps a plan from being reported as a fact, and the
+ * category is what keeps a referenced standard from becoming a partner.
+ */
+
+export const CONTEXT_CATEGORIES = /** @type {const} */ ([
+  "business",
+  "operating",
+  "technology",
+  "commercial",
+  "ecosystem",
+  "standards",
+]);
+
+/** Heading used for each category in the rendered context. */
+export const CONTEXT_CATEGORY_LABELS = {
+  business: "Business",
+  operating: "Operating Model",
+  technology: "Technology",
+  commercial: "Commercial",
+  ecosystem: "Ecosystem",
+  standards: "Standards",
+};
+
+export const CONTEXT_STATUSES = /** @type {const} */ ([
+  "current",
+  "planned",
+  "exploring",
+  "not_established",
+]);
+
+/** How a status is written in the prompt. Absence means unknown. */
+export const CONTEXT_STATUS_LABELS = {
+  current: "Current",
+  planned: "Planned",
+  exploring: "Exploring",
+  not_established: "Not established",
+};
+
+export const CONTEXT_SOURCES = /** @type {const} */ ([
+  "user",
+  "imported",
+  "system_derived",
+  "ai_suggested",
+]);
+
+const asText = (value, max) =>
+  typeof value === "string" ? value.trim().slice(0, max) : "";
+
+/**
+ * Keep only fully well-formed items; drop everything else.
+ *
+ * Nothing is defaulted. An unrecognized status must never fall back to
+ * "current", because that turns a malformed record into a stated present fact —
+ * precisely the failure this layer exists to prevent. The same applies to
+ * source: guessing "user" would fabricate provenance. Dropping an item costs a
+ * suggestion; promoting one costs the grounding guarantee.
+ *
+ * @param {unknown} value
+ * @returns {Array<{category: string, name: string, role: string, status: string, source: string}>}
+ */
+export function normalizeStructuredContext(value) {
+  if (!Array.isArray(value)) return [];
+
+  return value.flatMap(raw => {
+    const category = asText(raw?.category, 40);
+    const name = asText(raw?.name, 120);
+    const status = asText(raw?.status, 40);
+    const source = asText(raw?.source, 40);
+
+    const valid =
+      CONTEXT_CATEGORIES.includes(/** @type {any} */ (category))
+      && name.length > 0
+      && CONTEXT_STATUSES.includes(/** @type {any} */ (status))
+      && CONTEXT_SOURCES.includes(/** @type {any} */ (source));
+
+    return valid
+      ? [{ category, name, role: asText(raw?.role, 200), status, source }]
+      : [];
+  });
+}
+
+/**
+ * Render the structured items. Empty categories are omitted entirely: a heading
+ * with nothing under it invites the model to fill the gap, which is the
+ * behaviour this whole layer exists to prevent.
+ *
+ * @param {unknown} structuredContext
+ * @returns {string}
+ */
+export function buildStructuredContextBlock(structuredContext) {
+  const items = normalizeStructuredContext(structuredContext);
+  if (items.length === 0) return "";
+
+  const sections = CONTEXT_CATEGORIES
+    .map(category => {
+      const rows = items.filter(item => item.category === category);
+      if (rows.length === 0) return "";
+
+      const lines = rows.map(item => {
+        const role = item.role ? `: ${item.role}` : "";
+        return `- ${item.name}${role} [${CONTEXT_STATUS_LABELS[item.status]}]`;
+      });
+      return `${CONTEXT_CATEGORY_LABELS[category]}\n${lines.join("\n")}`;
+    })
+    .filter(Boolean);
+
+  return [
+    "",
+    "",
+    "COMPANY FACTUAL CONTEXT",
+    "The items below are stated by the company. Anything absent is unknown and",
+    "must not be inferred. Items marked Planned, Exploring or Not established are",
+    "not current facts and must not be described as if they were.",
+    "",
+    sections.join("\n\n"),
+  ].join("\n");
+}
+
+/**
+ * The context every AI prompt interpolates. Identity stays prose because those
+ * fields are genuinely prose; everything factual comes from the items.
+ *
+ * @param {any} profile
+ * @returns {string}
+ */
+export function buildCompanyContext(profile) {
+  const identity = [
+    `Company: ${profile?.name} (${profile?.industry}, ISIC: ${profile?.isicCode})`,
+    `Scale: ${profile?.employeeCount} employees, Revenue: ${profile?.revenueRange}`,
+    `Description: ${profile?.description}`,
+    `Mission: ${profile?.mission}`,
+    `Vision: ${profile?.vision}`,
+    `Key Products / Services: ${profile?.productsServices}`,
+  ].join("\n");
+
+  return identity + buildStructuredContextBlock(profile?.structuredContext);
+}

--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -6,6 +6,7 @@ import {
 } from "./_shared/internalJobAuth.js";
 import { withAIRequestFence } from "./_shared/aiRequestFence.js";
 import { loadOrganizationAiConfig } from "./_shared/organizationAiConfig.js";
+import { buildCompanyContext } from "./_shared/companyContext.js";
 import { loadOrganizationTier } from "./_shared/organizationTier.js";
 import {
   authorizeAiCall,
@@ -370,17 +371,6 @@ Return an empty array [] if no items apply.
 `;
 
 // Build a consistent company context block from a structured profile object.
-function buildCompanyContext(profile: any): string {
-  return [
-    `Company: ${profile.name} (${profile.industry}, ISIC: ${profile.isicCode})`,
-    `Scale: ${profile.employeeCount} employees, Revenue: ${profile.revenueRange}`,
-    `Description: ${profile.description}`,
-    `Mission: ${profile.mission}`,
-    `Vision: ${profile.vision}`,
-    `Key Products / Services: ${profile.productsServices}`,
-  ].join('\n');
-}
-
 // Join a BMC field (string[] after migration) for use in AI prompts.
 const joinField = (v: string | string[]): string =>
   Array.isArray(v) ? v.join(", ") : (v ?? "");

--- a/netlify/functions/assessment-background.ts
+++ b/netlify/functions/assessment-background.ts
@@ -2,6 +2,7 @@ import { GoogleGenAI, Type } from "@google/genai";
 import { createClient } from "@supabase/supabase-js";
 import { requireInternalJobAuth } from "./_shared/internalJobAuth.js";
 import { loadOrganizationAiConfig } from "./_shared/organizationAiConfig.js";
+import { buildCompanyContext } from "./_shared/companyContext.js";
 
 const apiKey = process.env.GEMINI_API_KEY;
 const supabaseUrl = process.env.VITE_SUPABASE_URL || process.env.SUPABASE_URL;
@@ -126,17 +127,6 @@ const handler = async (event: any) => {
       console.warn("[assessment-background] Failed to parse AI JSON:", e);
       return fallback;
     }
-  }
-
-  function buildCompanyContext(p: any): string {
-    return [
-      `Company: ${p.name} (${p.industry}, ISIC: ${p.isicCode})`,
-      `Scale: ${p.employeeCount} employees, Revenue: ${p.revenueRange}`,
-      `Description: ${p.description}`,
-      `Mission: ${p.mission}`,
-      `Vision: ${p.vision}`,
-      `Key Products / Services: ${p.productsServices}`,
-    ].join('\n');
   }
 
   const joinField = (v: string | string[]): string =>

--- a/services/dbService.ts
+++ b/services/dbService.ts
@@ -317,6 +317,7 @@ export const fromDbProfile = (row: any): CompanyProfile => ({
   mission: row.mission ?? "",
   vision: row.vision ?? "",
   productsServices: row.products_services ?? "",
+  structuredContext: Array.isArray(row.structured_context) ? row.structured_context : [],
 });
 
 export const toDbProfile = (data: CompanyProfile) => ({
@@ -339,6 +340,7 @@ export const toDbProfile = (data: CompanyProfile) => ({
   mission: data.mission,
   vision: data.vision,
   products_services: data.productsServices,
+  structured_context: data.structuredContext ?? [],
 });
 
 // =================================================================

--- a/supabase/migrations/031_company_structured_context.sql
+++ b/supabase/migrations/031_company_structured_context.sql
@@ -1,0 +1,43 @@
+-- ============================================================
+-- Migration 031 — structured company context
+-- ============================================================
+-- Dogfooding showed the free-text Business Description was acting as the
+-- grounding layer for every AI feature: naming an infrastructure provider
+-- there was the difference between SBMC returning Key Partners and returning
+-- nothing at all.
+--
+-- Prose is a poor place for facts. It cannot distinguish what a company does
+-- from what it is considering, and it cannot say that a standard is referenced
+-- rather than partnered with. This column holds those facts as items:
+--
+--   { id, category, name, role, status, source, updatedAt }
+--
+-- One shape serves all six categories (business, operating, technology,
+-- commercial, ecosystem, standards) because they differ only in what `name`
+-- and `role` mean. `status` (current | planned | exploring | not_established)
+-- is what stops a plan being reported as a fact; `source` records provenance
+-- so grounding stays auditable as AI-assisted entry is added later.
+--
+-- Unknown is represented by absence — there is deliberately no "unknown"
+-- status, because a user should never have to invent an answer.
+--
+-- Additive and backward compatible: existing profiles default to an empty
+-- array, and the rendered AI context is then byte-identical to today's.
+--
+-- Rollback:
+--   ALTER TABLE public.company_profiles DROP COLUMN IF EXISTS structured_context;
+-- ============================================================
+
+ALTER TABLE public.company_profiles
+  ADD COLUMN IF NOT EXISTS structured_context jsonb NOT NULL DEFAULT '[]'::jsonb;
+
+-- The shape is enforced in application code; the database guarantees only that
+-- this is a list, so a malformed value cannot be read back as a single fact.
+ALTER TABLE public.company_profiles
+  DROP CONSTRAINT IF EXISTS company_profiles_structured_context_is_array;
+ALTER TABLE public.company_profiles
+  ADD CONSTRAINT company_profiles_structured_context_is_array
+  CHECK (jsonb_typeof(structured_context) = 'array');
+
+COMMENT ON COLUMN public.company_profiles.structured_context
+  IS 'Company facts as items {id, category, name, role, status, source, updatedAt}. Absence means unknown; status keeps plans from being reported as current facts.';

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -155,6 +155,12 @@ CREATE TABLE company_profiles (
   mission          text NOT NULL DEFAULT '',
   vision           text NOT NULL DEFAULT '',
   products_services text NOT NULL DEFAULT '',
+  -- Migration 031: structured company facts shared by every AI feature.
+  -- Items are {id, category, name, role, status, source, updatedAt}; absence
+  -- means unknown, and status keeps plans from being read as current facts.
+  structured_context jsonb NOT NULL DEFAULT '[]'::jsonb
+    CONSTRAINT company_profiles_structured_context_is_array
+    CHECK (jsonb_typeof(structured_context) = 'array'),
   updated_at       timestamptz NOT NULL DEFAULT now()
 );
 

--- a/tests/unit/company-context.test.mjs
+++ b/tests/unit/company-context.test.mjs
@@ -1,0 +1,159 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildCompanyContext,
+  buildStructuredContextBlock,
+  normalizeStructuredContext,
+} from "../../netlify/functions/_shared/companyContext.js";
+
+const profile = {
+  name: "Acme", industry: "Sustainability software", isicCode: "6201",
+  employeeCount: "Micro", revenueRange: "Pre-revenue",
+  description: "Reporting software for SMEs.",
+  mission: "m", vision: "v", productsServices: "p",
+};
+
+const item = (category, name, role, status = "current") => ({
+  id: `${category}-${name}`, category, name, role, status, source: "user",
+  updatedAt: "2026-09-06T00:00:00.000Z",
+});
+
+test("a profile without structured context renders exactly as before", () => {
+  const legacy = buildCompanyContext(profile);
+
+  assert.match(legacy, /Company: Acme/);
+  assert.doesNotMatch(legacy, /COMPANY FACTUAL CONTEXT/);
+  assert.equal(buildCompanyContext({ ...profile, structuredContext: [] }), legacy);
+  // Older rows arrive as null or undefined and must not break the prompt.
+  assert.equal(buildCompanyContext({ ...profile, structuredContext: null }), legacy);
+});
+
+test("stated facts reach the model grouped, with status attached", () => {
+  const rendered = buildCompanyContext({
+    ...profile,
+    structuredContext: [
+      item("technology", "Netlify", "Application hosting"),
+      item("ecosystem", "Sustainability consultants", "Referral channel", "exploring"),
+      item("standards", "GRI", "Framework supported"),
+    ],
+  });
+
+  assert.match(rendered, /COMPANY FACTUAL CONTEXT/);
+  assert.match(rendered, /Technology\n- Netlify: Application hosting \[Current\]/);
+  assert.match(rendered, /Ecosystem\n- Sustainability consultants: Referral channel \[Exploring\]/);
+  assert.match(rendered, /Standards\n- GRI: Framework supported \[Current\]/);
+});
+
+test("a referenced standard never appears as an ecosystem relationship", () => {
+  const rendered = buildCompanyContext({
+    ...profile,
+    structuredContext: [item("standards", "GRI", "Framework supported")],
+  });
+
+  const ecosystem = rendered.split("Ecosystem")[1];
+  assert.equal(ecosystem, undefined, "no Ecosystem section should exist");
+  assert.match(rendered, /Standards/);
+});
+
+test("empty categories are omitted so there is no gap inviting invention", () => {
+  const rendered = buildStructuredContextBlock([item("technology", "Supabase", "Database")]);
+
+  assert.match(rendered, /Technology/);
+  for (const absent of ["Business", "Operating Model", "Commercial", "Ecosystem", "Standards"]) {
+    assert.doesNotMatch(rendered, new RegExp(`\\n${absent}\\n`), absent);
+  }
+});
+
+test("the context states that absence means unknown and plans are not facts", () => {
+  const rendered = buildStructuredContextBlock([item("commercial", "Subscription", "How customers pay", "planned")]);
+
+  assert.match(rendered, /Anything absent is unknown and/);
+  assert.match(rendered, /must not be inferred/);
+  assert.match(rendered, /Planned, Exploring or Not established are\nnot current facts/);
+  assert.match(rendered, /- Subscription: How customers pay \[Planned\]/);
+});
+
+test("malformed items are dropped, never repaired into facts", () => {
+  const normalized = normalizeStructuredContext([
+    item("technology", "Netlify", "Hosting"),
+    { category: "technology" },                                        // no name
+    { category: "not-a-category", name: "X", status: "current", source: "user" },
+    { category: "ecosystem", name: "Y", status: "maybe", source: "user" },
+    { category: "ecosystem", name: "Z", status: "current", source: "hearsay" },
+    "nonsense",
+  ]);
+
+  assert.deepEqual(normalized.map(i => i.name), ["Netlify"]);
+  assert.deepEqual(normalizeStructuredContext(null), []);
+  assert.deepEqual(normalizeStructuredContext({ category: "technology" }), []);
+});
+
+// ── Requested grounding guarantees ──────────────────────────────────────────
+
+test("a Planned item never reaches the model without its label", () => {
+  const rendered = buildStructuredContextBlock([
+    item("commercial", "SaaS subscription", "How customers will pay", "planned"),
+    item("ecosystem", "Reseller agreement", "", "planned"),
+  ]);
+
+  // Both forms carry the label, including the one with no role — the label
+  // must not depend on other fields being filled in.
+  assert.match(rendered, /- SaaS subscription: How customers will pay \[Planned\]/);
+  assert.match(rendered, /- Reseller agreement \[Planned\]/);
+
+  // Nothing may reach the model as a bare item: every rendered entry ends in a
+  // status label, so a plan can never read as something already true.
+  const entries = rendered.split("\n").filter(line => line.startsWith("- "));
+  assert.equal(entries.length, 2);
+  for (const entry of entries) {
+    assert.match(entry, /\[(Current|Planned|Exploring|Not established)\]$/, entry);
+  }
+  assert.doesNotMatch(rendered, /- SaaS subscription: How customers will pay$/m);
+});
+
+test("a Not established item renders as an explicit negative fact", () => {
+  const rendered = buildStructuredContextBlock([
+    item("operating", "Dedicated sales team", "No one does this yet", "not_established"),
+  ]);
+
+  assert.match(rendered, /- Dedicated sales team: No one does this yet \[Not established\]/);
+
+  // It must be stated, not omitted: "we do not have this" is information the
+  // model needs, and silence would invite it to assume the opposite.
+  assert.match(rendered, /Dedicated sales team/);
+
+  // And it must not be mistakable for something the company has.
+  assert.doesNotMatch(rendered, /Dedicated sales team[^\n]*\[Current\]/);
+  assert.match(rendered, /Not established are\nnot current facts/);
+});
+
+test("malformed category, status or source is dropped deterministically", () => {
+  const good = item("technology", "Netlify", "Application hosting");
+  const cases = [
+    { label: "unknown category", raw: { ...good, category: "infrastructure" } },
+    { label: "unknown status", raw: { ...good, status: "maybe" } },
+    { label: "unknown source", raw: { ...good, source: "hearsay" } },
+    { label: "empty status", raw: { ...good, status: "" } },
+    { label: "missing status", raw: { ...good, status: undefined } },
+    { label: "missing source", raw: { ...good, source: undefined } },
+    { label: "status wrong type", raw: { ...good, status: 3 } },
+    { label: "cased status", raw: { ...good, status: "Current" } },
+  ];
+
+  for (const { label, raw } of cases) {
+    const out = normalizeStructuredContext([raw]);
+    assert.deepEqual(out, [], `${label} must be dropped, not repaired`);
+
+    // Specifically: never silently promoted to a present fact.
+    assert.equal(out.some(i => i.status === "current"), false, label);
+  }
+
+  // Deterministic: identical input yields identical output every time, and a
+  // bad item never contaminates a good one beside it.
+  const mixed = [good, { ...good, name: "Ghost", status: "maybe" }];
+  const first = normalizeStructuredContext(mixed);
+  assert.deepEqual(first, normalizeStructuredContext(mixed));
+  assert.deepEqual(first.map(i => i.name), ["Netlify"]);
+  assert.doesNotMatch(buildStructuredContextBlock(mixed), /Ghost/);
+});

--- a/types.ts
+++ b/types.ts
@@ -93,6 +93,51 @@ export interface OrgInvite {
   created_at: string;
 }
 
+/**
+ * Structured company facts shared by every AI feature.
+ *
+ * One shape covers all six categories because they differ only in what `name`
+ * and `role` mean — "Netlify / Application hosting" and "GHG Protocol /
+ * Methodology used" are the same record with different meanings. `category` is
+ * what keeps a referenced standard from becoming a partner; `status` is what
+ * keeps a plan from being reported as a current fact.
+ *
+ * Unknown is represented by absence: there is deliberately no "unknown" status,
+ * because a user should never have to invent an answer.
+ */
+export type CompanyContextCategory =
+  | 'business'
+  | 'operating'
+  | 'technology'
+  | 'commercial'
+  | 'ecosystem'
+  | 'standards';
+
+export type CompanyContextStatus =
+  | 'current'
+  | 'planned'
+  | 'exploring'
+  | 'not_established';
+
+/** Provenance, stored from the start so grounding stays auditable later. */
+export type CompanyContextSource =
+  | 'user'
+  | 'imported'
+  | 'system_derived'
+  | 'ai_suggested';
+
+export interface CompanyContextItem {
+  id: string;
+  category: CompanyContextCategory;
+  /** What it is: "Netlify", "Founder-led sales", "GHG Protocol". */
+  name: string;
+  /** What it does for the business: "Application hosting", "Methodology used". */
+  role: string;
+  status: CompanyContextStatus;
+  source: CompanyContextSource;
+  updatedAt: string;
+}
+
 export interface CompanyProfile {
   name: string;
   taxId: string; // Registration Number
@@ -115,6 +160,8 @@ export interface CompanyProfile {
   mission: string;
   vision: string;
   productsServices: string; // Comma separated list
+  /** Structured facts behind the simple questions; empty for older profiles. */
+  structuredContext: CompanyContextItem[];
 }
 
 export interface SustainabilityBusinessModel {


### PR DESCRIPTION
MVP of the Company Profile → Organizational Context redesign. **Merge this first, dogfood with AeternumAlly, then AI-assisted extraction** — as agreed.

## Why

Your dogfooding proved it: adding Netlify / Supabase / Gemini to the free-text Business Description was the difference between SBMC Key Partners returning nothing and returning grounded suggestions. **Business Description is the grounding layer today**, by accident.

Prose is a poor place for facts. It cannot separate what a company *does* from what it is *considering*, and it cannot say a standard is *referenced* rather than *partnered with* — the two failures dogfooding surfaced most often.

## The design decision worth reviewing

**One item shape for all six categories**, not six bespoke structures:

```ts
{ id, category, name, role, status, source, updatedAt }
```

The categories differ only in what `name` and `role` mean — `Netlify / Application hosting` and `GHG Protocol / Methodology used` are the same record. Six shapes would have meant six migrations, six components and six normalizers for no added expressiveness.

- **`category`** keeps a referenced standard out of Ecosystem — GRI is `standards`, never a partner.
- **`status`** (`current | planned | exploring | not_established`) keeps a plan from being reported as a present fact.
- **Unknown is absence.** There is deliberately no "unknown" status, so nobody has to invent an answer.
- **`source`** records provenance now, so grounding stays auditable when AI-assisted entry arrives.

## Normalization fails closed

Per your review: an item whose `category`, `status` or `source` is unrecognized is **dropped, never defaulted**. My first version fell back to `current` — which turns a malformed record into a stated present fact, precisely the failure this layer exists to prevent. Guessing `user` would have fabricated provenance. Dropping an item costs a suggestion; promoting one costs the guarantee.

## UX

A fourth tab, **How We Work** — six plain-language questions with small repeatable rows and status chips (`Now / Planned / Exploring / Not yet`). Not a form over the data model; no internal vocabulary appears. Every question was written against the SME test:

> "Which tools, platforms, or services does your business run on?" — not "what is your technology stack architecture"

## Rendered context (actually run, not illustrative)

```
Technology
- Netlify: Application hosting [Current]
- Claude: Development assistant, not in the product [Current]

Commercial
- SaaS subscription: How customers will pay [Planned]

Ecosystem
- Sustainability consultants: Possible referral channel [Exploring]

Standards
- GHG Protocol: Methodology we follow [Current]
```

Claude stays out of the product. GRI stays out of Ecosystem. The subscription is visibly not yet real.

## Migration

One additive `jsonb` column with a `jsonb_typeof = 'array'` check. **Existing profiles default to `[]` and their rendered AI context stays byte-identical** — asserted by test, including the `null`/`undefined` cases older rows produce. Apply migration 031 before merge.

## Scope call I made beyond the brief

`buildCompanyContext` was **duplicated** in `assessment-background.ts:131`. I moved it to `_shared` rather than leaving it. Without that, assessment autofill — which feeds materiality scores and then the published statement — would have kept using the old prose context while every other feature moved on. That silent divergence was worse than the extra diff.

## Verification

```
npm run test:unit       # 20 pass (9 new)
npm run test:security   # 144 pass
npx tsc --noEmit         # clean
npm run build            # clean
```

Three tests cover the guarantees you asked for: a `Planned` item never renders without its label (every entry ends in a status, including one with no role); `Not established` renders as an explicit negative fact and is never mistakable for `Current`; and malformed category/status/source is dropped deterministically across eight variants, with a bad item never contaminating a good one beside it.

## Known limitations

Nothing *forces* prompts to honour `[Planned]` — the context states the rule, but only dogfooding proves the model obeys it. `jsonb` has no DB-level shape enforcement, hence the fail-closed normalizer. And an empty tab grounds nothing better than today; the layer only pays off once filled.

**Deferred deliberately:** the readiness indicator (needs a scoring heuristic that will be argued about, and it advertises emptiness before we know whether the tab gets filled) and AI-assisted extraction — next, after dogfooding, using the `source: 'ai_suggested'` value already in place.

Not visually verified — the tab needs a login. Worth a deploy-preview pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)