### PR TITLE
fix(ai): ground SWOT in supplied evidence instead of strategy language

### DIFF
--- a/netlify/functions/api.ts
+++ b/netlify/functions/api.ts
@@ -751,6 +751,13 @@ ${(qualityCheckContext.issues as any[]).map((i: any) =>
 /** Low, because canvas suggestions must stay tied to supplied evidence. */
 const CANVAS_SUGGESTION_TEMPERATURE = 0.2;
 
+/**
+ * SWOT is judgement rather than extraction, so it needs a little more room than
+ * the canvas — but not the provider default of 1.0, which rewards fluent
+ * strategy-speak over factors the supplied evidence actually supports.
+ */
+const SWOT_TEMPERATURE = 0.3;
+
 async function generateCanvasSuggestion(
   ai: GoogleGenAI,
   model: string,
@@ -809,6 +816,23 @@ async function generateSwotInternal(
     - Eco-Social Benefits: ${joinField(bmcData.ecoSocialBenefits)}
     - Eco-Social Costs: ${joinField(bmcData.ecoSocialCosts)}
 
+    Grounding rules:
+    - Every factor must trace to something in the company context or the canvas
+      above. Name the thing it comes from where it helps.
+    - Plausibility is not evidence. A strength common to SaaS companies,
+      sustainability platforms or consultancies is not this company's strength
+      unless the supplied content shows it.
+    - Do not invent capabilities, teams, customers, funding, market position,
+      technology, or track record that the supplied content does not show.
+    - An item marked "(planned)" or "(exploring)" is not yet a strength. It is
+      an intention, and treating it as an existing advantage is the most common
+      way this analysis goes wrong.
+    - Something the company explicitly does not have — marked "Not established",
+      or missing where the business model needs it — is legitimate evidence for
+      a weakness. Say what is absent rather than inventing a problem.
+    - Prefer fewer well-supported factors over a balanced-looking list. An empty
+      array is the correct answer when the supplied content shows nothing.
+
     CRITICAL: Return ONLY a JSON object with keys "strengths" and "weaknesses".
     Each value must be an array of short, distinct strings (one factor per item, under 15 words each).
   `;
@@ -825,6 +849,7 @@ async function generateSwotInternal(
           weaknesses: { type: Type.ARRAY, items: { type: Type.STRING } },
         },
       },
+      temperature: SWOT_TEMPERATURE,
     },
   });
 
@@ -832,6 +857,27 @@ async function generateSwotInternal(
     result: parseAIJson(response.text, { strengths: [], weaknesses: [] }),
     ...extractTokens(response),
   };
+}
+
+/**
+ * Turn a search-grounded bulleted answer into SWOT factors.
+ *
+ * Google Search grounding cannot be combined with JSON schema mode, so the
+ * model answers in prose and this has to recover the list. Headings and
+ * lead-ins were previously kept and stored as factors of their own.
+ */
+export function parseSwotExternalLines(text: unknown): string[] {
+  return String(text ?? "")
+    .split("\n")
+    .map(line => line.replace(/^[\s•\-\*–\d\.]+/, "").replace(/\*+/g, "").trim())
+    .filter(line =>
+      line.length > 0
+      && !line.startsWith("---")
+      && !line.startsWith("#")
+      // A trailing colon marks a heading or a lead-in ("Key opportunities:").
+      && !line.endsWith(":")
+      // Drop separators and stray punctuation left by a wrapped line.
+      && /[a-zA-Z]/.test(line));
 }
 
 async function generateSwotExternal(
@@ -850,20 +896,32 @@ async function generateSwotExternal(
     - New regulations (especially sustainability/ESG)
     - Technological shifts
 
-    Provide the answer as a bulleted list. Cite sources if possible.
+    Grounding rules:
+    - Search tells you about the world, not about this company. Describe the
+      market, regulation or technology shift, and say why it matters to a
+      company of this profile.
+    - Do not state anything about this company's own capabilities, customers,
+      partnerships, plans or position that the company context above does not
+      show. A search result is not evidence about them.
+    - Do not present an opportunity as one the company is already pursuing, or a
+      threat as one it is already exposed to, unless the company context says so.
+    - Where a factor rests on a specific development, name the source inline in
+      the same line, for example "... (Reuters, March 2026)". A separate list of
+      references does not survive into the result.
+    - Prefer fewer well-sourced factors over a long speculative list.
+
+    Return one factor per line as a plain bulleted list, each under 25 words.
+    No headings, no introduction, no closing summary.
   `;
 
   // Google Search grounding is incompatible with JSON schema mode; parse text manually.
   const response = await ai.models.generateContent({
     model,
     contents: prompt,
-    config: { tools: [{ googleSearch: {} }] },
+    config: { tools: [{ googleSearch: {} }], temperature: SWOT_TEMPERATURE },
   });
 
-  const items = (response.text || "")
-    .split("\n")
-    .map((line: string) => line.replace(/^[\s•\-\*–\d\.]+/, "").replace(/\*+/g, "").trim())
-    .filter((line: string) => line.length > 0 && !line.startsWith("---") && !line.startsWith("#"));
+  const items = parseSwotExternalLines(response.text);
 
   return {
     result: items,

--- a/tests/unit/swot-grounding.test.mjs
+++ b/tests/unit/swot-grounding.test.mjs
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+import { parseSwotExternalLines } from "../../netlify/functions/api.ts";
+
+const source = () => readFile(new URL("../../netlify/functions/api.ts", import.meta.url), "utf8");
+const swotInternal = (s) => s.match(/async function generateSwotInternal[\s\S]*?\n}\n/)[0];
+const swotExternal = (s) => s.match(/async function generateSwotExternal[\s\S]*?\n}\n/)[0];
+
+test("internal SWOT requires evidence rather than plausible strategy language", async () => {
+  const fn = swotInternal(await source());
+
+  assert.match(fn, /Every factor must trace to something in the company context or the canvas/);
+  assert.match(fn, /Plausibility is not evidence/);
+  assert.match(fn, /Do not invent capabilities, teams, customers, funding, market position/);
+  assert.match(fn, /An empty\s+array is the correct answer/);
+});
+
+test("an intention is not a strength, but a stated absence is a weakness", async () => {
+  const fn = swotInternal(await source());
+
+  // The asymmetry matters: treating a plan as an existing advantage is the
+  // usual way this analysis goes wrong, while a stated gap is real evidence.
+  assert.match(fn, /"\(planned\)" or "\(exploring\)" is not yet a strength/);
+  assert.match(fn, /legitimate evidence for\s+a weakness/);
+  assert.match(fn, /Say what is absent rather than inventing a problem/);
+});
+
+test("external SWOT keeps search results about the world, not about the company", async () => {
+  const fn = swotExternal(await source());
+
+  assert.match(fn, /Search tells you about the world, not about this company/);
+  assert.match(fn, /A search result is not evidence about them/);
+  // Opportunities must not be described as already being pursued.
+  assert.match(fn, /Do not present an opportunity as one the company is already pursuing/);
+});
+
+test("sources are requested inline, because a separate list is discarded", async () => {
+  const full = await source();
+  const fn = swotExternal(full);
+
+  // The response is flattened to string[], and Google's groundingMetadata is
+  // never read, so a citation only survives if it is inside the line.
+  assert.match(fn, /name the source inline in\s+the same line/);
+  assert.doesNotMatch(fn, /Cite sources if possible/);
+  assert.doesNotMatch(full, /groundingMetadata/);
+});
+
+test("both SWOT calls are pinned below the provider default", async () => {
+  const full = await source();
+
+  assert.match(full, /const SWOT_TEMPERATURE = 0\.3;/);
+  assert.match(swotInternal(full), /temperature: SWOT_TEMPERATURE/);
+  assert.match(swotExternal(full), /temperature: SWOT_TEMPERATURE/);
+});
+
+test("headings and lead-ins are not stored as SWOT factors", () => {
+  const answer = [
+    "Here are the key opportunities:",
+    "* Growing demand for CSRD-ready reporting among EU suppliers (Reuters, March 2026)",
+    "",
+    "- Falling cost of carbon accounting tooling",
+    "---",
+    "### Threats",
+    "1. New omnibus revisions may reduce mandatory scope (EFRAG, 2026)",
+    "   •",
+    "Summary:",
+  ].join("\n");
+
+  assert.deepEqual(parseSwotExternalLines(answer), [
+    "Growing demand for CSRD-ready reporting among EU suppliers (Reuters, March 2026)",
+    "Falling cost of carbon accounting tooling",
+    "New omnibus revisions may reduce mandatory scope (EFRAG, 2026)",
+  ]);
+});
+
+test("the parser tolerates an empty or absent answer", () => {
+  assert.deepEqual(parseSwotExternalLines(""), []);
+  assert.deepEqual(parseSwotExternalLines(null), []);
+  assert.deepEqual(parseSwotExternalLines(undefined), []);
+});


### PR DESCRIPTION
Next feature after SBMC. SWOT had **no grounding instructions at all** — the same shape the canvas prompt had before #200 — and ran at the provider default temperature.

It matters more than it looks: SWOT feeds assessment autofill, the DMA analysis and the strategic report, so anything it invents travels into the published statement.

## The two halves fail differently

**Internal** reads the company context and the canvas. Its risk is generic strategy language — *"scalable platform"*, *"strong domain expertise"* — true of every company in the category and evidence of nothing.

**External** is search-grounded. Its risk is the opposite: search returns facts about *the world*, and the model may attribute them to *this company*.

So they get different rules rather than one shared block.

## Internal: two deliberately asymmetric rules

This carries the status work from #204 into SWOT:

- An item marked `(planned)` or `(exploring)` **is not a strength.** It is an intention, and treating a plan as an existing advantage is the usual way this analysis goes wrong.
- But something explicitly **Not established**, or missing where the business model needs it, **is legitimate evidence for a weakness** — with the instruction to name what is absent rather than invent a problem.

The asymmetry is the point. A blanket "ignore non-current items" would throw away the most useful signal in the profile.

Plus: factors must trace to supplied content, plausibility is not evidence, and an empty array is stated as a correct answer.

## External: the world, not the company

It may describe a market, regulatory or technology shift and why it matters to a company of this profile. It may **not** state anything about this company's capabilities, customers, partnerships or position that the context does not show, nor present an opportunity as one the company is already pursuing.

**It also asked to "cite sources if possible" and then discarded them.** The result is flattened to `string[]` and Google's `groundingMetadata` is never read, so a citation only survives if it is inside the line. Sources are now requested inline.

And the parser was storing headings as factors — `"Key opportunities:"` became a SWOT item of its own. It now drops trailing-colon lines and punctuation-only fragments, and moves out of the handler so it can be tested.

## Verification

```
npm run test:unit       # 30 pass (7 new)
npm run test:security   # 148 pass
npx tsc --noEmit         # clean
npm run build            # clean
```

The parser tests use a realistic search-grounded answer — headings, blank lines, `---`, a stray bullet, a trailing "Summary:" — and assert only the three real factors survive, sources intact.

**Not proven:** as with SBMC, I cannot call the model. Whether generic strengths actually stop appearing needs a dogfooding run. Worth testing with the AeternumAlly canvas as it stands now, since it contains `(planned)` and `(exploring)` items — a strength citing either one would mean the rule is not biting.

## Still open elsewhere

`generateKPISuggestions` and `generateAssessmentSuggestions` remain ungrounded and at default temperature. The assessment one is the most consequential of the three, since its output feeds materiality scores directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)