### PR TITLE
fix(ai): carry Planned and Exploring into canvas suggestion text

### DIFF
--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -500,6 +500,11 @@ function buildCanvasSuggestionPrompt(profile: any, fieldLabel: unknown, bmcData:
       proprietary technology, certification, intellectual property, data-usage
       practice, or business activity. If that assumption is not supported by the
       supplied company context or current canvas, do not return it.
+    - A canvas block asserts what the company does today, so an item placed in one
+      reads as current no matter how it is worded. If a suggestion comes from a
+      context item marked Planned, Exploring or Not established, carry that
+      marker in the text itself — for example "Subscription fees (planned)" or
+      "Reseller network (exploring)". Never return such an item unmarked.
     - Apply the requested SBMC block definition strictly.
     - Do not suggest an item if it primarily belongs to another SBMC block.
     - Avoid duplicate or semantically overlapping suggestions already present anywhere in the current canvas.

--- a/tests/security/canvas-suggestion-prompt.test.mjs
+++ b/tests/security/canvas-suggestion-prompt.test.mjs
@@ -170,3 +170,26 @@ test("company strategic report SBMC context omits empty blocks and caps long inp
   assert.doesNotMatch(context, /Three/);
   assert.doesNotMatch(context, /Channels/);
 });
+
+test("a non-current context item cannot be suggested as a current canvas fact", () => {
+  // Dogfooding: "SaaS subscription" was marked Planned in the company profile
+  // and Revenue Streams still returned "SaaS subscription fees". The model was
+  // told not to describe a plan as current, but naming it in a present-tense
+  // block is the misrepresentation — nothing in the wording was wrong, so the
+  // rule never bit.
+  for (const label of SBMC_BLOCKS) {
+    const prompt = buildCanvasSuggestionPrompt(profile, label, bmcData);
+
+    assert.match(prompt, /A canvas block asserts what the company does today/, label);
+    assert.match(prompt, /carry that\s+marker in the text itself/, label);
+    assert.match(prompt, /Never return such an item unmarked/, label);
+
+    // All three non-current statuses, not just Planned.
+    for (const status of ["Planned", "Exploring", "Not established"]) {
+      assert.ok(
+        prompt.includes(status),
+        `${label} prompt must name ${status}`,
+      );
+    }
+  }
+});


### PR DESCRIPTION
Fixes dogfooding test 4. Test 3 passed — `category` works, GRI stayed out of Key Partners — so this is the remaining gap.

## What happened

Clean re-test: "SaaS subscription" marked **Planned** in the profile, Revenue Streams emptied, AI Suggest run fresh. It returned **"SaaS subscription fees"** — a plan presented as current revenue.

## Why the existing rule did not catch it

The context reached the model correctly, status included:

```
Commercial
- SaaS subscription: how customer pay [Planned]
```

And the rule was there: *"must not be described as if they were current facts"*.

**The model did not break that rule.** It returned a *name*, not a description, and nothing in the name is false. What turns it into a present-tense claim is **the block it lands in** — and no instruction connected those two things. A bullet under "Revenue Streams" asserts current state by position, regardless of its wording.

## The fix

The prompt now states that connection, and says what to do instead:

> A canvas block asserts what the company does today, so an item placed in one reads as current no matter how it is worded. If a suggestion comes from a context item marked Planned, Exploring or Not established, carry that marker in the text itself — for example "Subscription fees (planned)". Never return such an item unmarked.

**Labelling rather than omitting**, for two reasons: dropping it would discard strategic information the user entered themselves, and the marker then travels with the string into SWOT, the strategic report and DMA, all of which read the canvas as input.

## Honest framing

This is a **workaround for the `string[]` contract, not a solution to it.** Status can only survive inside the text because the position carries the meaning. The structured suggestion model (`kind: "hypothesis"`) proposed as follow-up in #200 is the real answer — this is now the second concrete case arguing for it, after Key Partners.

## Verification

```
npm run test:security   # 148 pass (1 new)
npm run test:unit       # 23 pass
npx tsc --noEmit         # clean
npm run build            # clean
```

The new test asserts the rule appears in **all 11 block prompts** and names all three non-current statuses, not just Planned. I also rendered the constructed prompt for this exact case to confirm the context and the rule sit together.

**Not proven:** I cannot call the model, so whether it now emits "(planned)" needs the same re-test — empty Revenue Streams, AI Suggest, with the item still marked Planned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)