### PR TITLE
fix(profile): make the How We Work rows answerable

### DIFF
--- a/components/CompanyProfileForm.tsx
+++ b/components/CompanyProfileForm.tsx
@@ -326,6 +326,10 @@ const ContextGroup: React.FC<{
 }> = ({ group, items, onChange }) => {
   const [name, setName] = useState('');
   const [role, setRole] = useState('');
+  // Chosen before the item exists. Creating everything as 'current' and asking
+  // the user to correct it afterwards records a plan as a present fact for as
+  // long as they do not notice — the failure this whole layer exists to stop.
+  const [status, setStatus] = useState<CompanyContextStatus>('current');
 
   const mine = items.filter(i => i.category === group.category);
   const others = items.filter(i => i.category !== group.category);
@@ -337,12 +341,13 @@ const ContextGroup: React.FC<{
       category: group.category,
       name: name.trim(),
       role: role.trim(),
-      status: 'current',
+      status,
       source: 'user',
       updatedAt: new Date().toISOString(),
     }]);
     setName('');
     setRole('');
+    setStatus('current');
   };
 
   const update = (id: string, patch: Partial<CompanyContextItem>) =>
@@ -404,6 +409,23 @@ const ContextGroup: React.FC<{
           placeholder={group.rolePlaceholder}
           className="flex-1 min-w-[160px] px-3 py-2 text-sm border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-950 text-slate-900 dark:text-white"
         />
+        <div className="flex items-center gap-1" role="group" aria-label="Status for the item being added">
+          {STATUS_CHOICES.map(choice => (
+            <button
+              key={choice.value}
+              type="button"
+              aria-pressed={status === choice.value}
+              onClick={() => setStatus(choice.value)}
+              className={`px-2.5 py-2 rounded-lg text-xs font-medium transition-colors ${
+                status === choice.value
+                  ? 'bg-esg-600 text-white'
+                  : 'bg-white dark:bg-slate-950 text-slate-500 dark:text-slate-400 border border-slate-300 dark:border-slate-600 hover:border-esg-400'
+              }`}
+            >
+              {choice.label}
+            </button>
+          ))}
+        </div>
         <button
           onClick={add}
           disabled={!name.trim()}

--- a/components/CompanyProfileForm.tsx
+++ b/components/CompanyProfileForm.tsx
@@ -265,6 +265,8 @@ const CONTEXT_GROUPS: {
   category: CompanyContextCategory;
   question: string;
   helper: string;
+  nameLabel: string;
+  roleLabel: string;
   namePlaceholder: string;
   rolePlaceholder: string;
 }[] = [
@@ -272,6 +274,8 @@ const CONTEXT_GROUPS: {
     category: 'business',
     question: 'What kind of business is this, and who are your main customers?',
     helper: 'For example: a subscription software product, sold to small manufacturers.',
+    nameLabel: 'Who you serve, or what kind of business',
+    roleLabel: 'What this is to you',
     namePlaceholder: 'e.g. Small manufacturers',
     rolePlaceholder: 'e.g. Main customer group',
   },
@@ -279,6 +283,8 @@ const CONTEXT_GROUPS: {
     category: 'operating',
     question: 'What work does your company need to do well to deliver what it sells?',
     helper: 'Only what you actually do today. If you do not have something yet, mark it "Not established".',
+    nameLabel: 'The work',
+    roleLabel: 'How it gets done',
     namePlaceholder: 'e.g. Software development',
     rolePlaceholder: 'e.g. Done in-house',
   },
@@ -286,6 +292,8 @@ const CONTEXT_GROUPS: {
     category: 'technology',
     question: 'Which tools, platforms, or services does your business run on?',
     helper: 'Say what each one is used for — running the product, building it, or internal work.',
+    nameLabel: 'Tool, platform, or service',
+    roleLabel: 'What you use it for',
     namePlaceholder: 'e.g. Netlify',
     rolePlaceholder: 'e.g. Application hosting',
   },
@@ -293,6 +301,8 @@ const CONTEXT_GROUPS: {
     category: 'commercial',
     question: 'How do customers pay you, and how do you reach them?',
     helper: 'For example: monthly subscription; introductions from existing customers.',
+    nameLabel: 'How you get paid, or how you reach people',
+    roleLabel: 'What this is',
     namePlaceholder: 'e.g. Monthly subscription',
     rolePlaceholder: 'e.g. How customers pay',
   },
@@ -300,6 +310,8 @@ const CONTEXT_GROUPS: {
     category: 'ecosystem',
     question: 'Which outside organizations does your business depend on or work with?',
     helper: 'Suppliers, resellers, consultants, or anyone you rely on. Not standards you follow — those go below.',
+    nameLabel: 'The organization',
+    roleLabel: 'What they do for you',
     namePlaceholder: 'e.g. Sustainability consultants',
     rolePlaceholder: 'e.g. Refer clients to us',
   },
@@ -307,6 +319,8 @@ const CONTEXT_GROUPS: {
     category: 'standards',
     question: 'Which sustainability standards or frameworks do you use or follow?',
     helper: 'Using a standard does not make its organization a partner — this is kept separate on purpose.',
+    nameLabel: 'Standard or framework',
+    roleLabel: 'How you use it',
     namePlaceholder: 'e.g. GHG Protocol',
     rolePlaceholder: 'e.g. Methodology we follow',
   },
@@ -394,29 +408,57 @@ const ContextGroup: React.FC<{
         </ul>
       )}
 
-      <div className="flex flex-wrap gap-2">
-        <input
-          value={name}
-          onChange={e => setName(e.target.value)}
-          onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); add(); } }}
-          placeholder={group.namePlaceholder}
-          className="flex-1 min-w-[160px] px-3 py-2 text-sm border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-950 text-slate-900 dark:text-white"
-        />
-        <input
-          value={role}
-          onChange={e => setRole(e.target.value)}
-          onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); add(); } }}
-          placeholder={group.rolePlaceholder}
-          className="flex-1 min-w-[160px] px-3 py-2 text-sm border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-950 text-slate-900 dark:text-white"
-        />
-        <div className="flex items-center gap-1" role="group" aria-label="Status for the item being added">
+      {/* Two calm lines rather than one dense strip: labelled inputs, then the
+          status choice and Add. Six of these stack on one page, so the row has
+          to read as a question being answered, not a control panel. */}
+      <div className="grid gap-3 sm:grid-cols-2">
+        <div>
+          <label
+            htmlFor={`${group.category}-name`}
+            className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1"
+          >
+            {group.nameLabel}
+          </label>
+          <input
+            id={`${group.category}-name`}
+            value={name}
+            onChange={e => setName(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); add(); } }}
+            placeholder={group.namePlaceholder}
+            className="w-full px-3 py-2 text-sm border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-950 text-slate-900 dark:text-white"
+          />
+        </div>
+        <div>
+          <label
+            htmlFor={`${group.category}-role`}
+            className="block text-xs font-medium text-slate-600 dark:text-slate-400 mb-1"
+          >
+            {group.roleLabel}{' '}
+            <span className="font-normal text-slate-400">(optional)</span>
+          </label>
+          <input
+            id={`${group.category}-role`}
+            value={role}
+            onChange={e => setRole(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); add(); } }}
+            placeholder={group.rolePlaceholder}
+            className="w-full px-3 py-2 text-sm border border-slate-300 dark:border-slate-600 rounded-lg bg-white dark:bg-slate-950 text-slate-900 dark:text-white"
+          />
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2 mt-3">
+        <span className="text-xs font-medium text-slate-600 dark:text-slate-400">
+          Is this happening now?
+        </span>
+        <div className="flex flex-wrap items-center gap-1" role="group" aria-label="Status for the item being added">
           {STATUS_CHOICES.map(choice => (
             <button
               key={choice.value}
               type="button"
               aria-pressed={status === choice.value}
               onClick={() => setStatus(choice.value)}
-              className={`px-2.5 py-2 rounded-lg text-xs font-medium transition-colors ${
+              className={`px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors ${
                 status === choice.value
                   ? 'bg-esg-600 text-white'
                   : 'bg-white dark:bg-slate-950 text-slate-500 dark:text-slate-400 border border-slate-300 dark:border-slate-600 hover:border-esg-400'
@@ -429,7 +471,7 @@ const ContextGroup: React.FC<{
         <button
           onClick={add}
           disabled={!name.trim()}
-          className="inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg bg-esg-600 hover:bg-esg-700 disabled:opacity-40 text-white"
+          className="ml-auto inline-flex items-center gap-1.5 px-3 py-2 text-sm font-medium rounded-lg bg-esg-600 hover:bg-esg-700 disabled:opacity-40 text-white"
         >
           <Plus className="w-4 h-4" /> Add
         </button>

--- a/tests/unit/company-context.test.mjs
+++ b/tests/unit/company-context.test.mjs
@@ -157,3 +157,30 @@ test("malformed category, status or source is dropped deterministically", () => 
   assert.deepEqual(first.map(i => i.name), ["Netlify"]);
   assert.doesNotMatch(buildStructuredContextBlock(mixed), /Ghost/);
 });
+
+test("status is chosen before an item is created, not corrected afterwards", async () => {
+  const { readFile } = await import("node:fs/promises");
+  const source = await readFile(
+    new URL("../../components/CompanyProfileForm.tsx", import.meta.url),
+    "utf8",
+  );
+
+  const addFn = source.match(/const add = \(\) => \{[\s\S]*?\n  \};/)?.[0];
+  assert.ok(addFn, "the add handler must exist");
+
+  // Regression: every item was created as 'current' and the user had to notice
+  // the chips and correct it. Until they did, a plan was stored as a fact.
+  assert.doesNotMatch(addFn, /status: 'current'/);
+  assert.match(addFn, /\n\s*status,\n/, "add must use the selected status");
+
+  // The selector has to exist before the item does.
+  assert.match(source, /const \[status, setStatus\] = useState<CompanyContextStatus>\('current'\)/);
+  assert.match(
+    source,
+    /aria-label="Status for the item being added"/,
+    "the add row needs its own status control, not only the saved rows",
+  );
+
+  // And it must reset, so one Planned entry does not silently mark the next.
+  assert.match(addFn, /setStatus\('current'\)/);
+});


### PR DESCRIPTION
Two fixes from dogfooding the deployed tab. Both UI only — no data model, migration, or prompt change.

## 1. There was no way to mark something Planned while adding it

The status chips rendered only on saved rows, while `add()` hardcoded `status: 'current'`. So adding "SaaS subscription" intending Planned:

1. Press **Add**
2. **Stored as `Current` immediately** — a present fact
3. If the chips go unnoticed, it stays wrong permanently

A plan recorded as something the company already does is precisely the failure this layer was built to prevent. The default also fell the wrong way: a missed step should fail toward *unknown*, not toward *fact*. And the helper text told users to "mark anything you are only considering as Planned" at a point where there was nothing to mark it with.

The selector now sits in the add row, so the choice happens before the item exists. It resets after each add, so one Planned entry cannot silently mark the next. Chips stay on saved rows for changing a status later.

## 2. The rows were unreadable and dense

The two inputs had **no labels** — the only explanation of what each field meant was a placeholder, which disappears the moment you type. And six rows of *two inputs + four status buttons + Add* on one line read as a control panel rather than a question being answered.

- Each field gets a label written for its own question: "Tool, platform, or service" / "What you use it for", not a generic "Name" and "Role". The second is marked optional, because it is.
- The row splits into two lines: labelled inputs, then the status choice and Add.
- The status buttons gain the question they answer — **"Is this happening now?"** — instead of floating unexplained.
- Inputs get ids, with labels properly associated.

I rendered the markup against the built stylesheet rather than guessing at the spacing, and it reads as three calm questions instead of three dense strips.

## Verification

```
npm run test:unit       # 21 pass (1 new)
npm run test:security   # 147 pass
npx tsc --noEmit         # clean
npm run build            # clean
```

The new test asserts `add()` no longer hardcodes `'current'`, that the add row has its own status control rather than only the saved rows, and that the selection resets.

The isolated render covers spacing, but the tab inside the real app still needs a login — worth a glance, particularly narrow viewports where the status row wraps.

## Why before dogfooding

Test case 4 — *SaaS subscription marked Planned, then check Revenue Streams doesn't describe it as existing revenue* — cannot be measured without fix 1. The item would be recorded as `Current` at creation, so the test would be checking the wrong thing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)